### PR TITLE
Support TCP transport in statsd backend

### DIFF
--- a/backend/backends/graphite/graphite_test.go
+++ b/backend/backends/graphite/graphite_test.go
@@ -7,16 +7,15 @@ import (
 	"github.com/atlassian/gostatsd/types"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type testData struct {
-	config  *Config
-	metrics *types.MetricMap
-	result  []byte
-}
-
 func TestPreparePayload(t *testing.T) {
-	assert := assert.New(t)
+	type testData struct {
+		config  *Config
+		metrics *types.MetricMap
+		result  []byte
+	}
 	timestamp := types.Nanotime(time.Unix(123456, 0).UnixNano())
 
 	metrics := &types.MetricMap{
@@ -130,11 +129,9 @@ func TestPreparePayload(t *testing.T) {
 	}
 	for i, td := range input {
 		c, err := NewClient(td.config)
-		if !assert.NoError(err, "test %d", i) {
-			continue
-		}
+		require.NoError(t, err)
 		cl := c.(*client)
-		b := cl.preparePayload(td.metrics, time.Unix(1234, 0)).Bytes()
-		assert.Equal(td.result, b, "test %d", i)
+		b := cl.preparePayload(td.metrics, time.Unix(1234, 0))
+		assert.Equal(t, string(td.result), b.String(), "test %d", i)
 	}
 }

--- a/backend/backends/sender.go
+++ b/backend/backends/sender.go
@@ -1,0 +1,101 @@
+package backends
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	backendTypes "github.com/atlassian/gostatsd/backend/types"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const maxStreamsPerConnection = 100
+
+type ConnFactory func() (net.Conn, error)
+
+type Stream struct {
+	Cb  backendTypes.SendCallback
+	Buf chan *bytes.Buffer
+}
+
+type Sender struct {
+	ConnFactory  ConnFactory
+	Sink         chan Stream
+	BufPool      sync.Pool
+	WriteTimeout time.Duration
+}
+
+func (s *Sender) Run(ctx context.Context) error {
+	var stream *Stream
+	var errs []error
+	for {
+		w, err := s.ConnFactory()
+		if err != nil {
+			log.Warnf("Failed to connect: %v", err)
+			// TODO do backoff
+			timer := time.NewTimer(1 * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		}
+		if stream, errs, err = s.innerRun(ctx, w, stream, errs); err != nil {
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return err
+			}
+			errs = append(errs, err)
+		}
+	}
+}
+
+func (s *Sender) innerRun(ctx context.Context, conn net.Conn, stream *Stream, errs []error) (*Stream, []error, error) {
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Warnf("Close failed: %v", err)
+		}
+	}()
+	var err error
+loop:
+	for streamCount := 0; streamCount < maxStreamsPerConnection; streamCount++ {
+		if stream == nil {
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+				break loop
+			case s := <-s.Sink:
+				stream = &s
+			}
+		}
+		for buf := range stream.Buf {
+			if s.WriteTimeout > 0 {
+				if e := conn.SetWriteDeadline(time.Now().Add(s.WriteTimeout)); e != nil {
+					log.Warnf("Failed to set write deadline: %v", e)
+				}
+			}
+			_, err = conn.Write(buf.Bytes())
+			s.PutBuffer(buf)
+			if err != nil {
+				break loop
+			}
+		}
+		stream.Cb(errs)
+		stream = nil
+		errs = nil
+	}
+	return stream, errs, err
+}
+
+func (s *Sender) GetBuffer() *bytes.Buffer {
+	return s.BufPool.Get().(*bytes.Buffer)
+}
+
+func (s *Sender) PutBuffer(buf *bytes.Buffer) {
+	buf.Reset() // Reset buffer before returning it into the pool
+	s.BufPool.Put(buf)
+}

--- a/backend/backends/sender_test.go
+++ b/backend/backends/sender_test.go
@@ -1,0 +1,103 @@
+package backends
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSend(t *testing.T) {
+	dc := dummyConn{}
+	sender := Sender{
+		ConnFactory: func() (net.Conn, error) {
+			return &dc, nil
+		},
+		Sink: make(chan Stream),
+		BufPool: sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
+		},
+	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancel()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := sender.Run(ctx); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+			t.Error(err)
+		}
+	}()
+	var wgTest sync.WaitGroup
+	for i := 0; i <= 4; i++ {
+		wgTest.Add(1)
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			sink := make(chan *bytes.Buffer, i)
+			sender.Sink <- Stream{
+				Cb: func(errs []error) {
+					defer wgTest.Done()
+					for _, e := range errs {
+						assert.NoError(t, e)
+					}
+				},
+				Buf: sink,
+			}
+			for x := 0; x < i; x++ {
+				sink <- bytes.NewBuffer([]byte{byte(x)})
+			}
+			close(sink)
+		})
+	}
+	wgTest.Wait()
+	assert.Equal(t, []byte{0x0, 0x0, 0x1, 0x0, 0x1, 0x2, 0x0, 0x1, 0x2, 0x3}, dc.buf.Bytes())
+}
+
+type dummyConn struct {
+	buf      bytes.Buffer
+	isClosed bool
+}
+
+func (c *dummyConn) Read(b []byte) (int, error) {
+	return 0, errors.New("asdasd")
+}
+
+func (c *dummyConn) Write(b []byte) (int, error) {
+	if c.isClosed {
+		panic("closed")
+	}
+	return c.buf.Write(b)
+}
+
+func (c *dummyConn) Close() error {
+	c.isClosed = true
+	return nil
+}
+
+func (c *dummyConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (c *dummyConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (c *dummyConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *dummyConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *dummyConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/backend/types/types.go
+++ b/backend/types/types.go
@@ -28,3 +28,10 @@ type Backend interface {
 	// SendEvent sends event to the backend.
 	SendEvent(context.Context, *types.Event) error
 }
+
+// RunnableBackend represents a backend that needs a Run method to be executed to work.
+type RunnableBackend interface {
+	Backend
+	// Run executes backend send operations. Should be started in a goroutine.
+	Run(context.Context) error
+}


### PR DESCRIPTION
- Reuse TCP and UDP connections
- Limit amount of data streamed over single connection
- Reuse memory buffers in more cases
- Support write timeouts in statsd backend