### PR TITLE
Better backend and cloud provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
 script:
   - make build-all
   - make test-race
-  - make check
+  - METALINTER_CONCURRENCY=2 make check
   - make bench-race
   - make coveralls

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GOBUILD_VERSION_ARGS := -ldflags "-s -X $(VERSION_VAR)=$(REPO_VERSION) -X $(GIT_
 BINARY_NAME := gostatsd
 IMAGE_NAME := atlassianlabs/$(BINARY_NAME)
 ARCH ?= darwin
+METALINTER_CONCURRENCY ?= 4
 
 setup:
 	go get -v -u github.com/Masterminds/glide
@@ -57,13 +58,13 @@ junit-test: build
 check:
 	go install
 	go install ./tester
-	gometalinter --deadline=180s ./... --vendor --linter='errcheck:errcheck:-ignore=net:Close' --cyclo-over=20 \
+	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=180s ./... --vendor --linter='errcheck:errcheck:-ignore=net:Close' --cyclo-over=20 \
 		--linter='vet:go tool vet -composites=false {paths}:PATH:LINE:MESSAGE' --disable=interfacer --dupl-threshold=200
 
 check-all:
 	go install
 	go install ./tester
-	gometalinter --deadline=600s ./... --vendor --cyclo-over=20 \
+	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=600s ./... --vendor --cyclo-over=20 \
 		--linter='vet:go tool vet {paths}:PATH:LINE:MESSAGE' --dupl-threshold=65
 
 profile:

--- a/backend/backends/backends.go
+++ b/backend/backends/backends.go
@@ -1,9 +1,0 @@
-package backends
-
-import (
-	_ "github.com/atlassian/gostatsd/backend/backends/datadog"     // imports backends to avoid cycle error
-	_ "github.com/atlassian/gostatsd/backend/backends/graphite"    // imports backends to avoid cycle error
-	_ "github.com/atlassian/gostatsd/backend/backends/null"        // imports backends to avoid cycle error
-	_ "github.com/atlassian/gostatsd/backend/backends/statsdaemon" // imports backends to avoid cycle error
-	_ "github.com/atlassian/gostatsd/backend/backends/stdout"      // imports backends to avoid cycle error
-)

--- a/backend/backends/graphite/graphite.go
+++ b/backend/backends/graphite/graphite.go
@@ -7,20 +7,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atlassian/gostatsd/backend"
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/types"
 
 	"github.com/spf13/viper"
 )
 
-const backendName = "graphite"
-
-func init() {
-	backend.RegisterBackend(backendName, func(v *viper.Viper) (backend.MetricSender, error) {
-		v.SetDefault("graphite.address", "localhost:2003")
-		return NewClient(v.GetString("graphite.address"))
-	})
-}
+// BackendName is the name of this backend.
+const BackendName = "graphite"
 
 const sampleConfig = `
 [graphite]
@@ -39,13 +33,13 @@ func normalizeBucketName(bucket string, tagsKey string) string {
 	return bucket
 }
 
-// Client is an object that is used to send messages to a Graphite server's TCP interface.
-type Client struct {
+// client is an object that is used to send messages to a Graphite server's TCP interface.
+type client struct {
 	address string
 }
 
 // SendMetrics sends the metrics in a MetricsMap to the Graphite server.
-func (client *Client) SendMetrics(metrics types.MetricMap) error {
+func (client *client) SendMetrics(metrics types.MetricMap) error {
 	if metrics.NumStats == 0 {
 		return nil
 	}
@@ -95,16 +89,22 @@ func (client *Client) SendMetrics(metrics types.MetricMap) error {
 }
 
 // SampleConfig returns the sample config for the graphite backend.
-func (client *Client) SampleConfig() string {
+func (client *client) SampleConfig() string {
 	return sampleConfig
 }
 
+// NewClientFromViper constructs a GraphiteClient object by connecting to an address.
+func NewClientFromViper(v *viper.Viper) (backendTypes.MetricSender, error) {
+	v.SetDefault("graphite.address", "localhost:2003")
+	return NewClient(v.GetString("graphite.address"))
+}
+
 // NewClient constructs a GraphiteClient object by connecting to an address.
-func NewClient(address string) (backend.MetricSender, error) {
-	return &Client{address}, nil
+func NewClient(address string) (backendTypes.MetricSender, error) {
+	return &client{address}, nil
 }
 
 // BackendName returns the name of the backend.
-func (client *Client) BackendName() string {
-	return backendName
+func (client *client) BackendName() string {
+	return BackendName
 }

--- a/backend/backends/null/null.go
+++ b/backend/backends/null/null.go
@@ -1,39 +1,39 @@
 package null
 
 import (
-	"github.com/atlassian/gostatsd/backend"
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/types"
 
 	"github.com/spf13/viper"
 )
 
-const backendName = "null"
+// BackendName is the name of this backend.
+const BackendName = "null"
 
-func init() {
-	backend.RegisterBackend(backendName, func(v *viper.Viper) (backend.MetricSender, error) {
-		return NewClient()
-	})
+// client represents a discarding backend.
+type client struct{}
+
+// NewClientFromViper constructs a GraphiteClient object by connecting to an address.
+func NewClientFromViper(v *viper.Viper) (backendTypes.MetricSender, error) {
+	return NewClient()
 }
 
-// Client is an object that is used to discard messages.
-type Client struct{}
-
-// NewClient constructs a StdoutClient object.
-func NewClient() (backend.MetricSender, error) {
-	return &Client{}, nil
+// NewClient constructs a client object.
+func NewClient() (backendTypes.MetricSender, error) {
+	return client{}, nil
 }
 
 // SampleConfig returns the sample config for the null backend.
-func (client *Client) SampleConfig() string {
+func (client client) SampleConfig() string {
 	return ""
 }
 
 // SendMetrics discards the metrics in a MetricsMap.
-func (client *Client) SendMetrics(metrics types.MetricMap) error {
+func (client client) SendMetrics(metrics types.MetricMap) error {
 	return nil
 }
 
 // BackendName returns the name of the backend.
-func (client *Client) BackendName() string {
-	return backendName
+func (client client) BackendName() string {
+	return BackendName
 }

--- a/backend/backends/stdout/stdout.go
+++ b/backend/backends/stdout/stdout.go
@@ -6,27 +6,27 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atlassian/gostatsd/backend"
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/types"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
-const backendName = "stdout"
+// BackendName is the name of this backend.
+const BackendName = "stdout"
 
-func init() {
-	backend.RegisterBackend(backendName, func(v *viper.Viper) (backend.MetricSender, error) {
-		return NewClient()
-	})
+// client is an object that is used to send messages to stdout.
+type client struct{}
+
+// NewClientFromViper constructs a stdout backend.
+func NewClientFromViper(v *viper.Viper) (backendTypes.MetricSender, error) {
+	return NewClient()
 }
 
-// Client is an object that is used to send messages to stdout.
-type Client struct{}
-
-// NewClient constructs a StdoutClient object.
-func NewClient() (backend.MetricSender, error) {
-	return &Client{}, nil
+// NewClient constructs a stdout backend.
+func NewClient() (backendTypes.MetricSender, error) {
+	return &client{}, nil
 }
 
 // composeMetricName adds the key and the tags to compose the metric name.
@@ -41,12 +41,12 @@ func composeMetricName(key string, tagsKey string) string {
 }
 
 // SampleConfig returns the sample config for the stdout backend.
-func (client *Client) SampleConfig() string {
+func (client client) SampleConfig() string {
 	return ""
 }
 
 // SendMetrics sends the metrics in a MetricsMap to the Graphite server.
-func (client *Client) SendMetrics(metrics types.MetricMap) (retErr error) {
+func (client client) SendMetrics(metrics types.MetricMap) (retErr error) {
 	buf := new(bytes.Buffer)
 	now := time.Now().Unix()
 	metrics.Counters.Each(func(key, tagsKey string, counter types.Counter) {
@@ -90,6 +90,6 @@ func (client *Client) SendMetrics(metrics types.MetricMap) (retErr error) {
 }
 
 // BackendName returns the name of the backend.
-func (client *Client) BackendName() string {
-	return backendName
+func (client client) BackendName() string {
+	return BackendName
 }

--- a/backend/types/types.go
+++ b/backend/types/types.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"github.com/atlassian/gostatsd/types"
+
+	"github.com/spf13/viper"
+)
+
+// Factory is a function that returns a MetricSender.
+type Factory func(v *viper.Viper) (MetricSender, error)
+
+// MetricSender represents a backend.
+type MetricSender interface {
+	// BackendName returns the name of the backend.
+	BackendName() string
+	// SampleConfig returns the sample config for the backend.
+	SampleConfig() string
+	// SendMetrics flushes the metrics to the backend.
+	SendMetrics(metrics types.MetricMap) error
+}

--- a/cloudprovider/providers/providers.go
+++ b/cloudprovider/providers/providers.go
@@ -1,5 +1,0 @@
-package providers
-
-import (
-	_ "github.com/atlassian/gostatsd/cloudprovider/providers/aws" // imports provider to avoid cycle error
-)

--- a/cloudprovider/types/types.go
+++ b/cloudprovider/types/types.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"github.com/atlassian/gostatsd/types"
+
+	"github.com/spf13/viper"
+)
+
+// Factory is a function that returns a cloud provider Interface.
+type Factory func(*viper.Viper) (Interface, error)
+
+// Instance represents a cloud instance.
+type Instance struct {
+	ID     string
+	Region string
+	Tags   types.Tags
+}
+
+// Interface represents a cloud provider.
+type Interface interface {
+	// ProviderName returns the name of the cloud provider.
+	ProviderName() string
+	// SampleConfig returns the sample config for the cloud provider.
+	SampleConfig() string
+	// Instance returns the instance details from the cloud provider.
+	Instance(IP string) (*Instance, error)
+}

--- a/cover.sh
+++ b/cover.sh
@@ -11,8 +11,11 @@ echo "mode: count" > coverage.out
 # Initialize error tracking
 ERROR=""
 
-declare -a packages=('backend' 'backend/backends' 'backend/backends/datadog' 'backend/backends/graphite' \
-	'backend/backends/stdout' 'backend/backends/statsdaemon' 'example' 'statsd' 'tester' 'types');
+declare -a packages=('backend' 'backend/types' \
+    'backend/backends/datadog' 'backend/backends/graphite' 'backend/backends/null' \
+    'backend/backends/statsdaemon' 'backend/backends/stdout' \
+    'cloudprovider' 'cloudprovider/providers/aws' 'cloudprovider/types' \
+    'statsd' 'types');
 
 # Test each package and append coverage profile info to coverage.out
 for pkg in "${packages[@]}"

--- a/statsd/flusher.go
+++ b/statsd/flusher.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/atlassian/gostatsd/backend"
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/types"
 
 	log "github.com/Sirupsen/logrus"
@@ -36,7 +36,7 @@ type flusher struct {
 	dispatcher    Dispatcher
 	receiver      Receiver
 	defaultTags   string
-	senders       []backend.MetricSender
+	senders       []backendTypes.MetricSender
 
 	// Sent statistics for Receiver. Keep sent values to calculate diff.
 	sentBadLines        uint64
@@ -45,7 +45,7 @@ type flusher struct {
 }
 
 // NewFlusher creates a new Flusher with provided configuration.
-func NewFlusher(flushInterval time.Duration, dispatcher Dispatcher, receiver Receiver, defaultTags []string, senders []backend.MetricSender) Flusher {
+func NewFlusher(flushInterval time.Duration, dispatcher Dispatcher, receiver Receiver, defaultTags []string, senders []backendTypes.MetricSender) Flusher {
 	return &flusher{
 		flushInterval: flushInterval,
 		dispatcher:    dispatcher,
@@ -99,7 +99,7 @@ func (f *flusher) sendFlushedData(ctx context.Context, metrics *types.MetricMap)
 	var wg sync.WaitGroup
 	wg.Add(len(f.senders))
 	for _, sender := range f.senders {
-		go func(s backend.MetricSender) {
+		go func(s backendTypes.MetricSender) {
 			defer wg.Done()
 			log.Debugf("Sending metrics to backend %s", s.BackendName())
 			//TODO pass ctx

--- a/statsd/receiver.go
+++ b/statsd/receiver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/atlassian/gostatsd/cloudprovider"
+	cloudTypes "github.com/atlassian/gostatsd/cloudprovider/types"
 	"github.com/atlassian/gostatsd/types"
 
 	log "github.com/Sirupsen/logrus"
@@ -55,14 +56,14 @@ type metricReceiver struct {
 	packetsReceived uint64
 	metricsReceived uint64
 
-	cloud     cloudprovider.Interface // Cloud provider interface
-	handler   Handler                 // handler to invoke
-	namespace string                  // Namespace to prefix all metrics
-	tags      types.Tags              // Tags to add to all metrics
+	cloud     cloudTypes.Interface // Cloud provider interface
+	handler   Handler              // handler to invoke
+	namespace string               // Namespace to prefix all metrics
+	tags      types.Tags           // Tags to add to all metrics
 }
 
 // NewMetricReceiver initialises a new Receiver.
-func NewMetricReceiver(ns string, tags []string, cloud cloudprovider.Interface, handler Handler) Receiver {
+func NewMetricReceiver(ns string, tags []string, cloud cloudTypes.Interface, handler Handler) Receiver {
 	return &metricReceiver{
 		cloud:     cloud,
 		handler:   handler,

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/atlassian/gostatsd/backend"
-	_ "github.com/atlassian/gostatsd/backend/backends" // import backends for initialisation
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/cloudprovider"
 	_ "github.com/atlassian/gostatsd/cloudprovider/providers" // import cloud providers for initialisation
 
@@ -144,7 +144,7 @@ type SocketFactory func() (net.PacketConn, error)
 // RunWithCustomSocket runs the server until context signals done.
 // Listening socket is created using sf.
 func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) error {
-	backends := make([]backend.MetricSender, 0, len(s.Backends))
+	backends := make([]backendTypes.MetricSender, 0, len(s.Backends))
 	for _, backendName := range s.Backends {
 		b, err := backend.InitBackend(backendName, s.Viper)
 		if err != nil {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -12,7 +12,6 @@ import (
 	"github.com/atlassian/gostatsd/backend"
 	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/cloudprovider"
-	_ "github.com/atlassian/gostatsd/cloudprovider/providers" // import cloud providers for initialisation
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/pflag"

--- a/types/cloud.go
+++ b/types/cloud.go
@@ -1,8 +1,0 @@
-package types
-
-// Instance represents a cloud instance.
-type Instance struct {
-	ID     string
-	Region string
-	Tags   Tags
-}


### PR DESCRIPTION
1. No side effects
2. `init()` of unused backends/provider are not executed (including during tests)
3. No mutexes
4. Easier to understand
5. No ugly empty imports
6. JSON logging for all messages