### PR TITLE
#77: Add flag to ignore source ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.1.x
+-----
+- New flag `--ignore-host` prevents capturing of source IP address.  Hostname can be provided
+  by client via a `host:` tag.
+
 2.1.0
 -----
 - Handle EC2 `InvalidInstanceID.NotFound` error gracefully

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -112,6 +112,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		DefaultTags:         toSlice(v.GetString(statsd.ParamDefaultTags)),
 		ExpiryInterval:      v.GetDuration(statsd.ParamExpiryInterval),
 		FlushInterval:       v.GetDuration(statsd.ParamFlushInterval),
+		IgnoreHost:          v.GetBool(statsd.ParamIgnoreHost),
 		MaxReaders:          v.GetInt(statsd.ParamMaxReaders),
 		MaxWorkers:          v.GetInt(statsd.ParamMaxWorkers),
 		MaxQueueSize:        v.GetInt(statsd.ParamMaxQueueSize),

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -30,7 +30,7 @@ func TestReceiveEmptyPacket(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", ch)
+			mr := NewMetricReceiver("", false, ch)
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, inp)
 			require.NoError(t, err)
@@ -51,6 +51,16 @@ func TestReceivePacket(t *testing.T) {
 		"f:2|c\n": {
 			metrics: []gostatsd.Metric{
 				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+			},
+		},
+		"f:2|c|#t": {
+			metrics: []gostatsd.Metric{
+				{Name:"f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+			},
+		},
+		"f:2|c|#host:h": {
+			metrics: []gostatsd.Metric{
+				{Name:"f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
@@ -80,7 +90,78 @@ func TestReceivePacket(t *testing.T) {
 		t.Run(packet, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", ch)
+			mr := NewMetricReceiver("", false, ch)
+
+			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
+			assert.NoError(t, err)
+			for i, e := range ch.events {
+				if e.DateHappened <= 0 {
+					t.Errorf("%q: DateHappened should be positive", e)
+				}
+				ch.events[i].DateHappened = 0
+			}
+			assert.Equal(t, mAndE.events, ch.events)
+			assert.Equal(t, mAndE.metrics, ch.metrics)
+		})
+	}
+}
+
+func TestReceivePacketIgnoreHost(t *testing.T) {
+	t.Parallel()
+	input := map[string]metricAndEvent{
+		"f:2|c": {
+			metrics: []gostatsd.Metric{
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+			},
+		},
+		"f:2|c\n": {
+			metrics: []gostatsd.Metric{
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+			},
+		},
+		"f:2|c|#t": {
+			metrics: []gostatsd.Metric{
+				{Name:"f", Value: 2, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+			},
+		},
+		"f:2|c|#host:h": {
+			metrics: []gostatsd.Metric{
+				{Name:"f", Value: 2, Hostname: "h", Type: gostatsd.COUNTER},
+			},
+		},
+		"f:2|c|#host:h1,host:h2": {
+			metrics: []gostatsd.Metric{
+				{Name:"f", Value: 2, Hostname: "h1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h2"}},
+			},
+		},
+		"f:2|c\nx:3|c": {
+			metrics: []gostatsd.Metric{
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+				{Name: "x", Value: 3, Type: gostatsd.COUNTER},
+			},
+		},
+		"f:2|c\nx:3|c\n": {
+			metrics: []gostatsd.Metric{
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+				{Name: "x", Value: 3, Type: gostatsd.COUNTER},
+			},
+		},
+		"_e{1,1}:a|b\nf:6|c": {
+			metrics: []gostatsd.Metric{
+				{Name: "f", Value: 6, Type: gostatsd.COUNTER},
+			},
+			events: gostatsd.Events{
+				gostatsd.Event{Title: "a", Text: "b", SourceIP: "127.0.0.1"},
+			},
+		},
+	}
+	for packet, mAndE := range input {
+		packet := packet
+		mAndE := mAndE
+		t.Run(packet, func(t *testing.T) {
+			t.Parallel()
+			ch := &countingHandler{}
+			mr := NewMetricReceiver("", true, ch)
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 			assert.NoError(t, err)

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -24,6 +24,7 @@ type Server struct {
 	DefaultTags         gostatsd.Tags
 	ExpiryInterval      time.Duration
 	FlushInterval       time.Duration
+	IgnoreHost          bool
 	MaxReaders          int
 	MaxWorkers          int
 	MaxQueueSize        int
@@ -113,7 +114,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 		}
 	}()
 
-	receiver := NewMetricReceiver(s.Namespace, handler)
+	receiver := NewMetricReceiver(s.Namespace, s.IgnoreHost, handler)
 	wgReceiver.Add(s.MaxReaders)
 	for r := 0; r < s.MaxReaders; r++ {
 		go receiver.Receive(ctx, wgReceiver.Done, c)

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -36,6 +36,8 @@ const (
 	DefaultExpiryInterval = 5 * time.Minute
 	// DefaultFlushInterval is the default metrics flush interval.
 	DefaultFlushInterval = 1 * time.Second
+	// DefaultIgnoreHost is the default value for whether the source should be used as the host
+	DefaultIgnoreHost = false
 	// DefaultMetricsAddr is the default address on which to listen for metrics.
 	DefaultMetricsAddr = ":8125"
 	// DefaultMaxQueueSize is the default maximum number of buffered metrics per worker.
@@ -67,6 +69,8 @@ const (
 	ParamExpiryInterval = "expiry-interval"
 	// ParamFlushInterval is the name of parameter with metrics flush interval.
 	ParamFlushInterval = "flush-interval"
+	// ParamIgnoreHost is the name of parameter indicating if the source should be used as the host
+	ParamIgnoreHost = "ignore-host"
 	// ParamMaxReaders is the name of parameter with number of socket readers.
 	ParamMaxReaders = "max-readers"
 	// ParamMaxWorkers is the name of parameter with number of goroutines that aggregate metrics.
@@ -98,6 +102,7 @@ func NewServer() *Server {
 		DefaultTags:         DefaultTags,
 		ExpiryInterval:      DefaultExpiryInterval,
 		FlushInterval:       DefaultFlushInterval,
+		IgnoreHost:          DefaultIgnoreHost,
 		MaxReaders:          DefaultMaxReaders,
 		MaxWorkers:          DefaultMaxWorkers,
 		MaxQueueSize:        DefaultMaxQueueSize,
@@ -119,6 +124,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.String(ParamCloudProvider, "", "If set, use the cloud provider to retrieve metadata about the sender")
 	fs.Duration(ParamExpiryInterval, DefaultExpiryInterval, "After how long do we expire metrics (0 to disable)")
 	fs.Duration(ParamFlushInterval, DefaultFlushInterval, "How often to flush metrics to the backends")
+	fs.Bool(ParamIgnoreHost, DefaultIgnoreHost, "Ignore the source for populating the hostname field of metrics")
 	fs.Int(ParamMaxReaders, DefaultMaxReaders, "Maximum number of socket readers")
 	fs.Int(ParamMaxWorkers, DefaultMaxWorkers, "Maximum number of workers to process metrics")
 	fs.Int(ParamMaxQueueSize, DefaultMaxQueueSize, "Maximum number of buffered metrics per worker")


### PR DESCRIPTION
If the ```--ignore-host``` flag is passed, it will not record or send a host.  If 1 or more host tags are sent by the client, the **first** one will be consumed as the hostname, and the following will be treated as normal tags.

All of this behavior changes if a cloud provider is enabled, as that will set the Hostname and stomp all over the tags.  Cloud providers take control away from the client, and are probably not a great idea anyway.