### PR TITLE
Try to address leak

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 359cade812f38c0fd4660a5faabea736675fc327392b120cb3bddc26573f46c3
-updated: 2016-12-27T16:05:41.886428348+11:00
+hash: f77792499d8963ba60189bf8c92420f988283b2c34430081d96985acd7f9f32f
+updated: 2017-01-20T16:37:01.201293964+11:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 1e6377549087b490b693300bce2c5e286dc87740
+  version: f82d132783af109928d89d526ccc8d9fc320639e
   subpackages:
   - aws
   - aws/awserr

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/spf13/pflag
 - package: github.com/spf13/viper
 - package: github.com/aws/aws-sdk-go
-  version: 1.6.8
+  version: 1.6.14
   subpackages:
   - aws/credentials
   - aws/credentials/ec2rolecreds

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -264,6 +264,10 @@ func NewClient(apiEndpoint, apiKey string, metricsPerBatch uint, clientTimeout, 
 			Timeout:   5 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
+		MaxIdleConns:          50,
+		IdleConnTimeout:       1 * time.Minute,
+		ResponseHeaderTimeout: 2 * time.Second,
+		ExpectContinueTimeout: 2 * time.Second,
 	}
 	if err := http2.ConfigureTransport(transport); err != nil {
 		return nil, err


### PR DESCRIPTION
For external observers - there are lots of goroutines stuck with this stacktrace. Trying to figure out why this is happening.
```
goroutine 1951186853 [select]:
net/http.(*persistConn).roundTrip(0xc428960c00, 0xc420930a40, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transport.go:1840 +0x93b
net/http.(*Transport).RoundTrip(0xc4200ca000, 0xc441fe8a50, 0xc4200ca000, 0xed01361e2, 0xc42b597a7d)
	/usr/local/go/src/net/http/transport.go:380 +0x4ee
net/http.send(0xc429b0b860, 0xd197c0, 0xc4200ca000, 0xed01361e2, 0x2b597a7d, 0xd41840, 0x8, 0xc4200249a8, 0x411dc8)
	/usr/local/go/src/net/http/client.go:256 +0x15f
net/http.(*Client).send(0xc4201174a0, 0xc429b0b860, 0xed01361e2, 0x2b597a7d, 0xd41840, 0xc4200249a8, 0x0, 0x1)
	/usr/local/go/src/net/http/client.go:146 +0x102
net/http.(*Client).doFollowingRedirects(0xc4201174a0, 0xc429b0b860, 0xa6d330, 0x4, 0xc425c21f01, 0x28)
	/usr/local/go/src/net/http/client.go:528 +0x5e5
net/http.(*Client).Do(0xc4201174a0, 0xc429b0b860, 0x0, 0xd19040, 0xc4201fe000)
	/usr/local/go/src/net/http/client.go:187 +0x11d
github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/corehandlers.glob..func2(0xc44211d180)
	/gopath/src/github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go:73 +0x53
github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/request.(*HandlerList).Run(0xc44211d2e8, 0xc44211d180)
	/gopath/src/github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go:136 +0x87
github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/request.(*Request).Send(0xc44211d180, 0xc45934d810, 0xc44211d180)
	/gopath/src/github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/aws/request/request.go:271 +0x22c
github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/service/ec2.(*EC2).DescribeInstances(0xc4201fe010, 0xc45934d810, 0xe, 0x48, 0x48)
	/gopath/src/github.com/atlassian/gostatsd/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go:3403 +0x4d
github.com/atlassian/gostatsd/cloudprovider/providers/aws.(*awsSdkEC2).DescribeInstances(0xc4201fe018, 0xc45934d810, 0x0, 0xc42a6f1130, 0x0, 0xc42a6f1180, 0xc4201b12c0)
	/gopath/src/github.com/atlassian/gostatsd/cloudprovider/providers/aws/aws.go:83 +0x7d
github.com/atlassian/gostatsd/cloudprovider/providers/aws.(*provider).Instance(0xc4201f6040, 0xc425d1e720, 0xe, 0xc438b15ee8, 0xc438b15e01, 0x60a5c5)
	/gopath/src/github.com/atlassian/gostatsd/cloudprovider/providers/aws/aws.go:118 +0x246
github.com/atlassian/gostatsd/statsd.(*cloudHandler).doLookup(0xc420212090, 0xd1f500, 0xc4201f6280, 0xc4201f9560, 0xc425d1e720, 0xe, 0xc420206e40)
	/gopath/src/github.com/atlassian/gostatsd/statsd/cloud_handler.go:308 +0xa3
created by github.com/atlassian/gostatsd/statsd.(*cloudHandler).lookupDispatcher
	/gopath/src/github.com/atlassian/gostatsd/statsd/cloud_handler.go:301 +0x2d6
```

Log errors from AWS requests
Set timeouts on more things