### PR TITLE
Add maxConcurrency argument to NewDispatchingHandler to rate limit active goroutines

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -179,7 +179,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 
 	// 2. Start handlers
 	var handler Handler
-	dispHandler := NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags)
+	dispHandler := NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags, 0)
 	handler = dispHandler
 	if s.CloudProvider != nil {
 		ch := NewCloudHandler(s.CloudProvider, handler, s.Limiter, nil)


### PR DESCRIPTION
Fixes #24.

Previously, the number of goroutines created by calls to DispatchEvent()
was unrestricted. This commit adds a new argument to
NewDispatchingHandler, backed by a new dispatchLimiter struct, that
limits the number of goroutines that DispatchEvent() can have in flight
at one time.

This is based heavily off the design of LimitListener from golang/net

TODO:

- [ ] Write tests
- [ ] Implement configuration mechanism for specifying maxConcurrency

Before completing the remaining tasks, I'd love to get some design feedback. 