### PR TITLE
Send data async

### DIFF
--- a/backend/backends/datadog/datadog.go
+++ b/backend/backends/datadog/datadog.go
@@ -109,14 +109,14 @@ func (d *client) SendMetrics(ctx context.Context, metrics *types.MetricMap) erro
 }
 
 // SendMetricsAsync flushes the metrics to Datadog, preparing payload synchronously but doing the send asynchronously.
-func (d *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+func (d *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, cb backendTypes.SendCallback) {
 	if metrics.NumStats == 0 {
-		c(nil)
+		cb(nil)
 		return
 	}
 	ts := d.prepareSeries(metrics)
 	go func() {
-		c(d.postMetrics(ts))
+		cb(d.postMetrics(ts))
 	}()
 }
 

--- a/backend/backends/graphite/graphite.go
+++ b/backend/backends/graphite/graphite.go
@@ -48,14 +48,14 @@ func (client *client) SendMetrics(ctx context.Context, metrics *types.MetricMap)
 }
 
 // SendMetricsAsync flushes the metrics to the Graphite server, preparing payload synchronously but doing the send asynchronously.
-func (client *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+func (client *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, cb backendTypes.SendCallback) {
 	if metrics.NumStats == 0 {
-		c(nil)
+		cb(nil)
 		return
 	}
 	buf := preparePayload(metrics)
 	go func() {
-		c(client.doSend(ctx, buf))
+		cb(client.doSend(ctx, buf))
 	}()
 }
 

--- a/backend/backends/graphite/graphite.go
+++ b/backend/backends/graphite/graphite.go
@@ -44,6 +44,41 @@ func (client *client) SendMetrics(ctx context.Context, metrics *types.MetricMap)
 	if metrics.NumStats == 0 {
 		return nil
 	}
+	return client.doSend(ctx, preparePayload(metrics))
+}
+
+// SendMetricsAsync flushes the metrics to the Graphite server, preparing payload synchronously but doing the send asynchronously.
+func (client *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+	if metrics.NumStats == 0 {
+		c(nil)
+		return
+	}
+	buf := preparePayload(metrics)
+	go func() {
+		c(client.doSend(ctx, buf))
+	}()
+}
+
+func (client *client) doSend(ctx context.Context, buf *bytes.Buffer) (retErr error) {
+	conn, err := net.Dial("tcp", client.address)
+	if err != nil {
+		return fmt.Errorf("[%s] error connecting: %v", BackendName, err)
+	}
+	defer func() {
+		errClose := conn.Close()
+		if errClose != nil && retErr == nil {
+			retErr = fmt.Errorf("[%s] error sending: %v", BackendName, errClose)
+		}
+	}()
+
+	_, err = buf.WriteTo(conn)
+	if err != nil {
+		return fmt.Errorf("[%s] error sending: %v", BackendName, err)
+	}
+	return nil
+}
+
+func preparePayload(metrics *types.MetricMap) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 	now := time.Now().Unix()
 	metrics.Counters.Each(func(key, tagsKey string, counter types.Counter) {
@@ -70,23 +105,11 @@ func (client *client) SendMetrics(ctx context.Context, metrics *types.MetricMap)
 		nk := normalizeBucketName(key, tagsKey)
 		fmt.Fprintf(buf, "stats.gauge.%s %f %d\n", nk, gauge.Value, now)
 	})
-
 	metrics.Sets.Each(func(key, tagsKey string, set types.Set) {
 		nk := normalizeBucketName(key, tagsKey)
 		fmt.Fprintf(buf, "stats.sets.%s %d %d\n", nk, len(set.Values), now)
 	})
-
-	conn, err := net.Dial("tcp", client.address)
-	if err != nil {
-		return fmt.Errorf("error connecting to graphite backend: %s", err)
-	}
-	defer conn.Close()
-
-	_, err = buf.WriteTo(conn)
-	if err != nil {
-		return fmt.Errorf("error sending to graphite: %s", err)
-	}
-	return nil
+	return buf
 }
 
 // SendEvent discards events.

--- a/backend/backends/null/null.go
+++ b/backend/backends/null/null.go
@@ -34,6 +34,11 @@ func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) 
 	return nil
 }
 
+// SendMetricsAsync discards the metrics in a MetricsMap.
+func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+	c(nil)
+}
+
 // SendEvent discards events.
 func (client client) SendEvent(ctx context.Context, e *types.Event) error {
 	return nil

--- a/backend/backends/null/null.go
+++ b/backend/backends/null/null.go
@@ -35,8 +35,8 @@ func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) 
 }
 
 // SendMetricsAsync discards the metrics in a MetricsMap.
-func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
-	c(nil)
+func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, cb backendTypes.SendCallback) {
+	cb(nil)
 }
 
 // SendEvent discards events.

--- a/backend/backends/statsdaemon/statsdaemon.go
+++ b/backend/backends/statsdaemon/statsdaemon.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 
 	backendTypes "github.com/atlassian/gostatsd/backend/types"
 	"github.com/atlassian/gostatsd/types"
@@ -27,45 +28,46 @@ const sampleConfig = `
 	address = "statsdaemon-master:6126"
 `
 
+// sendChannelSize specifies the size of the buffer of a channel between caller goroutine, producing buffers, and the
+// goroutine that writes them to the socket.
+const sendChannelSize = 1000
+
 // client is an object that is used to send messages to a statsd server's UDP interface.
 type client struct {
 	addr string
 }
 
-func (client *client) write(conn *net.Conn, buf *bytes.Buffer) error {
-	_, err := buf.WriteTo(*conn)
-	if err != nil {
-		return fmt.Errorf("error sending to statsd backend: %s", err)
-	}
-	return nil
+// overflowHandler is invoked when accumulated packed size has reached it's limit of maxUDPPacketSize.
+// This function should return a new buffer to be used for the rest of the work (may be the same buffer
+// if contents are processed somehow and are no longer needed).
+type overflowHandler func(*bytes.Buffer) (*bytes.Buffer, error)
+
+var bufFree = sync.Pool{
+	New: func() interface{} {
+		buf := new(bytes.Buffer)
+		buf.Grow(maxUDPPacketSize)
+		return buf
+	},
 }
 
-func (client *client) writeLine(conn *net.Conn, buf *bytes.Buffer, format, name, tags string, value interface{}) error {
-	line := new(bytes.Buffer)
-	if tags != "" {
-		format += "|#%s"
-	}
-	format += "\n"
+func writeLine(handler overflowHandler, line, buf *bytes.Buffer, format, name, tags string, value interface{}) (*bytes.Buffer, error) {
+	line.Reset()
 	if tags == "" {
+		format += "\n"
 		fmt.Fprintf(line, format, name, value)
 	} else {
+		format += "|#%s\n"
 		fmt.Fprintf(line, format, name, value, tags)
 	}
 	// Make sure we don't go over max udp datagram size
 	if buf.Len()+line.Len() > maxUDPPacketSize {
-		if err := client.write(conn, buf); err != nil {
-			return err
+		var err error
+		if buf, err = handler(buf); err != nil {
+			return nil, err
 		}
-		buf.Reset()
 	}
 	fmt.Fprint(buf, line)
-	line.Reset()
-	return nil
-}
-
-func logError(err error) error {
-	log.Errorf("Error sending to statsd backend: %s", err)
-	return err
+	return buf, nil
 }
 
 // SendMetrics sends the metrics in a MetricsMap to the statsd master server.
@@ -76,49 +78,125 @@ func (client *client) SendMetrics(ctx context.Context, metrics *types.MetricMap)
 
 	conn, err := net.Dial("udp", client.addr)
 	if err != nil {
-		return fmt.Errorf("error connecting to statsd backend: %s", err)
+		return fmt.Errorf("[%s] error connecting: %v", BackendName, err)
 	}
 	defer conn.Close()
 
-	var lastError error
-	buf := new(bytes.Buffer)
+	return processMetrics(metrics, func(buf *bytes.Buffer) (*bytes.Buffer, error) {
+		_, err := buf.WriteTo(conn)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] error sending: %v", BackendName, err)
+		}
+		return buf, nil
+	})
+}
+
+// SendMetricsAsync flushes the metrics to the statsd server, preparing payload synchronously but doing the send asynchronously.
+func (client *client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+	if metrics.NumStats == 0 {
+		c(nil)
+		return
+	}
+	localCtx, cancelFunc := context.WithCancel(ctx)
+
+	datagrams := make(chan *bytes.Buffer, sendChannelSize)
+
+	conn, err := net.Dial("udp", client.addr)
+	if err != nil {
+		c(fmt.Errorf("[%s] error connecting: %v", BackendName, err))
+		return
+	}
+	go func() {
+		defer conn.Close()
+		defer cancelFunc() // Tell the processMetrics function to stop if it is still running
+		for {
+			select {
+			case <-localCtx.Done():
+				c(localCtx.Err())
+				return
+			case buf, ok := <-datagrams:
+				if !ok {
+					c(nil)
+					return
+				}
+				_, errWrite := buf.WriteTo(conn)
+				buf.Reset() // In case of error we must reset the buffer before returning to the pool
+				bufFree.Put(buf)
+				if errWrite != nil {
+					c(fmt.Errorf("[%s] error sending: %v", BackendName, errWrite))
+					return
+				}
+			}
+		}
+	}()
+	err = processMetrics(metrics, func(buf *bytes.Buffer) (*bytes.Buffer, error) {
+		select {
+		case <-localCtx.Done(): // This can happen if 1) parent context is Done or 2) receiver encountered an error
+			return nil, localCtx.Err()
+		case datagrams <- buf:
+			return bufFree.Get().(*bytes.Buffer), nil
+		}
+	})
+	if err == nil {
+		// All metrics sent to the channel and context wasn't cancelled (yet) - consuming goroutine will exit
+		// with success (unless ctx gets a cancel after the close, which is also ok)
+		close(datagrams)
+	} else if err != context.Canceled && err != context.DeadlineExceeded {
+		log.Panicf("Unexpected error: %v", err)
+	}
+}
+
+func processMetrics(metrics *types.MetricMap, handler overflowHandler) (retErr error) {
+	type failure struct {
+		err error
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			if f, ok := r.(failure); ok {
+				retErr = f.err
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	buf := bufFree.Get().(*bytes.Buffer)
+	line := bufFree.Get().(*bytes.Buffer)
 	metrics.Counters.Each(func(key, tagsKey string, counter types.Counter) {
 		// do not send statsd stats as they will be recalculated on the master instead
 		if !strings.HasPrefix(key, "statsd.") {
-			if err = client.writeLine(&conn, buf, "%s:%d|c", key, tagsKey, counter.Value); err != nil {
-				lastError = logError(err)
+			var err error
+			if buf, err = writeLine(handler, line, buf, "%s:%d|c", key, tagsKey, counter.Value); err != nil {
+				panic(failure{err})
 			}
 		}
 	})
 	metrics.Timers.Each(func(key, tagsKey string, timer types.Timer) {
 		for _, tr := range timer.Values {
-			if err = client.writeLine(&conn, buf, "%s:%f|ms", key, tagsKey, tr); err != nil {
-				lastError = logError(err)
+			var err error
+			if buf, err = writeLine(handler, line, buf, "%s:%f|ms", key, tagsKey, tr); err != nil {
+				panic(failure{err})
 			}
 		}
 	})
 	metrics.Gauges.Each(func(key, tagsKey string, gauge types.Gauge) {
-		if err = client.writeLine(&conn, buf, "%s:%f|g", key, tagsKey, gauge.Value); err != nil {
-			lastError = logError(err)
+		var err error
+		if buf, err = writeLine(handler, line, buf, "%s:%f|g", key, tagsKey, gauge.Value); err != nil {
+			panic(failure{err})
 		}
 	})
-
 	metrics.Sets.Each(func(key, tagsKey string, set types.Set) {
 		for k := range set.Values {
-			if err = client.writeLine(&conn, buf, "%s:%s|s", key, tagsKey, k); err != nil {
-				lastError = logError(err)
+			var err error
+			if buf, err = writeLine(handler, line, buf, "%s:%s|s", key, tagsKey, k); err != nil {
+				panic(failure{err})
 			}
 		}
 	})
-
-	if err = client.write(&conn, buf); err != nil {
-		return err
+	var err error
+	if buf.Len() > 0 {
+		_, err = handler(buf) // Process what's left in the buffer
 	}
-
-	if lastError != nil {
-		return lastError
-	}
-	return nil
+	return err
 }
 
 // SendEvent sends events to the statsd master server.

--- a/backend/backends/statsdaemon/statsdaemon_test.go
+++ b/backend/backends/statsdaemon/statsdaemon_test.go
@@ -1,0 +1,47 @@
+package statsdaemon
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atlassian/gostatsd/types"
+)
+
+var longName = strings.Repeat("t", maxUDPPacketSize-5)
+var m = types.MetricMap{
+	NumStats: 1,
+	Counters: types.Counters{
+		longName: map[string]types.Counter{
+			"tag1": types.NewCounter(time.Now(), 1*time.Second, 5),
+		},
+	},
+}
+
+func TestProcessMetricsRecover(t *testing.T) {
+	expectedErr := errors.New("ABC some error")
+	actualErr := processMetrics(&m, func(buf *bytes.Buffer) (*bytes.Buffer, error) {
+		return nil, expectedErr
+	})
+	if expectedErr != actualErr {
+		t.Errorf("expected %v, actual %v", expectedErr, actualErr)
+	}
+}
+
+func TestProcessMetricsPanic(t *testing.T) {
+	expectedErr := errors.New("ABC some error")
+	defer func() {
+		if r := recover(); r != nil {
+			if r != expectedErr {
+				t.Errorf("expected %v, got %v", expectedErr, r)
+			}
+		} else {
+			t.Error("should have panicked")
+		}
+	}()
+	processMetrics(&m, func(buf *bytes.Buffer) (*bytes.Buffer, error) {
+		panic(expectedErr)
+	})
+}

--- a/backend/backends/stdout/stdout.go
+++ b/backend/backends/stdout/stdout.go
@@ -52,10 +52,10 @@ func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) 
 }
 
 // SendMetricsAsync prints the metrics in a MetricsMap to the stdout, preparing payload synchronously but doing the send asynchronously.
-func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, cb backendTypes.SendCallback) {
 	buf := preparePayload(metrics)
 	go func() {
-		c(writePayload(buf))
+		cb(writePayload(buf))
 	}()
 }
 

--- a/backend/backends/stdout/stdout.go
+++ b/backend/backends/stdout/stdout.go
@@ -47,7 +47,30 @@ func (client client) SampleConfig() string {
 }
 
 // SendMetrics prints the metrics in a MetricsMap to the stdout.
-func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) (retErr error) {
+func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) error {
+	return writePayload(preparePayload(metrics))
+}
+
+// SendMetricsAsync prints the metrics in a MetricsMap to the stdout, preparing payload synchronously but doing the send asynchronously.
+func (client client) SendMetricsAsync(ctx context.Context, metrics *types.MetricMap, c backendTypes.SendCallback) {
+	buf := preparePayload(metrics)
+	go func() {
+		c(writePayload(buf))
+	}()
+}
+
+func writePayload(buf *bytes.Buffer) (retErr error) {
+	writer := log.StandardLogger().Writer()
+	defer func() {
+		if err := writer.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+	_, err := buf.WriteTo(writer)
+	return err
+}
+
+func preparePayload(metrics *types.MetricMap) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 	now := time.Now().Unix()
 	metrics.Counters.Each(func(key, tagsKey string, counter types.Counter) {
@@ -74,20 +97,11 @@ func (client client) SendMetrics(ctx context.Context, metrics *types.MetricMap) 
 		nk := composeMetricName(key, tagsKey)
 		fmt.Fprintf(buf, "stats.gauge.%s %f %d\n", nk, gauge.Value, now)
 	})
-
 	metrics.Sets.Each(func(key, tagsKey string, set types.Set) {
 		nk := composeMetricName(key, tagsKey)
 		fmt.Fprintf(buf, "stats.set.%s %d %d\n", nk, len(set.Values), now)
 	})
-
-	writer := log.StandardLogger().Writer()
-	defer func() {
-		if err := writer.Close(); err != nil && retErr == nil {
-			retErr = err
-		}
-	}()
-	_, err := buf.WriteTo(writer)
-	return err
+	return buf
 }
 
 // SendEvent prints events to the stdout.

--- a/backend/types/types.go
+++ b/backend/types/types.go
@@ -10,6 +10,9 @@ import (
 // Factory is a function that returns a Backend.
 type Factory func(*viper.Viper) (Backend, error)
 
+// SendCallback is called by Backend.SendMetricsAsync() to notify about the result of operation.
+type SendCallback func(error)
+
 // Backend represents a backend.
 type Backend interface {
 	// BackendName returns the name of the backend.
@@ -18,6 +21,9 @@ type Backend interface {
 	SampleConfig() string
 	// SendMetrics flushes the metrics to the backend.
 	SendMetrics(context.Context, *types.MetricMap) error
+	// SendMetricsAsync flushes the metrics to the backend, preparing payload synchronously but doing the send asynchronously.
+	// Must not read/write MetricMap asynchronously.
+	SendMetricsAsync(context.Context, *types.MetricMap, SendCallback)
 	// SendEvent sends event to the backend.
 	SendEvent(context.Context, *types.Event) error
 }

--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -20,7 +20,7 @@ type ProcessFunc func(*types.MetricMap)
 // Incoming metrics should be passed via Receive function.
 type Aggregator interface {
 	Receive(*types.Metric, time.Time)
-	Flush(func() time.Time) *types.MetricMap
+	Flush(func() time.Time)
 	Process(ProcessFunc)
 	Reset(time.Time)
 }
@@ -55,7 +55,7 @@ func round(v float64) float64 {
 }
 
 // Flush prepares the contents of an Aggregator for sending via the Sender.
-func (a *aggregator) Flush(now func() time.Time) *types.MetricMap {
+func (a *aggregator) Flush(now func() time.Time) {
 	startTime := now()
 	flushInterval := startTime.Sub(a.lastFlush)
 
@@ -157,16 +157,6 @@ func (a *aggregator) Flush(now func() time.Time) *types.MetricMap {
 	a.receiveGauge(statName, a.defaultTags, float64(a.ProcessingTime)/float64(time.Millisecond), flushTime)
 
 	a.lastFlush = flushTime
-
-	return &types.MetricMap{
-		NumStats:       a.NumStats,
-		ProcessingTime: a.ProcessingTime,
-		FlushInterval:  flushInterval,
-		Counters:       a.Counters.Clone(),
-		Timers:         a.Timers.Clone(),
-		Gauges:         a.Gauges.Clone(),
-		Sets:           a.Sets.Clone(),
-	}
 }
 
 func (a *aggregator) Process(f ProcessFunc) {

--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -111,11 +111,11 @@ func TestFlush(t *testing.T) {
 	expected.Sets["some"] = make(map[string]types.Set)
 	expected.Sets["some"]["thing"] = types.Set{Values: unique}
 
-	actual := ma.Flush(nowFn)
-	assert.Equal(expected.Counters, actual.Counters)
-	assert.Equal(expected.Timers, actual.Timers)
-	assert.Equal(expected.Gauges, actual.Gauges)
-	assert.Equal(expected.Sets, actual.Sets)
+	ma.Flush(nowFn)
+	assert.Equal(expected.Counters, ma.Counters)
+	assert.Equal(expected.Timers, ma.Timers)
+	assert.Equal(expected.Gauges, ma.Gauges)
+	assert.Equal(expected.Sets, ma.Sets)
 }
 
 func BenchmarkFlush(b *testing.B) {

--- a/statsd/dispatcher_test.go
+++ b/statsd/dispatcher_test.go
@@ -25,11 +25,10 @@ func (a *testAggregator) Receive(m *types.Metric, t time.Time) {
 	a.af.Mutex.Unlock()
 }
 
-func (a *testAggregator) Flush(f func() time.Time) *types.MetricMap {
+func (a *testAggregator) Flush(f func() time.Time) {
 	a.af.Mutex.Lock()
 	a.af.flushInvocations[a.agrNumber]++
 	a.af.Mutex.Unlock()
-	return nil
 }
 
 func (a *testAggregator) Process(f ProcessFunc) {

--- a/types/counters.go
+++ b/types/counters.go
@@ -45,15 +45,3 @@ func (c Counters) Each(f func(string, string, Counter)) {
 		}
 	}
 }
-
-// Clone performs a deep copy of a map of counters into a new map.
-func (c Counters) Clone() Counters {
-	destination := Counters{}
-	c.Each(func(key, tags string, counter Counter) {
-		if _, ok := destination[key]; !ok {
-			destination[key] = make(map[string]Counter)
-		}
-		destination[key][tags] = counter
-	})
-	return destination
-}

--- a/types/gauges.go
+++ b/types/gauges.go
@@ -44,15 +44,3 @@ func (g Gauges) Each(f func(string, string, Gauge)) {
 		}
 	}
 }
-
-// Clone performs a deep copy of a map of gauges into a new map.
-func (g Gauges) Clone() Gauges {
-	destination := Gauges{}
-	g.Each(func(key, tags string, gauge Gauge) {
-		if _, ok := destination[key]; !ok {
-			destination[key] = make(map[string]Gauge)
-		}
-		destination[key][tags] = gauge
-	})
-	return destination
-}

--- a/types/sets.go
+++ b/types/sets.go
@@ -44,15 +44,3 @@ func (s Sets) Each(f func(string, string, Set)) {
 		}
 	}
 }
-
-// Clone performs a deep copy of a map of sets into a new map.
-func (s Sets) Clone() Sets {
-	destination := Sets{}
-	s.Each(func(key, tags string, set Set) {
-		if _, ok := destination[key]; !ok {
-			destination[key] = make(map[string]Set)
-		}
-		destination[key][tags] = set
-	})
-	return destination
-}

--- a/types/timers.go
+++ b/types/timers.go
@@ -54,15 +54,3 @@ func (t Timers) Each(f func(string, string, Timer)) {
 		}
 	}
 }
-
-// Clone performs a deep copy of a map of timers into a new map.
-func (t Timers) Clone() Timers {
-	destination := Timers{}
-	t.Each(func(key, tags string, timer Timer) {
-		if _, ok := destination[key]; !ok {
-			destination[key] = make(map[string]Timer)
-		}
-		destination[key][tags] = timer
-	})
-	return destination
-}


### PR DESCRIPTION
The main idea is to avoid cloning all metrics to generate less garbage.

`master` is the updated `statsd_test`:
```
time="2016-05-28T18:25:31+10:00" level=info msg="numStats: 1182124"
time="2016-05-28T18:25:32+10:00" level=info msg="numStats: 1283931"
time="2016-05-28T18:25:33+10:00" level=info msg="numStats: 1289507"
time="2016-05-28T18:25:34+10:00" level=info msg="numStats: 1255173"
time="2016-05-28T18:25:35+10:00" level=info msg="numStats: 1297849"
time="2016-05-28T18:25:36+10:00" level=info msg="numStats: 1291102"
time="2016-05-28T18:25:37+10:00" level=info msg="numStats: 1260675"
time="2016-05-28T18:25:38+10:00" level=info msg="numStats: 1003565"
time="2016-05-28T18:25:39+10:00" level=info msg="numStats: 1192724"
time="2016-05-28T18:25:41+10:00" level=info msg="numStats: 1195525"
time="2016-05-28T18:25:42+10:00" level=info msg="numStats: 1131726"
time="2016-05-28T18:25:43+10:00" level=info msg="numStats: 1136089"
time="2016-05-28T18:25:44+10:00" level=info msg="numStats: 1142574"

	statsd_test.go:49: Processed metrics: 1061381
		TotalAlloc: 9932219136 (9357 per metric)
		Mallocs: 236540591 (222 per metric)
		NumGC: 385
		GCCPUFraction: 0.163982
```

This branch:
```
time="2016-05-28T18:23:25+10:00" level=info msg="numStats: 1214117"
time="2016-05-28T18:23:26+10:00" level=info msg="numStats: 1307186"
time="2016-05-28T18:23:27+10:00" level=info msg="numStats: 1324007"
time="2016-05-28T18:23:28+10:00" level=info msg="numStats: 1299264"
time="2016-05-28T18:23:29+10:00" level=info msg="numStats: 1296963"
time="2016-05-28T18:23:30+10:00" level=info msg="numStats: 1304763"
time="2016-05-28T18:23:31+10:00" level=info msg="numStats: 1315937"
time="2016-05-28T18:23:33+10:00" level=info msg="numStats: 1294777"
time="2016-05-28T18:23:34+10:00" level=info msg="numStats: 1286428"
time="2016-05-28T18:23:35+10:00" level=info msg="numStats: 1305129"
time="2016-05-28T18:23:36+10:00" level=info msg="numStats: 1283802"
time="2016-05-28T18:23:37+10:00" level=info msg="numStats: 1251706"
time="2016-05-28T18:23:38+10:00" level=info msg="numStats: 1255325"
time="2016-05-28T18:23:39+10:00" level=info msg="numStats: 1155954"

	statsd_test.go:49: Processed metrics: 1155885
		TotalAlloc: 10451872568 (9042 per metric)
		Mallocs: 256015955 (221 per metric)
		NumGC: 410
		GCCPUFraction: 0.156066
```
Note that:
1. More metrics were processed in 15 seconds;
2. `TotalAlloc` is bigger because we managed to churn through more metrics. Per metric alloc is smaller 9357 vs 9042;
3. `Mallocs` is more or less the same... hm;
4. `GCCPUFraction` is less (fraction of CPU time used by GC)