### PR TITLE
Rework how IP buffering works

### DIFF
--- a/cloudprovider.go
+++ b/cloudprovider.go
@@ -24,6 +24,8 @@ type CloudProvider interface {
 	// ip -> nil pointer if instance was not found.
 	// map is returned even in case of errors because it may contain partial data.
 	Instance(context.Context, ...IP) (map[IP]*Instance, error)
+	// MaxInstancesBatch returns maximum number of instances that could be requested via the Instance method.
+	MaxInstancesBatch() int
 	// SelfIP returns host's IPv4 address.
 	SelfIP() (IP, error)
 }

--- a/pkg/statsd/cloud_handler_test.go
+++ b/pkg/statsd/cloud_handler_test.go
@@ -262,6 +262,10 @@ type fakeCountingProvider struct {
 	invocations uint64
 }
 
+func (p *fakeCountingProvider) MaxInstancesBatch() int {
+	return 16
+}
+
 func (fp *fakeCountingProvider) Invocations() uint64 {
 	fp.mu.Lock()
 	defer fp.mu.Unlock()

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -99,6 +99,10 @@ func (fp *fakeProvider) Name() string {
 	return "fakeProvider"
 }
 
+func (p *fakeProvider) MaxInstancesBatch() int {
+	return 16
+}
+
 func (fp *fakeProvider) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
 	instances := make(map[gostatsd.IP]*gostatsd.Instance, len(ips))
 	for _, ip := range ips {


### PR DESCRIPTION
Main `cloud_handler` loop handles both draining of `lookupResults` channel and pushes into `toLookup` channel to avoid deadlock with lookup goroutine. Also the batch size is configurable now.

Deadlock might happen if `cloud_handler` goroutine tries to push stuff into `toLookup` channel while it is full and the lookup goroutine is trying to push stuff into `lookupResults` channel. Each of them expects the other one to accept the item and both block on the send operation.

On stacktraces below this can be seen as:
```

goroutine 38 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).doLookup(0xc4201e39e0, 0x1005c20, 0xc42010d2c0, 0xc42012f000, 0x20, 0x20)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:79 +0x2a5
github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).run(0xc4201e39e0, 0x1005c20, 0xc42010d2c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:53 +0x318
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run.func1(0xc420203130, 0xc4201e39e0, 0x1005c20, 0xc42010d2c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:128 +0x65
created by github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:129 +0x361
```
and
```

goroutine 32 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).handleMetric(0xc4201bde60, 0x1005c20, 0xc42010d2c0, 0xc420242180, 0xc4206569a0, 0xc420200b38)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:231 +0x344
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run(0xc4201bde60, 0x1005c20, 0xc42010d2c0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:146 +0x63a
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func3(0xc420203030, 0xc4201bde60, 0x1005c20, 0xc42010d100)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:105 +0x6d
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:108 +0x10e0
```

Full traces:
```
goroutine 303286 [running]:
runtime/pprof.writeGoroutineStacks(0xffef60, 0xc432e06620, 0x30, 0xc42c27d080)
        /usr/local/go/src/runtime/pprof/pprof.go:603 +0x79
runtime/pprof.writeGoroutine(0xffef60, 0xc432e06620, 0x2, 0xc4201fea90, 0x40fde8)
        /usr/local/go/src/runtime/pprof/pprof.go:592 +0x44
runtime/pprof.(*Profile).WriteTo(0x1039100, 0xffef60, 0xc432e06620, 0x2, 0xc432e06620, 0xc4201fecc0)
        /usr/local/go/src/runtime/pprof/pprof.go:302 +0x3b5
net/http/pprof.handler.ServeHTTP(0xc42c27cf11, 0x9, 0x1005460, 0xc432e06620, 0xc4200b7000)
        /usr/local/go/src/net/http/pprof/pprof.go:209 +0x1d1
net/http/pprof.Index(0x1005460, 0xc432e06620, 0xc4200b7000)
        /usr/local/go/src/net/http/pprof/pprof.go:221 +0x1e3
net/http.HandlerFunc.ServeHTTP(0xc0a8c8, 0x1005460, 0xc432e06620, 0xc4200b7000)
        /usr/local/go/src/net/http/server.go:1942 +0x44
net/http.(*ServeMux).ServeHTTP(0x1046300, 0x1005460, 0xc432e06620, 0xc4200b7000)
        /usr/local/go/src/net/http/server.go:2238 +0x130
net/http.serverHandler.ServeHTTP(0xc4201c2420, 0x1005460, 0xc432e06620, 0xc4200b7000)
        /usr/local/go/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc4255ec820, 0x1005c20, 0xc4224f6740)
        /usr/local/go/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2668 +0x2ce

goroutine 1 [chan receive, 84 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket(0xc420120c00, 0x1005c20, 0xc42010d040, 0xc420202ed0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:172 +0x9d6
github.com/atlassian/gostatsd/pkg/statsd.(*Server).Run(0xc420120c00, 0x1005c20, 0xc42010d040, 0xc42010d040, 0xc420202ea0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:45 +0x80
main.run(0xc42014c0f0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:80 +0x1cc
main.main()
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:57 +0x115

goroutine 17 [syscall, 84 minutes]:
os/signal.signal_recv(0x0)
        /usr/local/go/src/runtime/sigqueue.go:116 +0x104
os/signal.loop()
        /usr/local/go/src/os/signal/signal_unix.go:22 +0x22
created by os/signal.init.1
        /usr/local/go/src/os/signal/signal_unix.go:28 +0x41

goroutine 19 [IO wait]:
net.runtime_pollWait(0x7f0229833ec8, 0x72, 0x0)
        /usr/local/go/src/runtime/netpoll.go:164 +0x59
net.(*pollDesc).wait(0xc4200fe4c8, 0x72, 0x0, 0xc4308476a0)
        /usr/local/go/src/net/fd_poll_runtime.go:75 +0x38
net.(*pollDesc).waitRead(0xc4200fe4c8, 0xffffffffffffffff, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:80 +0x34
net.(*netFD).accept(0xc4200fe460, 0x0, 0xfff220, 0xc4308476a0)
        /usr/local/go/src/net/fd_unix.go:430 +0x1e5
net.(*TCPListener).accept(0xc42000c0d0, 0xc4255ec8a0, 0xae8440, 0xffffffffffffffff)
        /usr/local/go/src/net/tcpsock_posix.go:136 +0x2e
net.(*TCPListener).AcceptTCP(0xc42000c0d0, 0xc420037e60, 0xc420037e68, 0xc420037e58)
        /usr/local/go/src/net/tcpsock.go:215 +0x49
net/http.tcpKeepAliveListener.Accept(0xc42000c0d0, 0xc0a6f0, 0xc4255ec820, 0x1005ce0, 0xc420011da0)
        /usr/local/go/src/net/http/server.go:3044 +0x2f
net/http.(*Server).Serve(0xc4201c2420, 0x1005660, 0xc42000c0d0, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:2643 +0x228
net/http.(*Server).ListenAndServe(0xc4201c2420, 0xc4201c2420, 0x1)
        /usr/local/go/src/net/http/server.go:2585 +0xb0
net/http.ListenAndServe(0x7fffdb9f8f3c, 0xe, 0x0, 0x0, 0xc42001cfc8, 0x76bf09)
        /usr/local/go/src/net/http/server.go:2787 +0x7f
main.run.func1(0x7fffdb9f8f3c, 0xe)
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:66 +0x4b
created by main.run
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:67 +0x350

goroutine 36 [select]:
github.com/atlassian/gostatsd/pkg/statsd.(*worker).work(0xc4201e3980, 0xc420203120)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher_worker.go:26 +0x1c1
created by github.com/atlassian/gostatsd/pkg/statsd.(*MetricDispatcher).Run
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher.go:57 +0x1e1

goroutine 31 [chan receive, 84 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*MetricDispatcher).Run(0xc420203000, 0x1005c20, 0xc42010d0c0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher.go:67 +0x277
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func2(0xc420203010, 0xc420203000, 0x1005c20, 0xc42010d0c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:85 +0x6d
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:88 +0x326

goroutine 30 [select, 84 minutes]:
main.cancelOnInterrupt.func1(0x1005c20, 0xc42010d040, 0xc420117680, 0xc420202ea0)
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:160 +0x111
created by main.cancelOnInterrupt
        /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:165 +0x107

goroutine 29 [select, 84 minutes, locked to thread]:
runtime.gopark(0xc0acd8, 0x0, 0xbe46b0, 0x6, 0x18, 0x2)
        /usr/local/go/src/runtime/proc.go:271 +0x13a
runtime.selectgoImpl(0xc42001df50, 0x0, 0x18)
        /usr/local/go/src/runtime/select.go:423 +0x1364
runtime.selectgo(0xc42001df50)
        /usr/local/go/src/runtime/select.go:238 +0x1c
runtime.ensureSigM.func1()
        /usr/local/go/src/runtime/signal_unix.go:434 +0x2dd
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:2197 +0x1

goroutine 32 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).handleMetric(0xc4201bde60, 0x1005c20, 0xc42010d2c0, 0xc420242180, 0xc4206569a0, 0xc420200b38)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:231 +0x344
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run(0xc4201bde60, 0x1005c20, 0xc42010d2c0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:146 +0x63a
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func3(0xc420203030, 0xc4201bde60, 0x1005c20, 0xc42010d100)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:105 +0x6d
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:108 +0x10e0

goroutine 43 [select]:
github.com/atlassian/gostatsd/pkg/statsd.(*MetricFlusher).Run(0xc4201da5a0, 0x1005c20, 0xc42010d040, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/flusher.go:65 +0x1c1
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func6(0xc420203260, 0xc4201da5a0, 0x1005c20, 0xc42010d040)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:152 +0x6d
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:155 +0x8b6

goroutine 42 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).DispatchMetric(0xc4201bde60, 0x1005c20, 0xc42010d040, 0xc420656a80, 0xc420656a80, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:78 +0x180
github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).handlePacket(0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1002b60, 0xc438770960, 0x0, 0x0, 0x0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:116 +0x33c
github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).Receive(0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1008200, 0xc420110220, 0x0, 0xc4202420c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:76 +0x37e
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func5(0xc420203230, 0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1008200, 0xc420110220)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:138 +0x8a
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:141 +0x684

goroutine 37 [select]:
github.com/atlassian/gostatsd/pkg/statsd.(*worker).work(0xc4201e39b0, 0xc420203120)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher_worker.go:26 +0x1c1
created by github.com/atlassian/gostatsd/pkg/statsd.(*MetricDispatcher).Run
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher.go:57 +0x1e1

goroutine 38 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).doLookup(0xc4201e39e0, 0x1005c20, 0xc42010d2c0, 0xc42012f000, 0x20, 0x20)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:79 +0x2a5
github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).run(0xc4201e39e0, 0x1005c20, 0xc42010d2c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:53 +0x318
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run.func1(0xc420203130, 0xc4201e39e0, 0x1005c20, 0xc42010d2c0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:128 +0x65
created by github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:129 +0x361

goroutine 41 [select, 12 minutes]:
github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).DispatchMetric(0xc4201bde60, 0x1005c20, 0xc42010d040, 0xc429f6e7e0, 0xc429f6e7e0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:78 +0x180
github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).handlePacket(0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1002b60, 0xc42de4fa10, 0x0, 0x0, 0x0, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:116 +0x33c
github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).Receive(0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1008200, 0xc420110220, 0x68d942, 0x180001)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:76 +0x37e
github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func5(0xc420203230, 0xc42010fa90, 0x1005c20, 0xc42010d040, 0x1008200, 0xc420110220)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:138 +0x8a
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:141 +0x684

goroutine 44 [IO wait, 84 minutes]:
net.runtime_pollWait(0x7f0229833d48, 0x72, 0x0)
        /usr/local/go/src/runtime/netpoll.go:164 +0x59
net.(*pollDesc).wait(0xc4201b7b18, 0x72, 0x0, 0xc420205120)
        /usr/local/go/src/net/fd_poll_runtime.go:75 +0x38
net.(*pollDesc).waitRead(0xc4201b7b18, 0xffffffffffffffff, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:80 +0x34
net.(*netFD).accept(0xc4201b7ab0, 0x0, 0xfff220, 0xc420205120)
        /usr/local/go/src/net/fd_unix.go:430 +0x1e5
net.(*TCPListener).accept(0xc420110238, 0xc4201f1938, 0xc4201f18b8, 0xc4201f1865)
        /usr/local/go/src/net/tcpsock_posix.go:136 +0x2e
net.(*TCPListener).Accept(0xc420110238, 0xc4201e3c20, 0xc4201fcf38, 0xc4201f1910, 0xc4201e3c20)
        /usr/local/go/src/net/tcpsock.go:228 +0x49
github.com/atlassian/gostatsd/pkg/statsd.(*ConsoleServer).Serve(0xc42010d6c0, 0x1005c20, 0xc42010d040, 0x1005260, 0xc420110238, 0xc420110238, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/console.go:102 +0x852
github.com/atlassian/gostatsd/pkg/statsd.(*ConsoleServer).ListenAndServe(0xc42010d6c0, 0x1005c20, 0xc42010d040, 0x0, 0x0)
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/console.go:42 +0xf9
created by github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket
        /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:160 +0xb4d

goroutine 300503 [IO wait]:
net.runtime_pollWait(0x7f02293e65e8, 0x72, 0xc)
        /usr/local/go/src/runtime/netpoll.go:164 +0x59
net.(*pollDesc).wait(0xc422c16bc8, 0x72, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_poll_runtime.go:75 +0x38
net.(*pollDesc).waitRead(0xc422c16bc8, 0xc425bb5c00, 0x400)
        /usr/local/go/src/net/fd_poll_runtime.go:80 +0x34
net.(*netFD).Read(0xc422c16b60, 0xc425bb5c00, 0x400, 0x400, 0x0, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_unix.go:250 +0x1b7
net.(*conn).Read(0xc4201101f0, 0xc425bb5c00, 0x400, 0x400, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:181 +0x70
crypto/tls.(*block).readFromUntil(0xc430b77800, 0x7f0229873128, 0xc4201101f0, 0x5, 0xc4201101f0, 0x28)
        /usr/local/go/src/crypto/tls/conn.go:488 +0x98
crypto/tls.(*Conn).readRecord(0xc431dcae00, 0xc0ad17, 0xc431dcaf20, 0x455550)
        /usr/local/go/src/crypto/tls/conn.go:590 +0xc4
crypto/tls.(*Conn).Read(0xc431dcae00, 0xc429a88000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1134 +0x11d
net/http.(*persistConn).Read(0xc42ed89320, 0xc429a88000, 0x1000, 0x1000, 0x5, 0x453650, 0xc4224004e0)
        /usr/local/go/src/net/http/transport.go:1316 +0x14b
bufio.(*Reader).fill(0xc420755200)
        /usr/local/go/src/bufio/bufio.go:97 +0x117
bufio.(*Reader).Peek(0xc420755200, 0x1, 0xc422e9fbe5, 0x1, 0x0, 0xc424d2f860, 0x0)
        /usr/local/go/src/bufio/bufio.go:129 +0x67
net/http.(*persistConn).readLoop(0xc42ed89320)
        /usr/local/go/src/net/http/transport.go:1474 +0x196
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1117 +0xa35

goroutine 300523 [select]:
net/http.(*persistConn).writeLoop(0xc4202085a0)
        /usr/local/go/src/net/http/transport.go:1704 +0x43a
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1118 +0xa5a

goroutine 300522 [IO wait]:
net.runtime_pollWait(0x7f022965b5b0, 0x72, 0x11)
        /usr/local/go/src/runtime/netpoll.go:164 +0x59
net.(*pollDesc).wait(0xc422c16e68, 0x72, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_poll_runtime.go:75 +0x38
net.(*pollDesc).waitRead(0xc422c16e68, 0xc425875000, 0x400)
        /usr/local/go/src/net/fd_poll_runtime.go:80 +0x34
net.(*netFD).Read(0xc422c16e00, 0xc425875000, 0x400, 0x400, 0x0, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_unix.go:250 +0x1b7
net.(*conn).Read(0xc42000c7f0, 0xc425875000, 0x400, 0x400, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:181 +0x70
crypto/tls.(*block).readFromUntil(0xc42e3adad0, 0x7f0229873128, 0xc42000c7f0, 0x5, 0xc42000c7f0, 0x28)
        /usr/local/go/src/crypto/tls/conn.go:488 +0x98
crypto/tls.(*Conn).readRecord(0xc4285ec700, 0xc0ad17, 0xc4285ec820, 0x455550)
        /usr/local/go/src/crypto/tls/conn.go:590 +0xc4
crypto/tls.(*Conn).Read(0xc4285ec700, 0xc4245d1000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1134 +0x11d
net/http.(*persistConn).Read(0xc4202085a0, 0xc4245d1000, 0x1000, 0x1000, 0x5, 0x453650, 0xc420755140)
        /usr/local/go/src/net/http/transport.go:1316 +0x14b
bufio.(*Reader).fill(0xc422400480)
        /usr/local/go/src/bufio/bufio.go:97 +0x117
bufio.(*Reader).Peek(0xc422400480, 0x1, 0xc428fe6be5, 0x1, 0x0, 0xc424d2f980, 0x0)
        /usr/local/go/src/bufio/bufio.go:129 +0x67
net/http.(*persistConn).readLoop(0xc4202085a0)
        /usr/local/go/src/net/http/transport.go:1474 +0x196
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1117 +0xa35

goroutine 300504 [select]:
net/http.(*persistConn).writeLoop(0xc42ed89320)
        /usr/local/go/src/net/http/transport.go:1704 +0x43a
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1118 +0xa5a

goroutine 303287 [IO wait]:
net.runtime_pollWait(0x7f0229280b38, 0x72, 0x6)
        /usr/local/go/src/runtime/netpoll.go:164 +0x59
net.(*pollDesc).wait(0xc42e50cd18, 0x72, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_poll_runtime.go:75 +0x38
net.(*pollDesc).waitRead(0xc42e50cd18, 0xc4224f67d1, 0x1)
        /usr/local/go/src/net/fd_poll_runtime.go:80 +0x34
net.(*netFD).Read(0xc42e50ccb0, 0xc4224f67d1, 0x1, 0x1, 0x0, 0x1000ea0, 0xffc448)
        /usr/local/go/src/net/fd_unix.go:250 +0x1b7
net.(*conn).Read(0xc42000c1f8, 0xc4224f67d1, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:181 +0x70
net/http.(*connReader).backgroundRead(0xc4224f67c0)
        /usr/local/go/src/net/http/server.go:656 +0x58
created by net/http.(*connReader).startBackgroundRead
        /usr/local/go/src/net/http/server.go:652 +0xdf
```
```
goroutine profile: total 20
2 @ 0x42c74a 0x427867 0x426ea9 0x5773c8 0x577434 0x578b87 0x58bf30 0x5ce968 0x5ceed4 0x5d2bdd 0x68b36b 0x52b0e7 0x52b2a7 0x68c016 0x4595a1
#       0x426ea8        net.runtime_pollWait+0x58               /usr/local/go/src/runtime/netpoll.go:164
#       0x5773c7        net.(*pollDesc).wait+0x37               /usr/local/go/src/net/fd_poll_runtime.go:75
#       0x577433        net.(*pollDesc).waitRead+0x33           /usr/local/go/src/net/fd_poll_runtime.go:80
#       0x578b86        net.(*netFD).Read+0x1b6                 /usr/local/go/src/net/fd_unix.go:250
#       0x58bf2f        net.(*conn).Read+0x6f                   /usr/local/go/src/net/net.go:181
#       0x5ce967        crypto/tls.(*block).readFromUntil+0x97  /usr/local/go/src/crypto/tls/conn.go:488
#       0x5ceed3        crypto/tls.(*Conn).readRecord+0xc3      /usr/local/go/src/crypto/tls/conn.go:590
#       0x5d2bdc        crypto/tls.(*Conn).Read+0x11c           /usr/local/go/src/crypto/tls/conn.go:1134
#       0x68b36a        net/http.(*persistConn).Read+0x14a      /usr/local/go/src/net/http/transport.go:1316
#       0x52b0e6        bufio.(*Reader).fill+0x116              /usr/local/go/src/bufio/bufio.go:97
#       0x52b2a6        bufio.(*Reader).Peek+0x66               /usr/local/go/src/bufio/bufio.go:129
#       0x68c015        net/http.(*persistConn).readLoop+0x195  /usr/local/go/src/net/http/transport.go:1474

2 @ 0x42c74a 0x43b974 0x43a5dc 0x68dc6a 0x4595a1
#       0x68dc69        net/http.(*persistConn).writeLoop+0x439 /usr/local/go/src/net/http/transport.go:1704

2 @ 0x42c74a 0x43b974 0x43a5dc 0xa03a60 0xa0dbac 0xa0d70e 0xa1460a 0x4595a1
#       0xa03a5f        github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).DispatchMetric+0x17f           /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:78
#       0xa0dbab        github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).handlePacket+0x33b           /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:116
#       0xa0d70d        github.com/atlassian/gostatsd/pkg/statsd.(*MetricReceiver).Receive+0x37d                /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/receiver.go:76
#       0xa14609        github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func5+0x89       /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:138

2 @ 0x42c74a 0x43b974 0x43a5dc 0xa093e1 0x4595a1
#       0xa093e0        github.com/atlassian/gostatsd/pkg/statsd.(*worker).work+0x1c0   /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher_worker.go:26

1 @ 0x40e442 0x4405d4 0x726f62 0x4595a1
#       0x4405d3        os/signal.signal_recv+0x103     /usr/local/go/src/runtime/sigqueue.go:116
#       0x726f61        os/signal.loop+0x21             /usr/local/go/src/os/signal/signal_unix.go:22

1 @ 0x42c74a 0x427867 0x426ea9 0x5773c8 0x577434 0x57a3a5 0x59681e 0x594a89 0x67ce2f 0x67bb78 0x67b860 0x67c56f 0xa17e9b 0x4595a1
#       0x426ea8        net.runtime_pollWait+0x58                       /usr/local/go/src/runtime/netpoll.go:164
#       0x5773c7        net.(*pollDesc).wait+0x37                       /usr/local/go/src/net/fd_poll_runtime.go:75
#       0x577433        net.(*pollDesc).waitRead+0x33                   /usr/local/go/src/net/fd_poll_runtime.go:80
#       0x57a3a4        net.(*netFD).accept+0x1e4                       /usr/local/go/src/net/fd_unix.go:430
#       0x59681d        net.(*TCPListener).accept+0x2d                  /usr/local/go/src/net/tcpsock_posix.go:136
#       0x594a88        net.(*TCPListener).AcceptTCP+0x48               /usr/local/go/src/net/tcpsock.go:215
#       0x67ce2e        net/http.tcpKeepAliveListener.Accept+0x2e       /usr/local/go/src/net/http/server.go:3044
#       0x67bb77        net/http.(*Server).Serve+0x227                  /usr/local/go/src/net/http/server.go:2643
#       0x67b85f        net/http.(*Server).ListenAndServe+0xaf          /usr/local/go/src/net/http/server.go:2585
#       0x67c56e        net/http.ListenAndServe+0x7e                    /usr/local/go/src/net/http/server.go:2787
#       0xa17e9a        main.run.func1+0x4a                             /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:66

1 @ 0x42c74a 0x427867 0x426ea9 0x5773c8 0x577434 0x57a3a5 0x59681e 0x594ce9 0xa07aa2 0xa071d9 0x4595a1
#       0x426ea8        net.runtime_pollWait+0x58                                                       /usr/local/go/src/runtime/netpoll.go:164
#       0x5773c7        net.(*pollDesc).wait+0x37                                                       /usr/local/go/src/net/fd_poll_runtime.go:75
#       0x577433        net.(*pollDesc).waitRead+0x33                                                   /usr/local/go/src/net/fd_poll_runtime.go:80
#       0x57a3a4        net.(*netFD).accept+0x1e4                                                       /usr/local/go/src/net/fd_unix.go:430
#       0x59681d        net.(*TCPListener).accept+0x2d                                                  /usr/local/go/src/net/tcpsock_posix.go:136
#       0x594ce8        net.(*TCPListener).Accept+0x48                                                  /usr/local/go/src/net/tcpsock.go:228
#       0xa07aa1        github.com/atlassian/gostatsd/pkg/statsd.(*ConsoleServer).Serve+0x851           /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/console.go:102
#       0xa071d8        github.com/atlassian/gostatsd/pkg/statsd.(*ConsoleServer).ListenAndServe+0xf8   /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/console.go:42

1 @ 0x42c74a 0x42c82e 0x404e31 0x404a65 0xa08c47 0xa1419d 0x4595a1
#       0xa08c46        github.com/atlassian/gostatsd/pkg/statsd.(*MetricDispatcher).Run+0x276                  /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/dispatcher.go:67
#       0xa1419c        github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func2+0x6c       /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:85

1 @ 0x42c74a 0x42c82e 0x404e31 0x404a65 0xa0edc6 0xa0e3a0 0xa163fc 0xa16045 0x42c2fa 0x4595a1
#       0xa0edc5        github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket+0x9d5    /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:172
#       0xa0e39f        github.com/atlassian/gostatsd/pkg/statsd.(*Server).Run+0x7f                     /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:45
#       0xa163fb        main.run+0x1cb                                                                  /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:80
#       0xa16044        main.main+0x114                                                                 /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:57
#       0x42c2f9        runtime.main+0x209                                                              /usr/local/go/src/runtime/proc.go:185

1 @ 0x42c74a 0x43b974 0x43a5dc 0x4561fd 0x4595a1
#       0x42c749        runtime.gopark+0x139            /usr/local/go/src/runtime/proc.go:271
#       0x43b973        runtime.selectgoImpl+0x1363     /usr/local/go/src/runtime/select.go:423
#       0x43a5db        runtime.selectgo+0x1b           /usr/local/go/src/runtime/select.go:238
#       0x4561fc        runtime.ensureSigM.func1+0x2dc  /usr/local/go/src/runtime/signal_unix.go:434

1 @ 0x42c74a 0x43b974 0x43a5dc 0xa053b4 0xa0442a 0xa1436d 0x4595a1
#       0xa053b3        github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).handleMetric+0x343             /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:231
#       0xa04429        github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run+0x639                      /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:146
#       0xa1436c        github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func3+0x6c       /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:105

1 @ 0x42c74a 0x43b974 0x43a5dc 0xa06fc5 0xa06ae8 0xa11be5 0x4595a1
#       0xa06fc4        github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).doLookup+0x2a4     /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:79
#       0xa06ae7        github.com/atlassian/gostatsd/pkg/statsd.(*lookupDispatcher).run+0x317          /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler_lookup.go:53
#       0xa11be4        github.com/atlassian/gostatsd/pkg/statsd.(*CloudHandler).Run.func1+0x64         /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/cloud_handler.go:128

1 @ 0x42c74a 0x43b974 0x43a5dc 0xa09f61 0xa147dd 0x4595a1
#       0xa09f60        github.com/atlassian/gostatsd/pkg/statsd.(*MetricFlusher).Run+0x1c0                     /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/flusher.go:65
#       0xa147dc        github.com/atlassian/gostatsd/pkg/statsd.(*Server).RunWithCustomSocket.func6+0x6c       /gopath/src/github.com/atlassian/gostatsd/pkg/statsd/statsd.go:152

1 @ 0x42c74a 0x43b974 0x43a5dc 0xa18031 0x4595a1
#       0xa18030        main.cancelOnInterrupt.func1+0x110      /gopath/src/github.com/atlassian/gostatsd/cmd/gostatsd/main.go:160

1 @ 0x479205 0x476b55 0x474df9 0x578b0b 0x58bf30 0x671c38 0x4595a1
#       0x479204        syscall.Syscall+0x4                             /usr/local/go/src/syscall/asm_linux_amd64.s:18
#       0x476b54        syscall.read+0x54                               /usr/local/go/src/syscall/zsyscall_linux_amd64.go:783
#       0x474df8        syscall.Read+0x48                               /usr/local/go/src/syscall/syscall_unix.go:162
#       0x578b0a        net.(*netFD).Read+0x13a                         /usr/local/go/src/net/fd_unix.go:246
#       0x58bf2f        net.(*conn).Read+0x6f                           /usr/local/go/src/net/net.go:181
#       0x671c37        net/http.(*connReader).backgroundRead+0x57      /usr/local/go/src/net/http/server.go:656

1 @ 0x722cc2 0x722ac0 0x71f135 0x7264c1 0x7267d3 0x678f14 0x67a350 0x67b712 0x677a82 0x4595a1
#       0x722cc1        runtime/pprof.writeRuntimeProfile+0xa1  /usr/local/go/src/runtime/pprof/pprof.go:632
#       0x722abf        runtime/pprof.writeGoroutine+0x9f       /usr/local/go/src/runtime/pprof/pprof.go:594
#       0x71f134        runtime/pprof.(*Profile).WriteTo+0x3b4  /usr/local/go/src/runtime/pprof/pprof.go:302
#       0x7264c0        net/http/pprof.handler.ServeHTTP+0x1d0  /usr/local/go/src/net/http/pprof/pprof.go:209
#       0x7267d2        net/http/pprof.Index+0x1e2              /usr/local/go/src/net/http/pprof/pprof.go:221
#       0x678f13        net/http.HandlerFunc.ServeHTTP+0x43     /usr/local/go/src/net/http/server.go:1942
#       0x67a34f        net/http.(*ServeMux).ServeHTTP+0x12f    /usr/local/go/src/net/http/server.go:2238
#       0x67b711        net/http.serverHandler.ServeHTTP+0x91   /usr/local/go/src/net/http/server.go:2568
#       0x677a81        net/http.(*conn).serve+0x611            /usr/local/go/src/net/http/server.go:1825
```