### PR TITLE
Optimize metrics sizes

### DIFF
--- a/backend/backends/datadog/datadog_test.go
+++ b/backend/backends/datadog/datadog_test.go
@@ -104,10 +104,10 @@ func metrics() *types.MetricMap {
 		NumStats: 2,
 		Counters: types.Counters{
 			"stat1": map[string]types.Counter{
-				"tag1": types.NewCounter(time.Now(), 1*time.Second, 5, "", nil),
+				"tag1": types.NewCounter(types.Nanotime(time.Now().UnixNano()), 5, "", nil),
 			},
 			"stat2": map[string]types.Counter{
-				"tag2": types.NewCounter(time.Now(), 2*time.Second, 50, "", nil),
+				"tag2": types.NewCounter(types.Nanotime(time.Now().UnixNano()), 50, "", nil),
 			},
 		},
 	}

--- a/backend/backends/graphite/graphite_test.go
+++ b/backend/backends/graphite/graphite_test.go
@@ -17,12 +17,12 @@ type testData struct {
 
 func TestPreparePayload(t *testing.T) {
 	assert := assert.New(t)
-	interval := types.Interval{Timestamp: time.Unix(123456, 0), Flush: 1 * time.Second}
+	timestamp := types.Nanotime(time.Unix(123456, 0).UnixNano())
 
 	metrics := &types.MetricMap{
 		Counters: types.Counters{
 			"stat1": map[string]types.Counter{
-				"tag1": {PerSecond: 1.1, Value: 5, Interval: interval},
+				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: timestamp},
 			},
 		},
 		Timers: types.Timers{
@@ -32,13 +32,13 @@ func TestPreparePayload(t *testing.T) {
 					Percentiles: types.Percentiles{
 						types.Percentile{Float: 90, Str: "count_90"},
 					},
-					Interval: interval,
+					Timestamp: timestamp,
 				},
 			},
 		},
 		Gauges: types.Gauges{
 			"g1": map[string]types.Gauge{
-				"baz": {Value: 3, Interval: interval},
+				"baz": {Value: 3, Timestamp: timestamp},
 			},
 		},
 		Sets: types.Sets{
@@ -49,7 +49,7 @@ func TestPreparePayload(t *testing.T) {
 						"bob":  {},
 						"john": {},
 					},
-					Interval: interval,
+					Timestamp: timestamp,
 				},
 			},
 		},

--- a/backend/backends/statsdaemon/statsdaemon_test.go
+++ b/backend/backends/statsdaemon/statsdaemon_test.go
@@ -15,7 +15,7 @@ var m = types.MetricMap{
 	NumStats: 1,
 	Counters: types.Counters{
 		longName: map[string]types.Counter{
-			"tag1": types.NewCounter(time.Now(), 1*time.Second, 5, "", nil),
+			"tag1": types.NewCounter(types.Nanotime(time.Now().UnixNano()), 5, "", nil),
 		},
 	},
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -310,7 +310,7 @@ func (af *agrFactory) Create() Aggregator {
 }
 
 func internalStatName(name string) string {
-	return fmt.Sprintf("statsd.%s", name)
+	return "statsd." + name
 }
 
 func toStringSlice(fs []float64) []string {

--- a/types/counters.go
+++ b/types/counters.go
@@ -1,19 +1,17 @@
 package types
 
-import "time"
-
 // Counter is used for storing aggregated values for counters.
 type Counter struct {
-	PerSecond float64 // The calculated per second rate
-	Value     int64   // The numeric value of the metric
-	Interval          // The flush and expiration interval information
-	Hostname  string  // Hostname of the source of the metric
-	Tags      Tags    // The tags for the counter
+	PerSecond float64  // The calculated per second rate
+	Value     int64    // The numeric value of the metric
+	Timestamp Nanotime // Last time value was updated
+	Hostname  string   // Hostname of the source of the metric
+	Tags      Tags     // The tags for the counter
 }
 
 // NewCounter initialises a new counter.
-func NewCounter(timestamp time.Time, flushInterval time.Duration, value int64, hostname string, tags Tags) Counter {
-	return Counter{Value: value, Interval: Interval{Timestamp: timestamp, Flush: flushInterval}, Hostname: hostname, Tags: tags}
+func NewCounter(timestamp Nanotime, value int64, hostname string, tags Tags) Counter {
+	return Counter{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags}
 }
 
 // Counters stores a map of counters by tags.

--- a/types/gauges.go
+++ b/types/gauges.go
@@ -1,18 +1,16 @@
 package types
 
-import "time"
-
 // Gauge is used for storing aggregated values for gauges.
 type Gauge struct {
-	Value    float64 // The numeric value of the metric
-	Interval         // The flush and expiration interval information
-	Hostname string  // Hostname of the source of the metric
-	Tags     Tags    // The tags for the gauge
+	Value     float64  // The numeric value of the metric
+	Timestamp Nanotime // Last time value was updated
+	Hostname  string   // Hostname of the source of the metric
+	Tags      Tags     // The tags for the gauge
 }
 
 // NewGauge initialises a new gauge.
-func NewGauge(timestamp time.Time, flushInterval time.Duration, value float64, hostname string, tags Tags) Gauge {
-	return Gauge{Value: value, Interval: Interval{Timestamp: timestamp, Flush: flushInterval}, Hostname: hostname, Tags: tags}
+func NewGauge(timestamp Nanotime, value float64, hostname string, tags Tags) Gauge {
+	return Gauge{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags}
 }
 
 // Gauges stores a map of gauges by tags.

--- a/types/metrics.go
+++ b/types/metrics.go
@@ -9,6 +9,10 @@ import (
 // MetricType is an enumeration of all the possible types of Metric.
 type MetricType byte
 
+// Nanotime is the number of nanoseconds elapsed since January 1, 1970 UTC.
+// Get the value with time.Now().UnixNano().
+type Nanotime int64
+
 // IP is a v4/v6 IP address.
 // We do not use net.IP because it will involve conversion to string and back several times.
 type IP string
@@ -104,10 +108,4 @@ func (m *MetricMap) String() string {
 		fmt.Fprintf(buf, "stats.set.%s: %d tags=%s\n", k, len(set.Values), tags)
 	})
 	return buf.String()
-}
-
-// Interval stores the flush interval and timestamp for expiration interval.
-type Interval struct {
-	Timestamp time.Time
-	Flush     time.Duration
 }

--- a/types/sets.go
+++ b/types/sets.go
@@ -1,18 +1,16 @@
 package types
 
-import "time"
-
 // Set is used for storing aggregated values for sets.
 type Set struct {
-	Values   map[string]struct{}
-	Interval        // The flush and expiration interval information
-	Hostname string // Hostname of the source of the metric
-	Tags     Tags   // The tags for the set
+	Values    map[string]struct{}
+	Timestamp Nanotime // Last time value was updated
+	Hostname  string   // Hostname of the source of the metric
+	Tags      Tags     // The tags for the set
 }
 
 // NewSet initialises a new set.
-func NewSet(timestamp time.Time, flushInterval time.Duration, values map[string]struct{}, hostname string, tags Tags) Set {
-	return Set{Values: values, Interval: Interval{Timestamp: timestamp, Flush: flushInterval}, Hostname: hostname, Tags: tags}
+func NewSet(timestamp Nanotime, values map[string]struct{}, hostname string, tags Tags) Set {
+	return Set{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags}
 }
 
 // Sets stores a map of sets by tags.

--- a/types/timers.go
+++ b/types/timers.go
@@ -1,7 +1,5 @@
 package types
 
-import "time"
-
 // Timer is used for storing aggregated values for timers.
 type Timer struct {
 	Count       int         // The number of timers in the series
@@ -15,14 +13,14 @@ type Timer struct {
 	SumSquares  float64     // The sum squares for the series
 	Values      []float64   // The numeric value of the metric
 	Percentiles Percentiles // The percentile aggregations of the metric
-	Interval                // The flush and expiration interval information
+	Timestamp   Nanotime    // Last time value was updated
 	Hostname    string      // Hostname of the source of the metric
 	Tags        Tags        // The tags for the timer
 }
 
 // NewTimer initialises a new timer.
-func NewTimer(timestamp time.Time, flushInterval time.Duration, values []float64, hostname string, tags Tags) Timer {
-	return Timer{Values: values, Interval: Interval{Timestamp: timestamp, Flush: flushInterval}, Hostname: hostname, Tags: tags}
+func NewTimer(timestamp Nanotime, values []float64, hostname string, tags Tags) Timer {
+	return Timer{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags}
 }
 
 // Timers stores a map of timers by tags.


### PR DESCRIPTION
1. No need to store flush interval in each metric, it is always the same for all of them.
2. Change last update time per-metric from `time.Time` (int64+int32+pointer) to just int64. Save 8-12 bytes per-metric.