### PR TITLE
Update readme to reference contributor license agreement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
+MIT License
+
 Copyright (c) 2012 Kamil Kisiel
+Copyright (c) 2016 Atlassian and others
 
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ Monitoring
 Currently you can get some basic idea of the status of the server by visiting the
 address given by the `--console-addr` option with your web browser.
 
-Contributing
-------------
-Contribute more backends by sending pull requests.
-
 Load balancing and scaling out
 ------------------------------
 It is possible to run multiple versions of `gostatsd` behind a load balancer by having them
@@ -103,6 +99,31 @@ In your source code:
 
 Documentation can be found via `go doc github.com/atlassian/gostatsd/statsd` or at
 https://godoc.org/github.com/atlassian/gostatsd/statsd
+
+Contributors
+------------
+
+Pull requests, issues and comments welcome. For pull requests:
+
+* Add tests for new features and bug fixes
+* Follow the existing style
+* Separate unrelated changes into multiple pull requests
+
+See the existing issues for things to start contributing.
+
+For bigger changes, make sure you start a discussion first by creating an issue and explaining the intended change.
+
+Atlassian requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have it used in distributions and derivative works (or is willing to transfer ownership).
+
+Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for those contributing as an individual.
+
+* [CLA for corporate contributors](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=e1c17c66-ca4d-4aab-a953-2c231af4a20b)
+* [CLA for individuals](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=3f94fbdc-2fbe-46ac-b14c-5d152700ae5d)
+
+License
+-------
+
+Copyright (c) 2012 Kamil Kisiel, Copyright (c) 2016 Atlassian and others. MIT licensed, see LICENSE file.
 
 [etsy]: https://www.etsy.com
 [statsd]: https://www.github.com/etsy/statsd


### PR DESCRIPTION
Atlassian has an internal process for managing its open source projects. This PR adds the CLA to gostatsd.

@kisielk, I'm a developer working with @ash2k (though I've mainly been lurking until now). Would you be willing to accept this agreement to cover your past contributions to gostatsd?

Please note that signing this agreement doesn't change your ownership of any code you wrote or how you are credited in the project documentation, it just grants some protections our lawyers tell us we need to manage this kind of project. It can be done entirely online at https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=3f94fbdc-2fbe-46ac-b14c-5d152700ae5d