### PR TITLE
Support for TLS in the statsdaemon backend

### DIFF
--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -3,6 +3,7 @@ package statsdaemon
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
@@ -12,8 +13,6 @@ import (
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
-
-	"crypto/tls"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"

--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -13,6 +13,8 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
 
+	"crypto/tls"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -199,7 +201,7 @@ func constructEventMessage(e *gostatsd.Event) *bytes.Buffer {
 }
 
 // NewClient constructs a new statsd backend client.
-func NewClient(address string, dialTimeout, writeTimeout time.Duration, disableTags, tcpTransport bool) (*Client, error) {
+func NewClient(address string, dialTimeout, writeTimeout time.Duration, disableTags, tcpTransport bool, tlsConfig *tls.Config) (*Client, error) {
 	if address == "" {
 		return nil, fmt.Errorf("[%s] address is required", BackendName)
 	}
@@ -211,22 +213,36 @@ func NewClient(address string, dialTimeout, writeTimeout time.Duration, disableT
 	}
 	log.Infof("[%s] address=%s dialTimeout=%s writeTimeout=%s", BackendName, address, dialTimeout, writeTimeout)
 	var packetSize int
-	var transport string
-	if tcpTransport {
+	var connFactory func() (net.Conn, error)
+
+	if tlsConfig != nil {
+		if !tcpTransport {
+			// Avoid surprising a user that expected this to enable DTLS.
+			return nil, fmt.Errorf("[%s] tcp_transport is required when using tls_transport", BackendName)
+		}
+
 		packetSize = maxTCPPacketSize
-		transport = "tcp"
+		dialer := &net.Dialer{Timeout: dialTimeout}
+		connFactory = func() (net.Conn, error) {
+			return tls.DialWithDialer(dialer, "tcp", address, tlsConfig)
+		}
+	} else if tcpTransport {
+		packetSize = maxTCPPacketSize
+		connFactory = func() (net.Conn, error) {
+			return net.DialTimeout("tcp", address, dialTimeout)
+		}
 	} else {
 		packetSize = maxUDPPacketSize
-		transport = "udp"
+		connFactory = func() (net.Conn, error) {
+			return net.DialTimeout("udp", address, dialTimeout)
+		}
 	}
 	return &Client{
 		packetSize:  packetSize,
 		disableTags: disableTags,
 		sender: sender.Sender{
-			ConnFactory: func() (net.Conn, error) {
-				return net.DialTimeout(transport, address, dialTimeout)
-			},
-			Sink: make(chan sender.Stream, maxConcurrentSends),
+			ConnFactory: connFactory,
+			Sink:        make(chan sender.Stream, maxConcurrentSends),
 			BufPool: sync.Pool{
 				New: func() interface{} {
 					buf := new(bytes.Buffer)
@@ -246,12 +262,22 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 	g.SetDefault("write_timeout", DefaultWriteTimeout)
 	g.SetDefault("disable_tags", false)
 	g.SetDefault("tcp_transport", false)
+	g.SetDefault("tls_transport", false)
+	maybeTLSConfig, err := getTLSConfiguration(
+		g.GetString("tls_ca_path"),
+		g.GetString("tls_cert_path"),
+		g.GetString("tls_key_path"),
+		g.GetBool("tls_transport"))
+	if err != nil {
+		return nil, err
+	}
 	return NewClient(
 		g.GetString("address"),
 		g.GetDuration("dial_timeout"),
 		g.GetDuration("write_timeout"),
 		g.GetBool("disable_tags"),
 		g.GetBool("tcp_transport"),
+		maybeTLSConfig,
 	)
 }
 

--- a/pkg/backends/statsdaemon/statsdaemon_test.go
+++ b/pkg/backends/statsdaemon/statsdaemon_test.go
@@ -28,7 +28,7 @@ var m = gostatsd.MetricMap{
 
 func TestProcessMetricsRecover(t *testing.T) {
 	t.Parallel()
-	c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, false, false)
+	c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, false, false, nil)
 	require.NoError(t, err)
 	c.processMetrics(&m, func(buf *bytes.Buffer) (*bytes.Buffer, bool) {
 		return nil, true
@@ -37,7 +37,7 @@ func TestProcessMetricsRecover(t *testing.T) {
 
 func TestProcessMetricsPanic(t *testing.T) {
 	t.Parallel()
-	c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, false, false)
+	c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, false, false, nil)
 	require.NoError(t, err)
 	expectedErr := errors.New("ABC some error")
 	defer func() {
@@ -83,7 +83,7 @@ func TestProcessMetrics(t *testing.T) {
 		val := val
 		t.Run(fmt.Sprintf("disableTags: %t", val.disableTags), func(t *testing.T) {
 			t.Parallel()
-			c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, val.disableTags, false)
+			c, err := NewClient("localhost:8125", 1*time.Second, 1*time.Second, val.disableTags, false, nil)
 			require.NoError(t, err)
 			c.processMetrics(&gaugeMetic, func(buf *bytes.Buffer) (*bytes.Buffer, bool) {
 				assert.EqualValues(t, val.expectedValue, buf.String())

--- a/pkg/backends/statsdaemon/tls.go
+++ b/pkg/backends/statsdaemon/tls.go
@@ -1,0 +1,56 @@
+package statsdaemon
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func getTLSConfiguration(caPath, certPath, keyPath string, enable bool) (*tls.Config, error) {
+	if !enable {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// Rationale:
+		// * Retain performance-conscious ordering from the crypto/tls defaults
+		// * Reject deprecated ciphers and modes, including non-DHE
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		},
+	}
+
+	if caPath != "" {
+		caPEM, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] error reading tls ca: %v", BackendName, err)
+		}
+
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if ok := tlsConfig.RootCAs.AppendCertsFromPEM(caPEM); !ok {
+			return nil, fmt.Errorf("[%s] error reading tls ca: no certs found", BackendName)
+		}
+	}
+
+	if certPath != "" || keyPath != "" {
+		if certPath == "" {
+			return nil, fmt.Errorf("[%s] tls_cert_path is required when tls_key_path is set", BackendName)
+		}
+		if keyPath == "" {
+			return nil, fmt.Errorf("[%s] tls_key_path is required when tls_cert_path is set", BackendName)
+		}
+
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] error loading client certificate: %v", BackendName, err)
+		}
+		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+	}
+
+	return tlsConfig, nil
+}

--- a/pkg/backends/statsdaemon/tls.go
+++ b/pkg/backends/statsdaemon/tls.go
@@ -13,27 +13,21 @@ func getTLSConfiguration(caPath, certPath, keyPath string, enable bool) (*tls.Co
 	}
 
 	tlsConfig := &tls.Config{
+		// Can't use SSLv3 because of POODLE and BEAST
+		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+		// Can't use TLSv1.1 because of RC4 cipher usage
 		MinVersion: tls.VersionTLS12,
-		// Rationale:
-		// * Retain performance-conscious ordering from the crypto/tls defaults
-		// * Reject deprecated ciphers and modes, including non-DHE
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		},
 	}
 
 	if caPath != "" {
 		caPEM, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			return nil, fmt.Errorf("[%s] error reading tls ca: %v", BackendName, err)
+			return nil, fmt.Errorf("[%s] error reading TLS CA: %v", BackendName, err)
 		}
 
 		tlsConfig.RootCAs = x509.NewCertPool()
 		if ok := tlsConfig.RootCAs.AppendCertsFromPEM(caPEM); !ok {
-			return nil, fmt.Errorf("[%s] error reading tls ca: no certs found", BackendName)
+			return nil, fmt.Errorf("[%s] error reading TLS CA: no certificates found", BackendName)
 		}
 	}
 


### PR DESCRIPTION
This is a works-for-me implementation of support for using TLS to secure the transmission of metrics over the statsd TCP protocol.

I'd very much like to get this merged eventually, including support in the receiver as well, but can't really make much progress on that for lack of support for TCP in the receiver. Were that to exist, this would have tests that exercise it end-to-end.

Are there any plans for or interest in TCP receiver support?

(If and when it's the remaining barrier for this being merged, getting the corporate CLA agreement taken care of shouldn't be an issue.)