### PR TITLE
Remove deprecated -f

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ docker: cross
 
 release: check test docker
 	docker push $(IMAGE_NAME):$(GIT_HASH)
-	docker tag -f $(IMAGE_NAME):$(GIT_HASH) $(IMAGE_NAME):latest
+	docker tag $(IMAGE_NAME):$(GIT_HASH) $(IMAGE_NAME):latest
 	docker push $(IMAGE_NAME):latest
-	docker tag -f $(IMAGE_NAME):$(GIT_HASH) $(IMAGE_NAME):$(REPO_VERSION)
+	docker tag $(IMAGE_NAME):$(GIT_HASH) $(IMAGE_NAME):$(REPO_VERSION)
 	docker push $(IMAGE_NAME):$(REPO_VERSION)
 
 run: build


### PR DESCRIPTION
I am not sure why it is needed and cannot find documentation on this flag. /cc @jtblin

```sh
docker tag -f atlassianlabs/gostatsd:$(git rev-parse --short HEAD) atlassianlabs/gostatsd:latest
Warning: '-f' is deprecated, it will be removed soon. See usage.
```