### PR TITLE
Implement deflate compression for metrics uploads in Datadog backend

### DIFF
--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -217,10 +217,13 @@ func (d *Client) constructPost(ctx context.Context, authenticatedURL string, bod
 			if err != nil {
 				return fmt.Errorf("unable to create zlib writer: %v", err)
 			}
-			compressor.Write(body)
+			_, err = compressor.Write(body)
+			if err != nil {
+				return fmt.Errorf("unable to write compressed payload: %v", err)
+			}
 			err = compressor.Close()
 			if err != nil {
-				return fmt.Errorf("unable to compress payload: %v", err)
+				return fmt.Errorf("unable to close compressor: %v", err)
 			}
 			reader = &buf
 			headers["Content-Encoding"] = "deflate"

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -210,8 +210,7 @@ func (d *Client) constructPost(ctx context.Context, authenticatedURL string, bod
 			"User-Agent":           dogstatsdUserAgent,
 		}
 		var reader io.Reader
-		switch compressPayload {
-		case true:
+		if compressPayload {
 			// Use deflate (zlib, since DD requires the zlib headers)
 			var buf bytes.Buffer
 			compressor, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
@@ -228,7 +227,7 @@ func (d *Client) constructPost(ctx context.Context, authenticatedURL string, bod
 			sc := buf.Len()
 			sp := len(body)
 			log.Debugf("payload_size=%d, compressed_size=%d, compression_ration=%.3f", sp, sc, float32(sc)/float32(sp))
-		default:
+		} else {
 			// No compression
 			reader = bytes.NewReader(body)
 		}


### PR DESCRIPTION
The python dd-agent uses deflate compression when POSTing to /api/v1/series. Doing this results in a substantial reduction in payload size.