### PR TITLE
Logrus dependency alias

### DIFF
--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/cloudproviders"
 	"github.com/atlassian/gostatsd/pkg/statsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"

--- a/cmd/tester/loader.go
+++ b/cmd/tester/loader.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func (s *Server) load() {

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/atlassian/gostatsd/pkg/statsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )

--- a/cmd/tester/sender.go
+++ b/cmd/tester/sender.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Metrics store the metrics to send.

--- a/cmd/tester/server.go
+++ b/cmd/tester/server.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -55,7 +55,7 @@ imports:
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/pelletier/go-toml
   version: 4692b8f9babfc93db58cc592ba2689d8736781de
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
 - name: github.com/spf13/afero
   version: 9be650865eab0c12963d8753212f4f9c66cdcf12

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,9 @@
 package: github.com/atlassian/gostatsd
 import:
+- package: github.com/sirupsen/logrus
 - package: github.com/Sirupsen/logrus
+  repo: git@github.com:sirupsen/logrus
+  vcs: git
 - package: github.com/spf13/pflag
 - package: github.com/spf13/viper
 - package: github.com/aws/aws-sdk-go

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -10,7 +10,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/backends/statsdaemon"
 	"github.com/atlassian/gostatsd/pkg/backends/stdout"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/spf13/viper"
 )

--- a/pkg/backends/graphite/graphite.go
+++ b/pkg/backends/graphite/graphite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/backends/sender/sender.go
+++ b/pkg/backends/sender/sender.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const maxStreamsPerConnection = 100

--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -14,7 +14,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/backends/stdout/stdout.go
+++ b/pkg/backends/stdout/stdout.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/cloudproviders/aws/aws.go
+++ b/pkg/cloudproviders/aws/aws.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"

--- a/pkg/cloudproviders/cloudproviders.go
+++ b/pkg/cloudproviders/cloudproviders.go
@@ -6,7 +6,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/statser"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // percentStruct is a cache of percentile names to avoid creating them for each timer.

--- a/pkg/statsd/cloud_handler.go
+++ b/pkg/statsd/cloud_handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/ash2k/stager/wait"
 	"golang.org/x/time/rate"
 )

--- a/pkg/statsd/cloud_handler_lookup.go
+++ b/pkg/statsd/cloud_handler_lookup.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 

--- a/pkg/statsd/dispatching_handler.go
+++ b/pkg/statsd/dispatching_handler.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // DispatchingHandler dispatches events to all configured backends and forwards metrics to a Dispatcher.

--- a/pkg/statsd/flusher.go
+++ b/pkg/statsd/flusher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/statser"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // MetricFlusher periodically flushes metrics from all Aggregators to Senders.

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/statser"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ip packet size is stored in two bytes and that is how big in theory the packet can be.

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/statser"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/ash2k/stager"
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"

--- a/pkg/statser/statser_logging.go
+++ b/pkg/statser/statser_logging.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // LoggingStatser is a Statser which emits logs


### PR DESCRIPTION
Sirupsen/logrus recently renamed to sirupsen/logrus. This change updates the package name across go files and sets an alias in glide for any dependencies referring to the original name.