### PR TITLE
Return structs, accept interfaces

### DIFF
--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -11,20 +11,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-// ProcessFunc is a function that gets executed by Aggregator with its state passed into the function.
-type ProcessFunc func(*gostatsd.MetricMap)
-
-// Aggregator is an object that aggregates statsd metrics.
-// The function NewAggregator should be used to create the objects.
-//
-// Incoming metrics should be passed via Receive function.
-type Aggregator interface {
-	Receive(*gostatsd.Metric, time.Time)
-	Flush(interval time.Duration)
-	Process(ProcessFunc)
-	Reset()
-}
-
 // percentStruct is a cache of percentile names to avoid creating them for each timer.
 type percentStruct struct {
 	count      string
@@ -35,16 +21,17 @@ type percentStruct struct {
 	lower      string
 }
 
-type aggregator struct {
+// MetricAggregator aggregates metrics.
+type MetricAggregator struct {
 	expiryInterval    time.Duration // How often to expire metrics
 	percentThresholds map[float64]percentStruct
 	now               func() time.Time // Returns current time. Useful for testing.
 	gostatsd.MetricMap
 }
 
-// NewAggregator creates a new Aggregator object.
-func NewAggregator(percentThresholds []float64, expiryInterval time.Duration) Aggregator {
-	a := aggregator{
+// NewMetricAggregator creates a new MetricAggregator object.
+func NewMetricAggregator(percentThresholds []float64, expiryInterval time.Duration) *MetricAggregator {
+	a := MetricAggregator{
 		expiryInterval:    expiryInterval,
 		percentThresholds: make(map[float64]percentStruct, len(percentThresholds)),
 		now:               time.Now,
@@ -76,7 +63,7 @@ func round(v float64) float64 {
 }
 
 // Flush prepares the contents of an Aggregator for sending via the Sender.
-func (a *aggregator) Flush(flushInterval time.Duration) {
+func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 	startTime := a.now()
 	a.FlushInterval = flushInterval
 	flushInSeconds := float64(flushInterval) / float64(time.Second)
@@ -170,11 +157,11 @@ func (a *aggregator) Flush(flushInterval time.Duration) {
 	a.ProcessingTime = a.now().Sub(startTime)
 }
 
-func (a *aggregator) Process(f ProcessFunc) {
+func (a *MetricAggregator) Process(f ProcessFunc) {
 	f(&a.MetricMap)
 }
 
-func (a *aggregator) isExpired(now, ts gostatsd.Nanotime) bool {
+func (a *MetricAggregator) isExpired(now, ts gostatsd.Nanotime) bool {
 	return a.expiryInterval != 0 && time.Duration(now-ts) > a.expiryInterval
 }
 
@@ -186,7 +173,7 @@ func deleteMetric(key, tagsKey string, metrics gostatsd.AggregatedMetrics) {
 }
 
 // Reset clears the contents of an Aggregator.
-func (a *aggregator) Reset() {
+func (a *MetricAggregator) Reset() {
 	a.NumStats = 0
 	nowNano := gostatsd.Nanotime(a.now().UnixNano())
 
@@ -235,7 +222,7 @@ func (a *aggregator) Reset() {
 	})
 }
 
-func (a *aggregator) receiveCounter(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
+func (a *MetricAggregator) receiveCounter(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
 	value := int64(m.Value)
 	v, ok := a.Counters[m.Name]
 	if ok {
@@ -254,7 +241,7 @@ func (a *aggregator) receiveCounter(m *gostatsd.Metric, tagsKey string, now gost
 	}
 }
 
-func (a *aggregator) receiveGauge(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
+func (a *MetricAggregator) receiveGauge(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
 	// TODO: handle +/-
 	v, ok := a.Gauges[m.Name]
 	if ok {
@@ -273,7 +260,7 @@ func (a *aggregator) receiveGauge(m *gostatsd.Metric, tagsKey string, now gostat
 	}
 }
 
-func (a *aggregator) receiveTimer(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
+func (a *MetricAggregator) receiveTimer(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
 	v, ok := a.Timers[m.Name]
 	if ok {
 		t, ok := v[tagsKey]
@@ -291,7 +278,7 @@ func (a *aggregator) receiveTimer(m *gostatsd.Metric, tagsKey string, now gostat
 	}
 }
 
-func (a *aggregator) receiveSet(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
+func (a *MetricAggregator) receiveSet(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
 	v, ok := a.Sets[m.Name]
 	if ok {
 		s, ok := v[tagsKey]
@@ -310,7 +297,7 @@ func (a *aggregator) receiveSet(m *gostatsd.Metric, tagsKey string, now gostatsd
 }
 
 // Receive aggregates an incoming metric.
-func (a *aggregator) Receive(m *gostatsd.Metric, now time.Time) {
+func (a *MetricAggregator) Receive(m *gostatsd.Metric, now time.Time) {
 	a.NumStats++
 	tagsKey := formatTagsKey(m.Tags, m.Hostname)
 	nowNano := gostatsd.Nanotime(now.UnixNano())

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -62,7 +62,7 @@ func round(v float64) float64 {
 	return math.Floor(v + 0.5)
 }
 
-// Flush prepares the contents of an Aggregator for sending via the Sender.
+// Flush prepares the contents of a MetricAggregator for sending via the Sender.
 func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 	startTime := a.now()
 	a.FlushInterval = flushInterval
@@ -172,7 +172,7 @@ func deleteMetric(key, tagsKey string, metrics gostatsd.AggregatedMetrics) {
 	}
 }
 
-// Reset clears the contents of an Aggregator.
+// Reset clears the contents of an MetricAggregator.
 func (a *MetricAggregator) Reset() {
 	a.NumStats = 0
 	nowNano := gostatsd.Nanotime(a.now().UnixNano())

--- a/pkg/statsd/aggregator_test.go
+++ b/pkg/statsd/aggregator_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newFakeAggregator() *aggregator {
-	return NewAggregator(
+func newFakeAggregator() *MetricAggregator {
+	return NewMetricAggregator(
 		[]float64{90},
 		5*time.Minute,
-	).(*aggregator)
+	)
 }
 
 func TestNewAggregator(t *testing.T) {
@@ -265,7 +265,7 @@ func TestIsExpired(t *testing.T) {
 
 	now := gostatsd.Nanotime(time.Now().UnixNano())
 
-	ma := &aggregator{expiryInterval: 0}
+	ma := &MetricAggregator{expiryInterval: 0}
 	assert.Equal(false, ma.isExpired(now, now))
 
 	ma.expiryInterval = 10 * time.Second

--- a/pkg/statsd/dispatcher_test.go
+++ b/pkg/statsd/dispatcher_test.go
@@ -85,7 +85,7 @@ func TestNewDispatcherShouldCreateCorrectNumberOfWorkers(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	n := r.Intn(5) + 1
 	factory := newTestFactory()
-	d := NewDispatcher(n, 1, factory).(*dispatcher)
+	d := NewMetricDispatcher(n, 1, factory)
 	if len(d.workers) != n {
 		t.Errorf("workers: expected %d, got %d", n, len(d.workers))
 	}
@@ -95,7 +95,7 @@ func TestNewDispatcherShouldCreateCorrectNumberOfWorkers(t *testing.T) {
 }
 
 func TestRunShouldReturnWhenContextCancelled(t *testing.T) {
-	d := NewDispatcher(5, 1, newTestFactory())
+	d := NewMetricDispatcher(5, 1, newTestFactory())
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancelFunc()
 
@@ -109,7 +109,7 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	n := r.Intn(5) + 1
 	factory := newTestFactory()
-	d := NewDispatcher(n, 10, factory).(*dispatcher)
+	d := NewMetricDispatcher(n, 10, factory)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
@@ -165,7 +165,7 @@ func getTotalInvocations(inv map[int]int) int {
 func BenchmarkDispatcher(b *testing.B) {
 	rand.Seed(time.Now().UnixNano())
 	factory := newTestFactory()
-	d := NewDispatcher(runtime.NumCPU(), 10, factory).(*dispatcher)
+	d := NewMetricDispatcher(runtime.NumCPU(), 10, factory)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup

--- a/pkg/statsd/dispatching_handler.go
+++ b/pkg/statsd/dispatching_handler.go
@@ -9,8 +9,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-// dispatchingHandler dispatches events to all configured backends and forwards metrics to a Dispatcher.
-type dispatchingHandler struct {
+// DispatchingHandler dispatches events to all configured backends and forwards metrics to a Dispatcher.
+type DispatchingHandler struct {
 	wg               sync.WaitGroup
 	dispatcher       Dispatcher
 	backends         []gostatsd.Backend
@@ -19,8 +19,8 @@ type dispatchingHandler struct {
 }
 
 // NewDispatchingHandler initialises a new dispatching handler.
-func NewDispatchingHandler(dispatcher Dispatcher, backends []gostatsd.Backend, tags gostatsd.Tags, maxConcurrentEvents uint) Handler {
-	return &dispatchingHandler{
+func NewDispatchingHandler(dispatcher Dispatcher, backends []gostatsd.Backend, tags gostatsd.Tags, maxConcurrentEvents uint) *DispatchingHandler {
+	return &DispatchingHandler{
 		dispatcher:       dispatcher,
 		backends:         backends,
 		tags:             tags,
@@ -28,7 +28,7 @@ func NewDispatchingHandler(dispatcher Dispatcher, backends []gostatsd.Backend, t
 	}
 }
 
-func (dh *dispatchingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+func (dh *DispatchingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	if m.Hostname == "" {
 		m.Hostname = string(m.SourceIP)
 	}
@@ -36,7 +36,7 @@ func (dh *dispatchingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Me
 	return dh.dispatcher.DispatchMetric(ctx, m)
 }
 
-func (dh *dispatchingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
+func (dh *DispatchingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
 	if e.Hostname == "" {
 		e.Hostname = string(e.SourceIP)
 	}
@@ -58,11 +58,11 @@ func (dh *dispatchingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Eve
 }
 
 // WaitForEvents waits for all event-dispatching goroutines to finish.
-func (dh *dispatchingHandler) WaitForEvents() {
+func (dh *DispatchingHandler) WaitForEvents() {
 	dh.wg.Wait()
 }
 
-func (dh *dispatchingHandler) dispatchEvent(ctx context.Context, backend gostatsd.Backend, e *gostatsd.Event) {
+func (dh *DispatchingHandler) dispatchEvent(ctx context.Context, backend gostatsd.Backend, e *gostatsd.Event) {
 	defer dh.wg.Done()
 	defer func() {
 		<-dh.concurrentEvents

--- a/pkg/statsd/flusher.go
+++ b/pkg/statsd/flusher.go
@@ -44,7 +44,7 @@ type MetricFlusher struct {
 	sentMetricsReceived uint64
 }
 
-// NewFlusher creates a new Flusher with provided configuration.
+// NewMetricFlusher creates a new MetricFlusher with provided configuration.
 func NewMetricFlusher(flushInterval time.Duration, dispatcher Dispatcher, receiver Receiver, handler Handler, backends []gostatsd.Backend, selfIP gostatsd.IP, hostname string) *MetricFlusher {
 	return &MetricFlusher{
 		flushInterval: flushInterval,
@@ -72,7 +72,7 @@ func (f *MetricFlusher) Run(ctx context.Context) error {
 	}
 }
 
-// GetStats returns Flusher statistics.
+// GetStats returns MetricFlusher statistics.
 func (f *MetricFlusher) GetStats() FlusherStats {
 	return FlusherStats{
 		time.Unix(0, atomic.LoadInt64(&f.lastFlush)),

--- a/pkg/statsd/flusher_test.go
+++ b/pkg/statsd/flusher_test.go
@@ -14,7 +14,7 @@ func TestFlusherHandleSendResultNoErrors(t *testing.T) {
 		{nil},
 	}
 	for pos, errs := range input {
-		fl := NewFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host").(*flusher)
+		fl := NewMetricFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host")
 		fl.handleSendResult(errs)
 
 		if fl.lastFlush == 0 || fl.lastFlushError != 0 {
@@ -32,7 +32,7 @@ func TestFlusherHandleSendResultError(t *testing.T) {
 		{errors.New("boom"), errors.New("boom")},
 	}
 	for pos, errs := range input {
-		fl := NewFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host").(*flusher)
+		fl := NewMetricFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host")
 		fl.handleSendResult(errs)
 
 		if fl.lastFlushError == 0 || fl.lastFlush != 0 {

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -149,7 +149,7 @@ func compareEvent(tests map[string]gostatsd.Event, t *testing.T) {
 
 var parselineBlackhole *gostatsd.Metric
 
-func benchmarkLexer(mr *metricReceiver, input string, b *testing.B) {
+func benchmarkLexer(mr *MetricReceiver, input string, b *testing.B) {
 	slice := []byte(input)
 	var r *gostatsd.Metric
 	for n := 0; n < b.N; n++ {
@@ -159,32 +159,32 @@ func benchmarkLexer(mr *metricReceiver, input string, b *testing.B) {
 }
 
 func BenchmarkParseCounter(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "foo.bar.baz:2|c", b)
+	benchmarkLexer(&MetricReceiver{}, "foo.bar.baz:2|c", b)
 }
 func BenchmarkParseCounterWithSampleRate(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "smp.rte:5|c|@0.1", b)
+	benchmarkLexer(&MetricReceiver{}, "smp.rte:5|c|@0.1", b)
 }
 func BenchmarkParseCounterWithTags(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "smp.rte:5|c|#foo:bar,baz", b)
+	benchmarkLexer(&MetricReceiver{}, "smp.rte:5|c|#foo:bar,baz", b)
 }
 func BenchmarkParseCounterWithTagsAndSampleRate(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "smp.rte:5|c|@0.1|#foo:bar,baz", b)
+	benchmarkLexer(&MetricReceiver{}, "smp.rte:5|c|@0.1|#foo:bar,baz", b)
 }
 func BenchmarkParseGauge(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "abc.def.g:3|g", b)
+	benchmarkLexer(&MetricReceiver{}, "abc.def.g:3|g", b)
 }
 func BenchmarkParseTimer(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "def.g:10|ms", b)
+	benchmarkLexer(&MetricReceiver{}, "def.g:10|ms", b)
 }
 func BenchmarkParseSet(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "uniq.usr:joe|s", b)
+	benchmarkLexer(&MetricReceiver{}, "uniq.usr:joe|s", b)
 }
 func BenchmarkParseCounterWithDefaultTags(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "foo.bar.baz:2|c", b)
+	benchmarkLexer(&MetricReceiver{}, "foo.bar.baz:2|c", b)
 }
 func BenchmarkParseCounterWithDefaultTagsAndTags(b *testing.B) {
-	benchmarkLexer(&metricReceiver{}, "foo.bar.baz:2|c|#foo:bar,baz", b)
+	benchmarkLexer(&MetricReceiver{}, "foo.bar.baz:2|c|#foo:bar,baz", b)
 }
 func BenchmarkParseCounterWithDefaultTagsAndTagsAndNameSpace(b *testing.B) {
-	benchmarkLexer(&metricReceiver{namespace: "stats"}, "foo.bar.baz:2|c|#foo:bar,baz", b)
+	benchmarkLexer(&MetricReceiver{namespace: "stats"}, "foo.bar.baz:2|c|#foo:bar,baz", b)
 }

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -24,7 +24,7 @@ func TestReceiveEmptyPacket(t *testing.T) {
 	}
 	for _, inp := range input {
 		ch := &countingHandler{}
-		mr := NewMetricReceiver("", ch).(*metricReceiver)
+		mr := NewMetricReceiver("", ch)
 
 		err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, inp)
 		if err != nil {
@@ -74,7 +74,7 @@ func TestReceivePacket(t *testing.T) {
 	}
 	for packet, mAndE := range input {
 		ch := &countingHandler{}
-		mr := NewMetricReceiver("", ch).(*metricReceiver)
+		mr := NewMetricReceiver("", ch)
 
 		err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 		if err != nil {
@@ -96,7 +96,7 @@ func TestReceivePacket(t *testing.T) {
 }
 
 func BenchmarkReceive(b *testing.B) {
-	mr := &metricReceiver{
+	mr := &MetricReceiver{
 		handler: nopHandler{},
 	}
 	c := fakesocket.FakePacketConn{}

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -200,7 +200,8 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	// 2. Start handlers
 	ip := gostatsd.UnknownIP
 
-	handler := NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags, uint(s.MaxConcurrentEvents))
+	var handler Handler
+	handler = NewDispatchingHandler(dispatcher, s.Backends, s.DefaultTags, uint(s.MaxConcurrentEvents))
 	if s.CloudProvider != nil {
 		ch := NewCloudHandler(s.CloudProvider, handler, s.Limiter, nil)
 		handler = ch

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -183,7 +183,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 		percentThresholds: s.PercentThreshold,
 		expiryInterval:    s.ExpiryInterval,
 	}
-	dispatcher := NewDispatcher(s.MaxWorkers, s.MaxQueueSize, &factory)
+	dispatcher := NewMetricDispatcher(s.MaxWorkers, s.MaxQueueSize, &factory)
 
 	var wgDispatcher sync.WaitGroup
 	defer wgDispatcher.Wait()                                       // Wait for dispatcher to shutdown

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -328,7 +328,7 @@ type agrFactory struct {
 }
 
 func (af *agrFactory) Create() Aggregator {
-	return NewAggregator(af.percentThresholds, af.expiryInterval)
+	return NewMetricAggregator(af.percentThresholds, af.expiryInterval)
 }
 
 func toStringSlice(fs []float64) []string {

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -253,7 +253,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 
 	// 4. Start the Flusher
 	hostname := getHost()
-	flusher := NewFlusher(s.FlushInterval, dispatcher, receiver, handler, s.Backends, ip, hostname)
+	flusher := NewMetricFlusher(s.FlushInterval, dispatcher, receiver, handler, s.Backends, ip, hostname)
 	var wgFlusher sync.WaitGroup
 	defer wgFlusher.Wait() // Wait for the Flusher to finish
 	wgFlusher.Add(1)

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"context"
+	"net"
 	"sync"
 	"time"
 
@@ -53,5 +54,25 @@ type FlusherStats struct {
 
 // Flusher periodically flushes metrics from all Aggregators to Senders.
 type Flusher interface {
+	// GetStats returns Flusher statistics.
 	GetStats() FlusherStats
+}
+
+// Receiver receives data on its PacketConn.
+type Receiver interface {
+	// Receive accepts incoming datagrams on packet connection.
+	// Safe for concurrent use.
+	Receive(context.Context, net.PacketConn) error
+	// GetStats returns current Receiver stats.
+	// Safe for concurrent use.
+	GetStats() ReceiverStats
+}
+
+// ReceiverStats holds statistics for a Receiver.
+type ReceiverStats struct {
+	LastPacket      time.Time
+	BadLines        uint64
+	PacketsReceived uint64
+	MetricsReceived uint64
+	EventsReceived  uint64
 }

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"context"
+	"time"
 
 	"github.com/atlassian/gostatsd"
 )
@@ -14,4 +15,18 @@ type Handler interface {
 	DispatchEvent(context.Context, *gostatsd.Event) error
 	// WaitForEvents waits for all event-dispatching goroutines to finish.
 	WaitForEvents()
+}
+
+// ProcessFunc is a function that gets executed by Aggregator with its state passed into the function.
+type ProcessFunc func(*gostatsd.MetricMap)
+
+// Aggregator is an object that aggregates statsd metrics.
+// The function NewAggregator should be used to create the objects.
+//
+// Incoming metrics should be passed via Receive function.
+type Aggregator interface {
+	Receive(*gostatsd.Metric, time.Time)
+	Flush(interval time.Duration)
+	Process(ProcessFunc)
+	Reset()
 }

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -44,3 +44,14 @@ type Dispatcher interface {
 	// less than numWorkers times if the context signals "done".
 	Process(context.Context, DispatcherProcessFunc) *sync.WaitGroup
 }
+
+// FlusherStats holds statistics about a Flusher.
+type FlusherStats struct {
+	LastFlush      time.Time // Last time the metrics where aggregated
+	LastFlushError time.Time // Time of the last flush error
+}
+
+// Flusher periodically flushes metrics from all Aggregators to Senders.
+type Flusher interface {
+	GetStats() FlusherStats
+}


### PR DESCRIPTION
No functional changes, just refactoring. Note how nicely `Dispatcher` and `Flusher` interfaces do not have `Run` method now.