### PR TITLE
Improve tags support

### DIFF
--- a/backend/backends/stdout/stdout.go
+++ b/backend/backends/stdout/stdout.go
@@ -35,10 +35,15 @@ func composeMetricName(key string, tagsKey string) string {
 	tags := strings.Split(tagsKey, ",")
 	for _, tag := range tags {
 		if tag != "" {
-			key += "." + types.TagToMetricName(tag)
+			key += "." + tagToMetricName(tag)
 		}
 	}
 	return key
+}
+
+// tagToMetricName transforms tags into metric names.
+func tagToMetricName(tag string) string {
+	return strings.Replace(tag, ":", ".", -1)
 }
 
 // SampleConfig returns the sample config for the stdout backend.

--- a/cloudprovider/providers/aws/aws.go
+++ b/cloudprovider/providers/aws/aws.go
@@ -126,7 +126,7 @@ func (p *provider) Instance(IP types.IP) (*cloudTypes.Instance, error) {
 		return nil, err
 	}
 	if len(instances) == 0 {
-		return nil, fmt.Errorf("no instances returned")
+		return nil, errors.New("no instances returned")
 	}
 
 	i := instances[0]
@@ -134,14 +134,16 @@ func (p *provider) Instance(IP types.IP) (*cloudTypes.Instance, error) {
 	if err != nil {
 		log.Errorf("Error getting instance region: %v", err)
 	}
+	tags := make(types.Tags, len(i.Tags))
+	for idx, tag := range i.Tags {
+		tags[idx] = fmt.Sprintf("%s:%s",
+			types.NormalizeTagKey(aws.StringValue(tag.Key)),
+			types.NormalizeTagValue(aws.StringValue(tag.Value)))
+	}
 	instance := &cloudTypes.Instance{
 		ID:     aws.StringValue(i.InstanceId),
 		Region: region,
-		Tags:   make(types.Tags, len(i.Tags)),
-	}
-	for idx, tag := range i.Tags {
-		instance.Tags[idx] = fmt.Sprintf("%s:%s",
-			types.NormalizeTagElement(aws.StringValue(tag.Key)), types.NormalizeTagElement(aws.StringValue(tag.Value)))
+		Tags:   tags,
 	}
 	return instance, nil
 }

--- a/statsd/lexer_test.go
+++ b/statsd/lexer_test.go
@@ -17,8 +17,8 @@ func TestMetricsLexer(t *testing.T) {
 		"smp.rte:5|c|#foo:bar,baz":      {Name: "smp.rte", Value: 5, Type: types.COUNTER, Tags: types.Tags{"foo:bar", "baz"}},
 		"uniq.usr:joe|s":                {Name: "uniq.usr", StringValue: "joe", Type: types.SET},
 		"fooBarBaz:2|c":                 {Name: "fooBarBaz", Value: 2, Type: types.COUNTER},
-		"smp.rte:5|c|#Foo:Bar,baz":      {Name: "smp.rte", Value: 5, Type: types.COUNTER, Tags: types.Tags{"foo:bar", "baz"}},
-		"smp.gge:1|g|#Foo:Bar":          {Name: "smp.gge", Value: 1, Type: types.GAUGE, Tags: types.Tags{"foo:bar"}},
+		"smp.rte:5|c|#Foo:Bar,baz":      {Name: "smp.rte", Value: 5, Type: types.COUNTER, Tags: types.Tags{"Foo:Bar", "baz"}},
+		"smp.gge:1|g|#Foo:Bar":          {Name: "smp.gge", Value: 1, Type: types.GAUGE, Tags: types.Tags{"Foo:Bar"}},
 		"smp.gge:1|g|#fo_o:ba-r":        {Name: "smp.gge", Value: 1, Type: types.GAUGE, Tags: types.Tags{"fo_o:ba-r"}},
 		"smp gge:1|g":                   {Name: "smp_gge", Value: 1, Type: types.GAUGE},
 		"smp/gge:1|g":                   {Name: "smp-gge", Value: 1, Type: types.GAUGE},
@@ -27,6 +27,12 @@ func TestMetricsLexer(t *testing.T) {
 		"un1qu3:john|s|#some:42":        {Name: "un1qu3", StringValue: "john", Type: types.SET, Tags: types.Tags{"some:42"}},
 		"da-sh:1|s":                     {Name: "da-sh", StringValue: "1", Type: types.SET},
 		"under_score:1|s":               {Name: "under_score", StringValue: "1", Type: types.SET},
+		"a:1|g|#f,,":                    {Name: "a", Value: 1, Type: types.GAUGE, Tags: types.Tags{"f"}},
+		"a:1|g|#,,f":                    {Name: "a", Value: 1, Type: types.GAUGE, Tags: types.Tags{"f"}},
+		"a:1|g|#f,,z":                   {Name: "a", Value: 1, Type: types.GAUGE, Tags: types.Tags{"f", "z"}},
+		"a:1|g|#":                       {Name: "a", Value: 1, Type: types.GAUGE},
+		"a:1|g|#,":                      {Name: "a", Value: 1, Type: types.GAUGE},
+		"a:1|g|#,,":                     {Name: "a", Value: 1, Type: types.GAUGE},
 	}
 
 	compareMetric(tests, "", t)

--- a/types/metrics.go
+++ b/types/metrics.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"regexp"
 	"time"
 )
 
@@ -30,12 +29,6 @@ const (
 	GAUGE
 	// SET is statsd set type
 	SET
-)
-
-// Regular expressions used for metric name normalization.
-var (
-	regDot       = regexp.MustCompile(`\.`)
-	regSemiColon = regexp.MustCompile(`:`)
 )
 
 func (m MetricType) String() string {

--- a/types/tags.go
+++ b/types/tags.go
@@ -8,6 +8,8 @@ import (
 // Tags represents a list of tags.
 type Tags []string
 
+var tagKeysReplacer = strings.NewReplacer(":", "_", ",", "_")
+
 // String sorts the tags alphabetically and returns
 // a comma-separated string representation of the tags.
 func (tags Tags) String() string {
@@ -26,16 +28,14 @@ func (tags Tags) IndexOfKey(key string) (int, string) {
 	return -1, ""
 }
 
-// TagToMetricName transforms tags into metric names.
-func TagToMetricName(tag string) string {
-	return regSemiColon.ReplaceAllString(tag, ".")
+// NormalizeTagKey cleans up the key of a tag.
+func NormalizeTagKey(key string) string {
+	return tagKeysReplacer.Replace(key)
 }
 
-// NormalizeTagElement cleans up the key or the value of a tag.
-func NormalizeTagElement(name string) string {
-	element := regSemiColon.ReplaceAllString(name, "_")
-	element = regDot.ReplaceAllString(element, "_")
-	return strings.ToLower(element)
+// NormalizeTagValue cleans up the value of a tag.
+func NormalizeTagValue(value string) string {
+	return strings.Replace(value, ",", "_", -1)
 }
 
 // ExtractSourceFromTags returns the source from the tags


### PR DESCRIPTION
1. Datadog supports unicode in tags so non-ASCII characters shouldn't be cut out
2. Datadog replaces invalid characters itself so we don't have to do double work
3. If tags are case sensitive they shouldn't be lowercased; if tags are case insensitive they don't have to be lowercased to avoid double work
4. Do not add empty tags