### PR TITLE
Push docker image on successful tag build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
+sudo: required
+
 language: go
+
+services:
+  - docker
 
 go:
   - 1.6.2
@@ -19,3 +24,12 @@ script:
   - METALINTER_CONCURRENCY=2 make check
   - make bench-race
   - make coveralls
+
+after_success:
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a ! -z "$TRAVIS_TAG" ]; then
+    echo "Executing release on tag build $TRAVIS_TAG";
+    docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    ARCH=linux make release;
+    else
+    echo "Not executing release on non-tag build";
+    fi


### PR DESCRIPTION
Release to docker on tagged builds.

Should work on lightweight tags and annotated tags (git tag -a). Travis-ci may not build again for lightweight tags since the commit hash does not change, so suggest we use annotated tags only.

Relevant travis-ci docs:
* https://docs.travis-ci.com/user/docker/#Branch-Based-Registry-Pushes
* https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables

See build of my branch:
* https://travis-ci.org/aelse/gostatsd/jobs/141248214
* https://hub.docker.com/r/aelse/gostatsd/tags/

I've added the DOCKER_* env vars to atlassian/gostatsd on travis-ci.
@ash2k 