### PR TITLE
Return an error instead of nil when parseline gets nil/empty input

### DIFF
--- a/statsd/receiver.go
+++ b/statsd/receiver.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -188,10 +189,15 @@ func (mr *metricReceiver) getAdditionalTags(addr string) types.Tags {
 
 // ParseLine with lexer impl.
 func (mr *metricReceiver) parseLine(line []byte) (*types.Metric, error) {
+	if line == nil {
+		return nil, errors.New("Error parsing line. Byte array is nil")
+	}
+
 	llen := len(line)
 	if llen == 0 {
-		return nil, nil
+		return nil, errors.New("Error parsing line. Byte array is empty")
 	}
+
 	metric := &types.Metric{}
 	metric.Tags = append(metric.Tags, mr.tags...)
 	l := &lexer{input: line, len: llen, m: metric, namespace: mr.namespace}

--- a/statsd/receiver_test.go
+++ b/statsd/receiver_test.go
@@ -33,6 +33,17 @@ func TestParseLine(t *testing.T) {
 	}
 
 	mr := &metricReceiver{}
+
+	_, err := mr.parseLine([]byte{})
+	if err == nil {
+		t.Errorf("Attempting to parse empty byte slice and did not get error back")
+	}
+
+	_, err = mr.parseLine(nil)
+	if err == nil {
+		t.Errorf("Attempting to parse nil slice and did not get error back")
+	}
+
 	compare(tests, mr, t)
 
 	failing := []string{"fOO|bar:bazkk", "foo.bar.baz:1|q", "NaN.should.be:NaN|g"}


### PR DESCRIPTION
This is a result of my first pass at go-fuzz'ing the lexer