### PR TITLE
Limit concurrent events

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -84,6 +84,8 @@ const (
 	ParamWebAddr = "web-addr"
 )
 
+const maxConcurrentEvents = 1024 // Random, should be good enough.
+
 // Server encapsulates all of the parameters necessary for starting up
 // the statsd server. These can either be set via command line or directly.
 type Server struct {
@@ -179,7 +181,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 
 	// 2. Start handlers
 	var handler Handler
-	dispHandler := NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags)
+	dispHandler := NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags, maxConcurrentEvents)
 	handler = dispHandler
 	if s.CloudProvider != nil {
 		ch := NewCloudHandler(s.CloudProvider, handler, s.Limiter, nil)


### PR DESCRIPTION
Fixes #24 

@mark-adams FYI. I thought about a buffer but it is not needed because 1024 goroutines is our "buffer".