### PR TITLE
Refactoring

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,7 +37,7 @@ func GetBackend(name string, v *viper.Viper) (backendTypes.Backend, error) {
 // InitBackend creates an instance of the named backend.
 func InitBackend(name string, v *viper.Viper) (backendTypes.Backend, error) {
 	if name == "" {
-		log.Info("No backend specified.")
+		log.Info("No backend specified")
 		return nil, nil
 	}
 

--- a/cloudprovider/cloudprovider.go
+++ b/cloudprovider/cloudprovider.go
@@ -1,0 +1,46 @@
+package cloudprovider
+
+import (
+	"fmt"
+
+	"github.com/atlassian/gostatsd/cloudprovider/providers/aws"
+	cloudTypes "github.com/atlassian/gostatsd/cloudprovider/types"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// All registered cloud providers.
+var providers = map[string]cloudTypes.Factory{
+	aws.ProviderName: aws.NewProviderFromViper,
+}
+
+// GetCloudProvider creates an instance of the named provider, or nil if
+// the name is not known.  The error return is only used if the named provider
+// was known but failed to initialize.
+func GetCloudProvider(name string, v *viper.Viper) (cloudTypes.Interface, error) {
+	f, found := providers[name]
+	if !found {
+		return nil, nil
+	}
+	return f(v)
+}
+
+// InitCloudProvider creates an instance of the named cloud provider.
+func InitCloudProvider(name string, v *viper.Viper) (cloudTypes.Interface, error) {
+	if name == "" {
+		log.Info("No cloud provider specified")
+		return nil, nil
+	}
+
+	provider, err := GetCloudProvider(name, v)
+	if err != nil {
+		return nil, fmt.Errorf("could not init cloud provider %q: %v", name, err)
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("unknown cloud provider %q", name)
+	}
+	log.Infof("Initialised cloud provider %q", name)
+
+	return provider, nil
+}

--- a/cover.sh
+++ b/cover.sh
@@ -14,7 +14,7 @@ ERROR=""
 declare -a packages=('backend' 'backend/types' \
     'backend/backends/datadog' 'backend/backends/graphite' 'backend/backends/null' \
     'backend/backends/statsdaemon' 'backend/backends/stdout' \
-    'cloudprovider/providers/aws' 'cloudprovider/types' \
+    'cloudprovider' 'cloudprovider/providers/aws' 'cloudprovider/types' \
     'statsd' 'types');
 
 # Test each package and append coverage profile info to coverage.out

--- a/tester/main.go
+++ b/tester/main.go
@@ -37,7 +37,6 @@ func main() {
 	}
 	if s.Benchmark != 0 {
 		server := statsd.Server{
-			Backends:         []string{"null"},
 			ConsoleAddr:      "",
 			DefaultTags:      statsd.DefaultTags,
 			ExpiryInterval:   statsd.DefaultExpiryInterval,


### PR DESCRIPTION
- Revive cloudprovider but without unnecessary methods;
- statsd server accepts strict types for percentiles and backends;
- More precisely count metrics in the test (it was counting reads before)