### PR TITLE
Refactor internal metrics to use a Statser

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1,0 +1,32 @@
+This documents the metrics and tags emitted by gostatsd, their type, tags, and interpretation.
+
+| Name                          | type    | tags          | description
+| ----------------------------- | ------- | ------------- | -----------
+| metrics_received              | gauge   | aggregator_id | The number of datapoints received during the flush interval
+| processing_time               | gauge   | aggregator_id | The time taken (in ms) to aggregate all datapoints in this flush interval
+| bad_lines_seen                | counter |               | The number of unprocessable lines that have been seen
+| events_received               | counter |               | The number of events received
+| metrics_received              | counter |               | The number of metrics received
+| packets_received              | counter |               | The number of packets received
+| channel.capacity              | gauge   | channel       | The capacity of the channel
+| channel.queued                | gauge   | channel       | The absolute amount of items in a channel
+| channel.pct_used              | gauge   | channel       | The percentage of how full a channel is
+
+
+| Tag           | Description
+| ------------- | -----------
+| aggregator_id | The index of an aggregator, the amount corresponds to the --max-workers flag
+| channel       | The name of an internal channel
+
+
+A number of channels are tracked internally, they emit metrics under the channels.* space.  They will all have a
+channel tag, and may have additional tags specified below.
+
+| Channel name        | Additional tags | Description
+| ------------------- | --------------- | -----------
+| dispatch_aggregator | aggregator_id   | Channel to dispatch metrics to a specific aggregator.
+
+
+- The metric numStats is no longer tracked
+- If both --internal-namespace and --namespace are specified, and metrics are dispatched internally, the resulting
+  metric will be namespace.internal_namespace.metric.

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,16 +1,20 @@
 This documents the metrics and tags emitted by gostatsd, their type, tags, and interpretation.
 
-| Name                          | type    | tags          | description
-| ----------------------------- | ------- | ------------- | -----------
-| metrics_received              | gauge   | aggregator_id | The number of datapoints received during the flush interval
-| processing_time               | gauge   | aggregator_id | The time taken (in ms) to aggregate all datapoints in this flush interval
-| bad_lines_seen                | counter |               | The number of unprocessable lines that have been seen
-| events_received               | counter |               | The number of events received
-| metrics_received              | counter |               | The number of metrics received
-| packets_received              | counter |               | The number of packets received
-| channel.capacity              | gauge   | channel       | The capacity of the channel
-| channel.queued                | gauge   | channel       | The absolute amount of items in a channel
-| channel.pct_used              | gauge   | channel       | The percentage of how full a channel is
+| Name              | type    | tags          | description
+| ----------------- | ------- | ------------- | -----------
+| metrics_received  | gauge   | aggregator_id | The number of datapoints received during the flush interval
+| processing_time   | gauge   | aggregator_id | The time taken (in ms) to aggregate all datapoints in this
+|                   |         |               | flush interval
+| bad_lines_seen    | counter |               | The number of unprocessable lines that have been seen
+| events_received   | counter |               | The number of events received
+| metrics_received  | counter |               | The number of metrics received
+| packets_received  | counter |               | The number of packets received
+| channel.capacity  | gauge   | channel       | The capacity of the channel
+| channel.queued    | gauge   | channel       | The absolute amount of items in a channel
+| channel.pct_used  | gauge   | channel       | The percentage of how full a channel is
+| internal_dropped  | gauge   |               | The number of internal metrics which have been dropped in the
+|                   |         |               | lifetime of the process.  Not a counter, because it may not be
+|                   |         |               | submitted.
 
 
 | Tag           | Description

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_HASH := $$(git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS := -ldflags "-s -X $(VERSION_VAR)=$(REPO_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
 BINARY_NAME := gostatsd
 IMAGE_NAME := atlassianlabs/$(BINARY_NAME)
-ARCH ?= darwin
+ARCH ?= $$(uname -s | tr A-Z a-z)
 METALINTER_CONCURRENCY ?= 4
 GOVERSION := 1.8
 GP := /gopath
@@ -132,7 +132,7 @@ release-race: docker-race
 release: release-normal release-race
 
 run: build
-	./build/bin/$(ARCH)/$(BINARY_NAME) --backends=stdout --verbose --flush-interval=1s
+	./build/bin/$(ARCH)/$(BINARY_NAME) --backends=stdout --verbose --flush-interval=2s
 
 run-docker: docker
 	cd build/ && docker-compose rm -f gostatsd

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_HASH := $$(git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS := -ldflags "-s -X $(VERSION_VAR)=$(REPO_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
 BINARY_NAME := gostatsd
 IMAGE_NAME := atlassianlabs/$(BINARY_NAME)
-ARCH ?= $$(uname -s | tr A-Z a-z)
+ARCH ?= darwin
 METALINTER_CONCURRENCY ?= 4
 GOVERSION := 1.8
 GP := /gopath
@@ -132,7 +132,7 @@ release-race: docker-race
 release: release-normal release-race
 
 run: build
-	./build/bin/$(ARCH)/$(BINARY_NAME) --backends=stdout --verbose --flush-interval=2s
+	./build/bin/$(ARCH)/$(BINARY_NAME) --backends=stdout --verbose --flush-interval=1s
 
 run-docker: docker
 	cd build/ && docker-compose rm -f gostatsd

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -109,6 +109,8 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		Backends:            backendsList,
 		CloudProvider:       cloud,
 		Limiter:             rate.NewLimiter(rate.Limit(v.GetInt(statsd.ParamMaxCloudRequests)), v.GetInt(statsd.ParamBurstCloudRequests)),
+		InternalTags:        toSlice(v.GetString(statsd.ParamInternalTags)),
+		InternalNamespace:   v.GetString(statsd.ParamInternalNamespace),
 		DefaultTags:         toSlice(v.GetString(statsd.ParamDefaultTags)),
 		ExpiryInterval:      v.GetDuration(statsd.ParamExpiryInterval),
 		FlushInterval:       v.GetDuration(statsd.ParamFlushInterval),

--- a/cover.sh
+++ b/cover.sh
@@ -17,7 +17,8 @@ declare -a packages=('' \
     'pkg/backends/datadog' 'pkg/backends/graphite' 'pkg/backends/null' \
     'pkg/backends/statsdaemon' 'pkg/backends/stdout' \
     'pkg/cloudproviders' 'pkg/cloudproviders//aws' \
-    'pkg/fakesocket' 'pkg/statsd');
+    'pkg/fakesocket' 'pkg/statsd' \
+    'pkg/statser' );
 
 # Test each package and append coverage profile info to coverage.out
 for pkg in "${packages[@]}"

--- a/metrics.go
+++ b/metrics.go
@@ -58,16 +58,9 @@ type AggregatedMetrics interface {
 	HasChildren(string) bool
 }
 
-// MetricStats holds stats of an Aggregator.
-type MetricStats struct {
-	ProcessingTime time.Duration
-	NumStats       uint32
-}
-
 // MetricMap is used for storing aggregated Metric values.
 // The keys of each map are metric names.
 type MetricMap struct {
-	MetricStats
 	FlushInterval time.Duration
 	Counters      Counters
 	Timers        Timers

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -61,10 +61,6 @@ type event struct {
 
 // SendMetricsAsync flushes the metrics to Datadog, preparing payload synchronously but doing the send asynchronously.
 func (d *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	if metrics.NumStats == 0 {
-		cb(nil)
-		return
-	}
 	counter := 0
 	results := make(chan error)
 	d.processMetrics(metrics, func(ts *timeSeries) {

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -124,9 +124,6 @@ func TestSendMetrics(t *testing.T) {
 // twoCounters returns two counters.
 func twoCounters() *gostatsd.MetricMap {
 	return &gostatsd.MetricMap{
-		MetricStats: gostatsd.MetricStats{
-			NumStats: 2,
-		},
 		Counters: gostatsd.Counters{
 			"stat1": map[string]gostatsd.Counter{
 				"tag1": gostatsd.NewCounter(gostatsd.Nanotime(time.Now().UnixNano()), 5, "", nil),
@@ -140,10 +137,6 @@ func twoCounters() *gostatsd.MetricMap {
 
 func metricsOneOfEach() *gostatsd.MetricMap {
 	return &gostatsd.MetricMap{
-		MetricStats: gostatsd.MetricStats{
-			NumStats:       4,
-			ProcessingTime: 10 * time.Millisecond,
-		},
 		FlushInterval: 1100 * time.Millisecond,
 		Counters: gostatsd.Counters{
 			"c1": map[string]gostatsd.Counter{

--- a/pkg/backends/graphite/graphite.go
+++ b/pkg/backends/graphite/graphite.go
@@ -84,10 +84,6 @@ func (client *Client) Run(ctx context.Context, done gostatsd.Done) {
 
 // SendMetricsAsync flushes the metrics to the Graphite server, preparing payload synchronously but doing the send asynchronously.
 func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	if metrics.NumStats == 0 {
-		cb(nil)
-		return
-	}
 	buf := client.preparePayload(metrics, time.Now())
 	sink := make(chan *bytes.Buffer, 1)
 	sink <- buf

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -156,9 +156,6 @@ func metrics() *gostatsd.MetricMap {
 	timestamp := gostatsd.Nanotime(time.Unix(123456, 0).UnixNano())
 
 	return &gostatsd.MetricMap{
-		MetricStats: gostatsd.MetricStats{
-			NumStats: 10,
-		},
 		Counters: gostatsd.Counters{
 			"stat1": map[string]gostatsd.Counter{
 				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: timestamp},

--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -53,11 +53,6 @@ func (client *Client) Run(ctx context.Context, done gostatsd.Done) {
 
 // SendMetricsAsync flushes the metrics to the statsd server, preparing payload synchronously but doing the send asynchronously.
 func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	if metrics.NumStats == 0 {
-		cb(nil)
-		return
-	}
-
 	sink := make(chan *bytes.Buffer, sendChannelSize)
 	select {
 	case <-ctx.Done():

--- a/pkg/backends/statsdaemon/statsdaemon_test.go
+++ b/pkg/backends/statsdaemon/statsdaemon_test.go
@@ -16,9 +16,6 @@ import (
 
 var longName = strings.Repeat("t", maxUDPPacketSize-5)
 var m = gostatsd.MetricMap{
-	MetricStats: gostatsd.MetricStats{
-		NumStats: 1,
-	},
 	Counters: gostatsd.Counters{
 		longName: map[string]gostatsd.Counter{
 			"tag1": gostatsd.NewCounter(gostatsd.Nanotime(time.Now().UnixNano()), 5, "", nil),
@@ -54,9 +51,6 @@ func TestProcessMetricsPanic(t *testing.T) {
 }
 
 var gaugeMetic = gostatsd.MetricMap{
-	MetricStats: gostatsd.MetricStats{
-		NumStats: 1,
-	},
 	Gauges: gostatsd.Gauges{
 		"statsd.processing_time": map[string]gostatsd.Gauge{
 			"tag1": gostatsd.NewGauge(gostatsd.Nanotime(time.Now().UnixNano()), 2, "", nil),

--- a/pkg/statsd/dispatcher.go
+++ b/pkg/statsd/dispatcher.go
@@ -51,8 +51,8 @@ func NewMetricDispatcher(numWorkers int, perWorkerBufferSize int, af AggregatorF
 	}
 }
 
-// Run runs the MetricDispatcher.
-func (d *MetricDispatcher) Run(ctx context.Context, done gostatsd.Done) {
+// RunAsync runs the MetricDispatcher in a goroutine.
+func (d *MetricDispatcher) RunAsync(ctx context.Context, done gostatsd.Done) {
 	d.runContext = ctx
 
 	go func() {

--- a/pkg/statsd/dispatcher.go
+++ b/pkg/statsd/dispatcher.go
@@ -27,18 +27,19 @@ func (f AggregatorFactoryFunc) Create() Aggregator {
 // MetricDispatcher dispatches incoming metrics to corresponding aggregators.
 type MetricDispatcher struct {
 	numWorkers int
-	workers    map[uint16]worker
-	runContext context.Context
+	workers    map[uint16]*worker
+	lock       sync.RWMutex
+	running    bool
 }
 
 // NewMetricDispatcher creates a new NewMetricDispatcher with provided configuration.
 func NewMetricDispatcher(numWorkers int, perWorkerBufferSize int, af AggregatorFactory) *MetricDispatcher {
-	workers := make(map[uint16]worker, numWorkers)
+	workers := make(map[uint16]*worker, numWorkers)
 
 	n := uint16(numWorkers)
 
 	for i := uint16(0); i < n; i++ {
-		workers[i] = worker{
+		workers[i] = &worker{
 			aggr:         af.Create(),
 			metricsQueue: make(chan *gostatsd.Metric, perWorkerBufferSize),
 			processChan:  make(chan *processCommand),
@@ -51,19 +52,28 @@ func NewMetricDispatcher(numWorkers int, perWorkerBufferSize int, af AggregatorF
 	}
 }
 
-// RunAsync runs the MetricDispatcher in a goroutine.
+// RunAsync runs the MetricDispatcher in a goroutine
 func (d *MetricDispatcher) RunAsync(ctx context.Context, done gostatsd.Done) {
-	d.runContext = ctx
-
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.running = true
 	go func() {
 		defer done()
+
 		var wg sync.WaitGroup
 		wg.Add(d.numWorkers)
 		for _, worker := range d.workers {
 			w := worker // Make a copy of the loop variable! https://github.com/golang/go/wiki/CommonMistakes
 			go w.work(wg.Done)
 		}
+
 		defer func() {
+			// Once this is indicated as not running, DispatchMetric will no longer
+			// try to send to the channel, so it is safe to close.
+			d.lock.Lock()
+			d.running = false
+			d.lock.Unlock()
+
 			for _, worker := range d.workers {
 				close(worker.metricsQueue) // Close channel to terminate worker
 			}
@@ -89,9 +99,15 @@ func (d *MetricDispatcher) runMetrics(ctx context.Context, statser statser.Stats
 func (d *MetricDispatcher) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	hash := adler32.Checksum([]byte(m.Name))
 	w := d.workers[uint16(hash%uint32(d.numWorkers))]
+
+	// Protects both the read of d.running, and that the channel remains open
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	if !d.running {
+		return nil
+	}
+
 	select {
-	case <-d.runContext.Done():
-		return d.runContext.Err()
 	case <-ctx.Done():
 		return ctx.Err()
 	case w.metricsQueue <- m:
@@ -113,9 +129,6 @@ func (d *MetricDispatcher) Process(ctx context.Context, f DispatcherProcessFunc)
 loop:
 	for _, worker := range d.workers {
 		select {
-		case <-d.runContext.Done():
-			wg.Add(cmdSent - d.numWorkers) // Not all commands have been sent, should decrement the WG counter.
-			break loop
 		case <-ctx.Done():
 			wg.Add(cmdSent - d.numWorkers) // Not all commands have been sent, should decrement the WG counter.
 			break loop

--- a/pkg/statsd/dispatcher_test.go
+++ b/pkg/statsd/dispatcher_test.go
@@ -104,7 +104,7 @@ func TestRunShouldReturnWhenContextCancelled(t *testing.T) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	d.RunAsync(ctx, wgFinish.Done)
+	d.Run(ctx, wgFinish.Done)
 	wgFinish.Wait() // Make sure waitgroup was released
 }
 
@@ -118,7 +118,7 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	d.RunAsync(ctx, wgFinish.Done)
+	go d.Run(ctx, wgFinish.Done)
 	numMetrics := r.Intn(1000) + n*10
 	var wg sync.WaitGroup
 	wg.Add(numMetrics)
@@ -165,7 +165,7 @@ func BenchmarkDispatcher(b *testing.B) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	d.RunAsync(ctx, wgFinish.Done)
+	go d.Run(ctx, wgFinish.Done)
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/pkg/statsd/dispatcher_test.go
+++ b/pkg/statsd/dispatcher_test.go
@@ -104,7 +104,7 @@ func TestRunShouldReturnWhenContextCancelled(t *testing.T) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	d.Run(ctx, wgFinish.Done)
+	d.RunAsync(ctx, wgFinish.Done)
 	wgFinish.Wait() // Make sure waitgroup was released
 }
 
@@ -118,7 +118,7 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	d.Run(ctx, wgFinish.Done)
+	d.RunAsync(ctx, wgFinish.Done)
 	numMetrics := r.Intn(1000) + n*10
 	var wg sync.WaitGroup
 	wg.Add(numMetrics)
@@ -165,7 +165,7 @@ func BenchmarkDispatcher(b *testing.B) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	go d.Run(ctx, wgFinish.Done)
+	d.RunAsync(ctx, wgFinish.Done)
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/pkg/statsd/dispatcher_test.go
+++ b/pkg/statsd/dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/statser"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,6 +19,9 @@ type testAggregator struct {
 	agrNumber int
 	af        *testAggregatorFactory
 	gostatsd.MetricMap
+}
+
+func (a *testAggregator) TrackMetrics(statser statser.Statser) {
 }
 
 func (a *testAggregator) Receive(m *gostatsd.Metric, t time.Time) {
@@ -114,7 +118,7 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 	defer cancelFunc()
 	var wgFinish sync.WaitGroup
 	wgFinish.Add(1)
-	go d.Run(ctx, wgFinish.Done)
+	d.Run(ctx, wgFinish.Done)
 	numMetrics := r.Intn(1000) + n*10
 	var wg sync.WaitGroup
 	wg.Add(numMetrics)

--- a/pkg/statsd/dispatcher_worker.go
+++ b/pkg/statsd/dispatcher_worker.go
@@ -1,9 +1,12 @@
 package statsd
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/statser"
 )
 
 type processCommand struct {
@@ -37,4 +40,16 @@ func (w *worker) work(done gostatsd.Done) {
 func (w *worker) executeProcess(cmd *processCommand) {
 	defer cmd.done() // Done with the process command
 	cmd.f(w.id, w.aggr)
+}
+
+func (w *worker) runMetrics(ctx context.Context, s statser.Statser) {
+	csw := statser.NewChannelStatsWatcher(
+		s,
+		"dispatch_aggregator",
+		gostatsd.Tags{fmt.Sprintf("aggregator_id:%d", w.id)},
+		cap(w.metricsQueue),
+		func() int { return len(w.metricsQueue) },
+		1000*time.Millisecond, // TODO: Make configurable
+	)
+	csw.Run(ctx)
 }

--- a/pkg/statsd/dispatcher_worker.go
+++ b/pkg/statsd/dispatcher_worker.go
@@ -51,5 +51,5 @@ func (w *worker) runMetrics(ctx context.Context, s statser.Statser) {
 		func() int { return len(w.metricsQueue) },
 		1000*time.Millisecond, // TODO: Make configurable
 	)
-	csw.Run(ctx)
+	go csw.Run(ctx)
 }

--- a/pkg/statsd/flusher_test.go
+++ b/pkg/statsd/flusher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/statser"
 )
 
 func TestFlusherHandleSendResultNoErrors(t *testing.T) {
@@ -19,7 +20,7 @@ func TestFlusherHandleSendResultNoErrors(t *testing.T) {
 		errs := errs
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
-			fl := NewMetricFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host")
+			fl := NewMetricFlusher(0, nil, nil, nil, gostatsd.UnknownIP, "host", statser.NewNullStatser())
 			fl.handleSendResult(errs)
 
 			if fl.lastFlush == 0 || fl.lastFlushError != 0 {
@@ -41,7 +42,7 @@ func TestFlusherHandleSendResultError(t *testing.T) {
 		errs := errs
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
-			fl := NewMetricFlusher(0, nil, nil, nil, nil, gostatsd.UnknownIP, "host")
+			fl := NewMetricFlusher(0, nil, nil, nil, gostatsd.UnknownIP, "host", statser.NewNullStatser())
 			fl.handleSendResult(errs)
 
 			if fl.lastFlushError == 0 || fl.lastFlush != 0 {

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -179,8 +179,6 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 }
 
 func BenchmarkReceive(b *testing.B) {
-	// TODO: This is a bad benchmark as mr.Receive() is normally long running.  This
-	// benchmarks "how fast can we allocate and GC 64k"
 	mr := &MetricReceiver{
 		handler: nopHandler{},
 	}

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
+	"github.com/atlassian/gostatsd/pkg/statser"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestReceiveEmptyPacket(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", false, ch)
+			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser())
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, inp)
 			require.NoError(t, err)
@@ -55,12 +56,12 @@ func TestReceivePacket(t *testing.T) {
 		},
 		"f:2|c|#t": {
 			metrics: []gostatsd.Metric{
-				{Name:"f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
 			metrics: []gostatsd.Metric{
-				{Name:"f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h"}},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
@@ -90,7 +91,7 @@ func TestReceivePacket(t *testing.T) {
 		t.Run(packet, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", false, ch)
+			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser())
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 			assert.NoError(t, err)
@@ -121,17 +122,17 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 		},
 		"f:2|c|#t": {
 			metrics: []gostatsd.Metric{
-				{Name:"f", Value: 2, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
 			metrics: []gostatsd.Metric{
-				{Name:"f", Value: 2, Hostname: "h", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Hostname: "h", Type: gostatsd.COUNTER},
 			},
 		},
 		"f:2|c|#host:h1,host:h2": {
 			metrics: []gostatsd.Metric{
-				{Name:"f", Value: 2, Hostname: "h1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h2"}},
+				{Name: "f", Value: 2, Hostname: "h1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h2"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
@@ -161,7 +162,7 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 		t.Run(packet, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", true, ch)
+			mr := NewMetricReceiver("", true, ch, statser.NewNullStatser())
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 			assert.NoError(t, err)
@@ -178,6 +179,8 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 }
 
 func BenchmarkReceive(b *testing.B) {
+	// TODO: This is a bad benchmark as mr.Receive() is normally long running.  This
+	// benchmarks "how fast can we allocate and GC 64k"
 	mr := &MetricReceiver{
 		handler: nopHandler{},
 	}

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -117,7 +117,8 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 
 	ctxStatser, cancelStatser := context.WithCancel(context.Background())
 	defer cancelStatser()
-	statser := statser.NewInternalStatser(ctxStatser, &wgStatser, s.InternalTags, namespace, hostname, handler)
+	bufferSize := 10 + 4*s.MaxWorkers // Estimate: 3 for the CSW on each, and a bit of overhead for things that tick in the background
+	statser := statser.NewInternalStatser(ctxStatser, &wgStatser, bufferSize, s.InternalTags, namespace, hostname, handler)
 	// TODO: Make internal metric dispatch configurable
 	// statser := NewLoggingStatser(s.InternalTags, log.NewEntry(log.New()))
 	dispatcher.runMetrics(ctxStatser, statser)

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -77,7 +77,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	ctxDisp, cancelDisp := context.WithCancel(context.Background()) // Separate context!
 	defer cancelDisp()                                              // Tell the dispatcher to shutdown
 	wgDispatcher.Add(1)
-	dispatcher.Run(ctxDisp, wgDispatcher.Done)
+	dispatcher.RunAsync(ctxDisp, wgDispatcher.Done)
 
 	// 2. Start handlers
 	ip := gostatsd.UnknownIP

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -27,6 +27,9 @@ var DefaultPercentThreshold = []float64{90}
 // DefaultTags is the default list of additional tags.
 var DefaultTags = gostatsd.Tags{}
 
+// DefaultInternalTags is the default list of additional tags on internal metrics
+var DefaultInternalTags = gostatsd.Tags{}
+
 const (
 	// DefaultMaxCloudRequests is the maximum number of cloud provider requests per second.
 	DefaultMaxCloudRequests = 10
@@ -52,6 +55,8 @@ const (
 	DefaultCacheTTL = 30 * time.Minute
 	// DefaultCacheNegativeTTL is the default cache TTL for failed lookups (errors or when instance was not found).
 	DefaultCacheNegativeTTL = 1 * time.Minute
+	// DefaultInternalNamespace is the default internal namespace
+	DefaultInternalNamespace = "statsd"
 )
 
 const (
@@ -65,6 +70,10 @@ const (
 	ParamBurstCloudRequests = "burst-cloud-requests"
 	// ParamDefaultTags is the name of parameter with the list of additional tags.
 	ParamDefaultTags = "default-tags"
+	// ParamInternalTags is the name of parameter with the list of tags for internal metrics.
+	ParamInternalTags = "internal-tags"
+	// ParamInternalNamespace is the name of parameter with the namespace for internal metrics.
+	ParamInternalNamespace = "internal-namespace"
 	// ParamExpiryInterval is the name of parameter with expiry interval for metrics.
 	ParamExpiryInterval = "expiry-interval"
 	// ParamFlushInterval is the name of parameter with metrics flush interval.
@@ -141,5 +150,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Int(ParamMaxCloudRequests, DefaultMaxCloudRequests, "Maximum number of cloud provider requests per second")
 	fs.Int(ParamBurstCloudRequests, DefaultBurstCloudRequests, "Burst number of cloud provider requests per second")
 	fs.String(ParamDefaultTags, strings.Join(DefaultTags, ","), "Comma-separated list of tags to add to all metrics")
+	fs.String(ParamInternalTags, strings.Join(DefaultInternalTags, ","), "Comma-separated list of tags to add to internal metrics")
+	fs.String(ParamInternalNamespace, DefaultInternalNamespace, "Namespace for internal metrics, may be \"\"")
 	fs.String(ParamPercentThreshold, strings.Join(toStringSlice(DefaultPercentThreshold), ","), "Comma-separated list of percentiles")
 }

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -18,6 +18,7 @@ import (
 // TestStatsdThroughput emulates statsd work using fake network socket and null backend to
 // measure throughput.
 func TestStatsdThroughput(t *testing.T) {
+	// TODO: Refactor this in to a Benchmark
 	rand.Seed(time.Now().UnixNano())
 	var memStatsStart, memStatsFinish runtime.MemStats
 	runtime.ReadMemStats(&memStatsStart)
@@ -82,7 +83,20 @@ func (cb *countingBackend) Name() string {
 }
 
 func (cb *countingBackend) SendMetricsAsync(ctx context.Context, m *gostatsd.MetricMap, callback gostatsd.SendCallback) {
-	atomic.AddUint64(&cb.metrics, uint64(m.NumStats))
+	count := 0
+	m.Counters.Each(func(name, tagset string, c gostatsd.Counter) {
+		count++
+	})
+	m.Gauges.Each(func(name, tagset string, g gostatsd.Gauge) {
+		count++
+	})
+	m.Timers.Each(func(name, tagset string, t gostatsd.Timer) {
+		count++
+	})
+	m.Sets.Each(func(name, tagset string, s gostatsd.Set) {
+		count++
+	})
+	atomic.AddUint64(&cb.metrics, uint64(count))
 	callback(nil)
 }
 

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -18,7 +18,6 @@ import (
 // TestStatsdThroughput emulates statsd work using fake network socket and null backend to
 // measure throughput.
 func TestStatsdThroughput(t *testing.T) {
-	// TODO: Refactor this in to a Benchmark
 	rand.Seed(time.Now().UnixNano())
 	var memStatsStart, memStatsFinish runtime.MemStats
 	runtime.ReadMemStats(&memStatsStart)

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/statser"
 )
 
 // Handler interface can be used to handle metrics and events.
@@ -25,6 +26,7 @@ type ProcessFunc func(*gostatsd.MetricMap)
 //
 // Incoming metrics should be passed via Receive function.
 type Aggregator interface {
+	TrackMetrics(statser statser.Statser)
 	Receive(*gostatsd.Metric, time.Time)
 	Flush(interval time.Duration)
 	Process(ProcessFunc)
@@ -42,32 +44,4 @@ type Dispatcher interface {
 	// DispatcherProcessFunc function may be executed zero or up to numWorkers times. It is executed
 	// less than numWorkers times if the context signals "done".
 	Process(context.Context, DispatcherProcessFunc) gostatsd.Wait
-}
-
-// FlusherStats holds statistics about a Flusher.
-type FlusherStats struct {
-	LastFlush      time.Time // Last time the metrics where aggregated
-	LastFlushError time.Time // Time of the last flush error
-}
-
-// Flusher periodically flushes metrics from all Aggregators to Senders.
-type Flusher interface {
-	// GetStats returns Flusher statistics.
-	GetStats() FlusherStats
-}
-
-// ReceiverStatsGetter returns current Receiver stats.
-type ReceiverStatsGetter interface {
-	// GetStats returns current Receiver stats.
-	// Safe for concurrent use.
-	GetStats() ReceiverStats
-}
-
-// ReceiverStats holds statistics for a Receiver.
-type ReceiverStats struct {
-	LastPacket      time.Time
-	BadLines        uint64
-	PacketsReceived uint64
-	MetricsReceived uint64
-	EventsReceived  uint64
 }

--- a/pkg/statser/channel_stats_watcher.go
+++ b/pkg/statser/channel_stats_watcher.go
@@ -34,19 +34,16 @@ func NewChannelStatsWatcher(client Statser, channelName string, tags gostatsd.Ta
 // Run will run a ChannelStatsWatcher in the background until the supplied context is
 // closed, or Stop is called.
 func (csw *ChannelStatsWatcher) Run(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(csw.interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				csw.emit()
-			}
+	ticker := time.NewTicker(csw.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			csw.emit()
 		}
-	}()
+	}
 }
 
 func (csw *ChannelStatsWatcher) emit() {

--- a/pkg/statser/channel_stats_watcher.go
+++ b/pkg/statser/channel_stats_watcher.go
@@ -18,13 +18,9 @@ type ChannelStatsWatcher struct {
 
 // NewChannelStatsWatcher creates a new ChannelStatsWatcher
 func NewChannelStatsWatcher(client Statser, channelName string, tags gostatsd.Tags, capacity int, lenFunc func() int, interval time.Duration) *ChannelStatsWatcher {
-	t := gostatsd.Tags{"channel:" + channelName}
-	if tags != nil {
-		t = append(t, tags...)
-	}
 	return &ChannelStatsWatcher{
 		client:   client,
-		tags:     t,
+		tags:     tags.Concat(gostatsd.Tags{"channel:" + channelName}),
 		capacity: capacity,
 		lenFunc:  lenFunc,
 		interval: interval,
@@ -54,7 +50,7 @@ func (csw *ChannelStatsWatcher) emit() {
 	// tags are normally read from external sources, so are distinct even if the
 	// same values.  As such, many things make assumptions about the ability to
 	// modify tags in place.  So we duplicate them.
-	csw.client.Gauge("channel.capacity", capacity, copyTags(csw.tags))
-	csw.client.Gauge("channel.queued", queued, copyTags(csw.tags))
-	csw.client.Gauge("channel.pct_used", percentUsed, copyTags(csw.tags))
+	csw.client.Gauge("channel.capacity", capacity, csw.tags.Copy())
+	csw.client.Gauge("channel.queued", queued, csw.tags.Copy())
+	csw.client.Gauge("channel.pct_used", percentUsed, csw.tags.Copy())
 }

--- a/pkg/statser/channel_stats_watcher.go
+++ b/pkg/statser/channel_stats_watcher.go
@@ -1,0 +1,63 @@
+package statser
+
+import (
+	"context"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// ChannelStatsWatcher reports metrics about channel usage to a Statser
+type ChannelStatsWatcher struct {
+	client   Statser
+	tags     gostatsd.Tags
+	capacity int
+	lenFunc  func() int
+	interval time.Duration
+}
+
+// NewChannelStatsWatcher creates a new ChannelStatsWatcher
+func NewChannelStatsWatcher(client Statser, channelName string, tags gostatsd.Tags, capacity int, lenFunc func() int, interval time.Duration) *ChannelStatsWatcher {
+	t := gostatsd.Tags{"channel:" + channelName}
+	if tags != nil {
+		t = append(t, tags...)
+	}
+	return &ChannelStatsWatcher{
+		client:   client,
+		tags:     t,
+		capacity: capacity,
+		lenFunc:  lenFunc,
+		interval: interval,
+	}
+}
+
+// Run will run a ChannelStatsWatcher in the background until the supplied context is
+// closed, or Stop is called.
+func (csw *ChannelStatsWatcher) Run(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(csw.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				csw.emit()
+			}
+		}
+	}()
+}
+
+func (csw *ChannelStatsWatcher) emit() {
+	capacity := float64(csw.capacity)
+	queued := float64(csw.lenFunc())
+	percentUsed := 100.0 * (queued / capacity)
+
+	// tags are normally read from external sources, so are distinct even if the
+	// same values.  As such, many things make assumptions about the ability to
+	// modify tags in place.  So we duplicate them.
+	csw.client.Gauge("channel.capacity", capacity, copyTags(csw.tags))
+	csw.client.Gauge("channel.queued", queued, copyTags(csw.tags))
+	csw.client.Gauge("channel.pct_used", percentUsed, copyTags(csw.tags))
+}

--- a/pkg/statser/statser.go
+++ b/pkg/statser/statser.go
@@ -25,7 +25,7 @@ func concatTags(a, b gostatsd.Tags) gostatsd.Tags {
 }
 
 func copyTags(tags gostatsd.Tags) gostatsd.Tags {
-	new := make(gostatsd.Tags, len(tags))
-	copy(new, tags)
-	return new
+	tagCopy := make(gostatsd.Tags, len(tags))
+	copy(tagCopy, tags)
+	return tagCopy
 }

--- a/pkg/statser/statser.go
+++ b/pkg/statser/statser.go
@@ -1,0 +1,31 @@
+package statser
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// Statser is the interface for sending metrics
+type Statser interface {
+	Gauge(name string, value float64, tags gostatsd.Tags)
+	Count(name string, amount float64, tags gostatsd.Tags)
+	Increment(name string, tags gostatsd.Tags)
+	TimingMS(name string, ms float64, tags gostatsd.Tags)
+	TimingDuration(name string, d time.Duration, tags gostatsd.Tags)
+	NewTimer(name string, tags gostatsd.Tags) *Timer
+	WithTags(tags gostatsd.Tags) Statser
+}
+
+func concatTags(a, b gostatsd.Tags) gostatsd.Tags {
+	t := make(gostatsd.Tags, 0, len(a)+len(b))
+	t = append(t, a...)
+	t = append(t, b...)
+	return t
+}
+
+func copyTags(tags gostatsd.Tags) gostatsd.Tags {
+	new := make(gostatsd.Tags, len(tags))
+	copy(new, tags)
+	return new
+}

--- a/pkg/statser/statser.go
+++ b/pkg/statser/statser.go
@@ -1,6 +1,7 @@
 package statser
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -8,6 +9,7 @@ import (
 
 // Statser is the interface for sending metrics
 type Statser interface {
+	Run(ctx context.Context, done gostatsd.Done)
 	Gauge(name string, value float64, tags gostatsd.Tags)
 	Count(name string, amount float64, tags gostatsd.Tags)
 	Increment(name string, tags gostatsd.Tags)
@@ -15,17 +17,4 @@ type Statser interface {
 	TimingDuration(name string, d time.Duration, tags gostatsd.Tags)
 	NewTimer(name string, tags gostatsd.Tags) *Timer
 	WithTags(tags gostatsd.Tags) Statser
-}
-
-func concatTags(a, b gostatsd.Tags) gostatsd.Tags {
-	t := make(gostatsd.Tags, 0, len(a)+len(b))
-	t = append(t, a...)
-	t = append(t, b...)
-	return t
-}
-
-func copyTags(tags gostatsd.Tags) gostatsd.Tags {
-	tagCopy := make(gostatsd.Tags, len(tags))
-	copy(tagCopy, tags)
-	return tagCopy
 }

--- a/pkg/statser/statser_internal.go
+++ b/pkg/statser/statser_internal.go
@@ -96,5 +96,5 @@ func (is *InternalStatser) dispatchMetric(metric *gostatsd.Metric) {
 		metric.Name = is.namespace + "." + metric.Name
 	}
 	metric.Tags = append(metric.Tags, is.tags...)
-	is.handler.DispatchMetric(is.ctx, metric)
+	_ = is.handler.DispatchMetric(is.ctx, metric)
 }

--- a/pkg/statser/statser_internal.go
+++ b/pkg/statser/statser_internal.go
@@ -1,0 +1,100 @@
+package statser
+
+import (
+	"context"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// InternalHandler is an interface to dispatch metrics to.  Exists
+// to break circular dependencies.
+type InternalHandler interface {
+	DispatchMetric(ctx context.Context, m *gostatsd.Metric) error
+}
+
+// InternalStatser is a Statser which sends metrics to a handler
+type InternalStatser struct {
+	ctx       context.Context
+	tags      gostatsd.Tags
+	namespace string
+	hostname  string
+	handler   InternalHandler
+}
+
+// NewInternalStatser creates a new Statser which sends metrics to the
+// supplied InternalHandler
+func NewInternalStatser(ctx context.Context, tags gostatsd.Tags, namespace, hostname string, handler InternalHandler) Statser {
+	return &InternalStatser{
+		ctx:       ctx,
+		tags:      tags,
+		namespace: namespace,
+		hostname:  hostname,
+		handler:   handler,
+	}
+}
+
+// Gauge sends a gauge metric
+func (is *InternalStatser) Gauge(name string, value float64, tags gostatsd.Tags) {
+	g := &gostatsd.Metric{
+		Name:     name,
+		Value:    value,
+		Tags:     tags,
+		Hostname: is.hostname,
+		Type:     gostatsd.GAUGE,
+	}
+	is.dispatchMetric(g)
+}
+
+// Count sends a counter metric
+func (is *InternalStatser) Count(name string, amount float64, tags gostatsd.Tags) {
+	c := &gostatsd.Metric{
+		Name:     name,
+		Value:    amount,
+		Tags:     tags,
+		Hostname: is.hostname,
+		Type:     gostatsd.COUNTER,
+	}
+	is.dispatchMetric(c)
+}
+
+// Increment sends a counter metric with a value of 1
+func (is *InternalStatser) Increment(name string, tags gostatsd.Tags) {
+	is.Count(name, 1, tags)
+}
+
+// TimingMS sends a timing metric from a millisecond value
+func (is *InternalStatser) TimingMS(name string, ms float64, tags gostatsd.Tags) {
+	c := &gostatsd.Metric{
+		Name:     name,
+		Value:    ms,
+		Tags:     tags,
+		Hostname: is.hostname,
+		Type:     gostatsd.TIMER,
+	}
+	is.dispatchMetric(c)
+}
+
+// TimingDuration sends a timing metric from a time.Duration
+func (is *InternalStatser) TimingDuration(name string, d time.Duration, tags gostatsd.Tags) {
+	is.TimingMS(name, float64(d)/float64(time.Millisecond), tags)
+}
+
+// NewTimer returns a new timer with time set to now
+func (is *InternalStatser) NewTimer(name string, tags gostatsd.Tags) *Timer {
+	return newTimer(is, name, tags)
+}
+
+// WithTags creates a new InternalStatser with additional tags
+func (is *InternalStatser) WithTags(tags gostatsd.Tags) Statser {
+	return NewInternalStatser(is.ctx, concatTags(is.tags, tags), is.namespace, is.hostname, is.handler)
+}
+
+func (is *InternalStatser) dispatchMetric(metric *gostatsd.Metric) {
+	// the metric is owned by this file, we can change it freely because we know its origins
+	if is.namespace != "" {
+		metric.Name = is.namespace + "." + metric.Name
+	}
+	metric.Tags = append(metric.Tags, is.tags...)
+	is.handler.DispatchMetric(is.ctx, metric)
+}

--- a/pkg/statser/statser_internal.go
+++ b/pkg/statser/statser_internal.go
@@ -44,15 +44,13 @@ func NewInternalStatser(ctx context.Context, wg *sync.WaitGroup, tags gostatsd.T
 }
 
 func (is *InternalStatser) run() {
-	select {
-	case <-is.ctx.Done():
-		// At this point we're certain the Context is closed.  Wait for
-		// all consumers to release their locks.  On the next dispatch,
-		// they will see the closed Context and not attempt to proceed.
-		is.lock.Lock()
-		is.lock.Unlock()
-		is.wg.Done()
-	}
+	<-is.ctx.Done()
+	// At this point we're certain the Context is closed.  Wait for
+	// all consumers to release their locks.  On the next dispatch,
+	// they will see the closed Context and not attempt to proceed.
+	is.lock.Lock()
+	is.wg.Done()
+	is.lock.Unlock()
 }
 
 // Gauge sends a gauge metric

--- a/pkg/statser/statser_logging.go
+++ b/pkg/statser/statser_logging.go
@@ -68,7 +68,7 @@ func (ls *LoggingStatser) NewTimer(name string, tags gostatsd.Tags) *Timer {
 	return newTimer(ls, name, tags)
 }
 
-// WithTags creates a new LoggingStatser with additional tags
+// WithTags creates a new Statser with additional tags
 func (ls *LoggingStatser) WithTags(tags gostatsd.Tags) Statser {
-	return NewLoggingStatser(concatTags(ls.tags, tags), ls.logger)
+	return NewTaggedStatser(ls, tags)
 }

--- a/pkg/statser/statser_logging.go
+++ b/pkg/statser/statser_logging.go
@@ -1,6 +1,7 @@
 package statser
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -23,11 +24,16 @@ func NewLoggingStatser(tags gostatsd.Tags, logger *log.Entry) Statser {
 	}
 }
 
+// Run does nothing for a LoggingStatser
+func (ls *LoggingStatser) Run(ctx context.Context, done gostatsd.Done) {
+	done()
+}
+
 // Gauge sends a gauge metric
 func (ls *LoggingStatser) Gauge(name string, value float64, tags gostatsd.Tags) {
 	ls.logger.WithFields(log.Fields{
 		"name":  name,
-		"tags":  concatTags(ls.tags, tags),
+		"tags":  ls.tags.Concat(tags),
 		"value": value,
 	}).Infof("gauge")
 }
@@ -36,7 +42,7 @@ func (ls *LoggingStatser) Gauge(name string, value float64, tags gostatsd.Tags) 
 func (ls *LoggingStatser) Count(name string, amount float64, tags gostatsd.Tags) {
 	ls.logger.WithFields(log.Fields{
 		"name":   name,
-		"tags":   concatTags(ls.tags, tags),
+		"tags":   ls.tags.Concat(tags),
 		"amount": amount,
 	}).Infof("count")
 }
@@ -45,7 +51,7 @@ func (ls *LoggingStatser) Count(name string, amount float64, tags gostatsd.Tags)
 func (ls *LoggingStatser) Increment(name string, tags gostatsd.Tags) {
 	ls.logger.WithFields(log.Fields{
 		"name": name,
-		"tags": concatTags(ls.tags, tags),
+		"tags": ls.tags.Concat(tags),
 	}).Infof("increment")
 }
 
@@ -53,7 +59,7 @@ func (ls *LoggingStatser) Increment(name string, tags gostatsd.Tags) {
 func (ls *LoggingStatser) TimingMS(name string, ms float64, tags gostatsd.Tags) {
 	ls.logger.WithFields(log.Fields{
 		"name": name,
-		"tags": concatTags(ls.tags, tags),
+		"tags": ls.tags.Concat(tags),
 		"ms":   ms,
 	}).Infof("timing")
 }

--- a/pkg/statser/statser_logging.go
+++ b/pkg/statser/statser_logging.go
@@ -1,0 +1,74 @@
+package statser
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// LoggingStatser is a Statser which emits logs
+type LoggingStatser struct {
+	tags   gostatsd.Tags
+	logger *log.Entry
+}
+
+// NewLoggingStatser creates a new Statser which sends metrics to the
+// supplied log.Entry
+func NewLoggingStatser(tags gostatsd.Tags, logger *log.Entry) Statser {
+	return &LoggingStatser{
+		tags:   tags,
+		logger: logger,
+	}
+}
+
+// Gauge sends a gauge metric
+func (ls *LoggingStatser) Gauge(name string, value float64, tags gostatsd.Tags) {
+	ls.logger.WithFields(log.Fields{
+		"name":  name,
+		"tags":  concatTags(ls.tags, tags),
+		"value": value,
+	}).Infof("gauge")
+}
+
+// Count sends a counter metric
+func (ls *LoggingStatser) Count(name string, amount float64, tags gostatsd.Tags) {
+	ls.logger.WithFields(log.Fields{
+		"name":   name,
+		"tags":   concatTags(ls.tags, tags),
+		"amount": amount,
+	}).Infof("count")
+}
+
+// Increment sends a counter metric with a value of 1
+func (ls *LoggingStatser) Increment(name string, tags gostatsd.Tags) {
+	ls.logger.WithFields(log.Fields{
+		"name": name,
+		"tags": concatTags(ls.tags, tags),
+	}).Infof("increment")
+}
+
+// TimingMS sends a timing metric from a millisecond value
+func (ls *LoggingStatser) TimingMS(name string, ms float64, tags gostatsd.Tags) {
+	ls.logger.WithFields(log.Fields{
+		"name": name,
+		"tags": concatTags(ls.tags, tags),
+		"ms":   ms,
+	}).Infof("timing")
+}
+
+// TimingDuration sends a timing metric from a time.Duration
+func (ls *LoggingStatser) TimingDuration(name string, d time.Duration, tags gostatsd.Tags) {
+	ls.TimingMS(name, float64(d)/float64(time.Millisecond), tags)
+}
+
+// NewTimer returns a new timer with time set to now
+func (ls *LoggingStatser) NewTimer(name string, tags gostatsd.Tags) *Timer {
+	return newTimer(ls, name, tags)
+}
+
+// WithTags creates a new LoggingStatser with additional tags
+func (ls *LoggingStatser) WithTags(tags gostatsd.Tags) Statser {
+	return NewLoggingStatser(concatTags(ls.tags, tags), ls.logger)
+}

--- a/pkg/statser/statser_null.go
+++ b/pkg/statser/statser_null.go
@@ -1,6 +1,7 @@
 package statser
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -13,6 +14,11 @@ type NullStatser struct{}
 // NewNullStatser creates a new NullStatser
 func NewNullStatser() Statser {
 	return &NullStatser{}
+}
+
+// Run does nothing
+func (ns *NullStatser) Run(ctx context.Context, done gostatsd.Done) {
+	done()
 }
 
 // Gauge does nothing

--- a/pkg/statser/statser_null.go
+++ b/pkg/statser/statser_null.go
@@ -1,0 +1,41 @@
+package statser
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// NullStatser is a null implementation of Statser, intended primarily
+// for test purposes
+type NullStatser struct{}
+
+// NewNullStatser creates a new NullStatser
+func NewNullStatser() Statser {
+	return &NullStatser{}
+}
+
+// Gauge does nothing
+func (ns *NullStatser) Gauge(name string, value float64, tags gostatsd.Tags) {}
+
+// Count does nothing
+func (ns *NullStatser) Count(name string, amount float64, tags gostatsd.Tags) {}
+
+// Increment does nothing
+func (ns *NullStatser) Increment(name string, tags gostatsd.Tags) {}
+
+// TimingMS does nothing
+func (ns *NullStatser) TimingMS(name string, ms float64, tags gostatsd.Tags) {}
+
+// TimingDuration does nothing
+func (ns *NullStatser) TimingDuration(name string, d time.Duration, tags gostatsd.Tags) {}
+
+// NewTimer returns a new timer with time set to now
+func (ns *NullStatser) NewTimer(name string, tags gostatsd.Tags) *Timer {
+	return newTimer(ns, name, tags)
+}
+
+// WithTags returns a NullStatser
+func (ns *NullStatser) WithTags(tags gostatsd.Tags) Statser {
+	return ns
+}

--- a/pkg/statser/statser_tagged.go
+++ b/pkg/statser/statser_tagged.go
@@ -1,0 +1,76 @@
+package statser
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// TaggedStatser adds tags and submits metrics to another Statser
+type TaggedStatser struct {
+	statser Statser
+	tags    gostatsd.Tags // invariant: non-empty (otherwise we return the original Statser)
+}
+
+// NewTaggedStatser creates a new Statser which adds additional tags
+// all metrics submitted.
+func NewTaggedStatser(statser Statser, tags gostatsd.Tags) Statser {
+	if len(tags) == 0 {
+		return statser
+	}
+
+	return &TaggedStatser{
+		statser: statser,
+		tags:    tags,
+	}
+}
+
+// Gauge sends a gauge metric
+func (ts *TaggedStatser) Gauge(name string, value float64, tags gostatsd.Tags) {
+	ts.statser.Gauge(name, value, ts.concatTags(ts.tags, tags))
+}
+
+// Count sends a counter metric
+func (ts *TaggedStatser) Count(name string, amount float64, tags gostatsd.Tags) {
+	ts.statser.Count(name, amount, ts.concatTags(ts.tags, tags))
+}
+
+// Increment sends a counter metric with a value of 1
+func (ts *TaggedStatser) Increment(name string, tags gostatsd.Tags) {
+	ts.statser.Increment(name, ts.concatTags(ts.tags, tags))
+}
+
+// TimingMS sends a timing metric from a millisecond value
+func (ts *TaggedStatser) TimingMS(name string, ms float64, tags gostatsd.Tags) {
+	ts.statser.TimingMS(name, ms, ts.concatTags(ts.tags, tags))
+}
+
+// TimingDuration sends a timing metric from a time.Duration
+func (ts *TaggedStatser) TimingDuration(name string, d time.Duration, tags gostatsd.Tags) {
+	ts.statser.TimingDuration(name, d, ts.concatTags(ts.tags, tags))
+}
+
+// NewTimer returns a new timer with time set to now
+func (ts *TaggedStatser) NewTimer(name string, tags gostatsd.Tags) *Timer {
+	return ts.statser.NewTimer(name, ts.concatTags(ts.tags, tags))
+}
+
+// WithTags creates a new Statser with additional tags
+func (ts *TaggedStatser) WithTags(tags gostatsd.Tags) Statser {
+	// There's no value wrapping it up in multiple layers
+	if len(tags) == 0 {
+		return ts
+	}
+
+	return &TaggedStatser{
+		statser: ts.statser, // Base Statser
+		tags:    concatTags(ts.tags, tags),
+	}
+}
+
+func (ts *TaggedStatser) concatTags(base, extra gostatsd.Tags) gostatsd.Tags {
+	if len(extra) == 0 {
+		return base
+	}
+	return concatTags(base, extra)
+}

--- a/pkg/statser/statser_tagged.go
+++ b/pkg/statser/statser_tagged.go
@@ -1,6 +1,7 @@
 package statser
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -24,6 +25,9 @@ func NewTaggedStatser(statser Statser, tags gostatsd.Tags) Statser {
 		tags:    tags,
 	}
 }
+
+// Run does nothing for a TaggedStatser
+func (ts *TaggedStatser) Run(ctx context.Context, done gostatsd.Done) {}
 
 // Gauge sends a gauge metric
 func (ts *TaggedStatser) Gauge(name string, value float64, tags gostatsd.Tags) {
@@ -64,7 +68,7 @@ func (ts *TaggedStatser) WithTags(tags gostatsd.Tags) Statser {
 
 	return &TaggedStatser{
 		statser: ts.statser, // Base Statser
-		tags:    concatTags(ts.tags, tags),
+		tags:    ts.tags.Concat(tags),
 	}
 }
 
@@ -72,5 +76,5 @@ func (ts *TaggedStatser) concatTags(base, extra gostatsd.Tags) gostatsd.Tags {
 	if len(extra) == 0 {
 		return base
 	}
-	return concatTags(base, extra)
+	return base.Concat(extra)
 }

--- a/pkg/statser/timer.go
+++ b/pkg/statser/timer.go
@@ -1,0 +1,47 @@
+package statser
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// Timer times an operation and submits a timing or gauge metric
+type Timer struct {
+	statser   Statser
+	name      string
+	tags      gostatsd.Tags
+	startTime time.Time
+	endTime   time.Time
+}
+
+func newTimer(statser Statser, name string, tags gostatsd.Tags) *Timer {
+	return &Timer{
+		statser:   statser,
+		name:      name,
+		tags:      tags,
+		startTime: time.Now(),
+	}
+}
+
+// Stop stops the time being recorded
+func (t *Timer) Stop() {
+	t.endTime = time.Now()
+}
+
+// Send sends a timing style metric
+func (t *Timer) Send() {
+	t.statser.TimingDuration(t.name, t.duration(), t.tags)
+}
+
+// SendGauge sends a gauge metric in milliseconds
+func (t *Timer) SendGauge() {
+	t.statser.Gauge(t.name, float64(t.duration())/float64(time.Millisecond), t.tags)
+}
+
+func (t *Timer) duration() time.Duration {
+	if t.endTime.IsZero() {
+		return time.Since(t.startTime)
+	}
+	return t.endTime.Sub(t.startTime)
+}

--- a/tags.go
+++ b/tags.go
@@ -34,3 +34,18 @@ func (tags Tags) SortedString() string {
 func NormalizeTagKey(key string) string {
 	return strings.Replace(key, ":", "_", -1)
 }
+
+// Concat returns a new Tags with the additional ones added
+func (tags Tags) Concat(additional Tags) Tags {
+	t := make(Tags, 0, len(tags)+len(additional))
+	t = append(t, tags...)
+	t = append(t, additional...)
+	return t
+}
+
+// Copy returns a copy of the Tags
+func (tags Tags) Copy() Tags {
+	tagCopy := make(Tags, len(tags))
+	copy(tagCopy, tags)
+	return tagCopy
+}


### PR DESCRIPTION
This touches on a whole heap of stuff, but the gist is that we currently have all these backdoory hooks, and adding more internal metrics means per-metric backdoory hooks.

This removes all of them, and replaces them with a Statser.  We still use use backdoory hooks to get the Statser where it needs to be, but then it's done.  It gives a better foundation to build internal metrics on.

It also gives us the facility to send to an alternate statsd service, which means we should retain metrics under failure-to-submit conditions.  Currently that's not implemented.  Configuring Statsers is also not implemented.

Metrics now send on their own interval, rather than being slaved to the MetricFlusher, because they may not be going to the current flusher.  Intervals are also not yet configurable.

It also splits out an internal metric namespace and internal metric tags.  If we were any other service we would have this control over our internal metrics, so I want them for this service too.