### PR TITLE
Allows for dual stack mode to be enabled in the Datadog backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.4.x
+-----
+- New Datadog option: `dual_stack` allows control of RFC-6555 "Happy Eyeballs" for IPv6 control.  Defaults `false`.
+
 2.4.1
 -----
 - No functional changes over previous version. Release tag to trigger build process.
@@ -5,7 +9,8 @@
 2.4.0
 -----
 - Build with Go 1.9
-- Compress metrics uploads to Datadog. Add `compress_payload` config option to disable this
+- Add support for compression in Datadog payload.
+- New Datadog option: `compress_payload` allows compression of Datadog payload.  Defaults `true`.
 - Add staged shutdown
 - Update logrus import path
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_HASH := $$(git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS := -ldflags "-s -X $(VERSION_VAR)=$(REPO_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
 BINARY_NAME := gostatsd
 IMAGE_NAME := atlassianlabs/$(BINARY_NAME)
-ARCH ?= $((uname -s | tr A-Z a-z))
+ARCH ?= $$(uname -s | tr A-Z a-z)
 METALINTER_CONCURRENCY ?= 4
 GOVERSION := 1.8
 GP := /gopath

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -258,6 +258,7 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 	dd.SetDefault("api_endpoint", apiURL)
 	dd.SetDefault("metrics_per_batch", defaultMetricsPerBatch)
 	dd.SetDefault("compress_payload", true)
+	dd.SetDefault("dual_stack", false)
 	dd.SetDefault("client_timeout", defaultClientTimeout)
 	dd.SetDefault("max_request_elapsed_time", defaultMaxRequestElapsedTime)
 	return NewClient(
@@ -265,13 +266,14 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 		dd.GetString("api_key"),
 		uint(dd.GetInt("metrics_per_batch")),
 		dd.GetBool("compress_payload"),
+		dd.GetBool("dual_stack"),
 		dd.GetDuration("client_timeout"),
 		dd.GetDuration("max_request_elapsed_time"),
 	)
 }
 
 // NewClient returns a new Datadog API client.
-func NewClient(apiEndpoint, apiKey string, metricsPerBatch uint, compressPayload bool, clientTimeout, maxRequestElapsedTime time.Duration) (*Client, error) {
+func NewClient(apiEndpoint, apiKey string, metricsPerBatch uint, compressPayload, dualStack bool, clientTimeout, maxRequestElapsedTime time.Duration) (*Client, error) {
 	if apiEndpoint == "" {
 		return nil, fmt.Errorf("[%s] apiEndpoint is required", BackendName)
 	}
@@ -300,6 +302,7 @@ func NewClient(apiEndpoint, apiKey string, metricsPerBatch uint, compressPayload
 		DialContext: (&net.Dialer{
 			Timeout:   5 * time.Second,
 			KeepAlive: 30 * time.Second,
+			DualStack: dualStack,
 		}).DialContext,
 		MaxIdleConns:    50,
 		IdleConnTimeout: 1 * time.Minute,

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -37,7 +37,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", defaultMetricsPerBatch, true, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", defaultMetricsPerBatch, true, false, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -66,7 +66,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", 1, true, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", 1, true, false, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -118,7 +118,7 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	cli, err := NewClient(ts.URL, "apiKey123", 1000, true, 1*time.Second, 2*time.Second)
+	cli, err := NewClient(ts.URL, "apiKey123", 1000, true, false, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	cli.now = func() time.Time {
 		return time.Unix(100, 0)


### PR DESCRIPTION
Datadog recently started publishing AAAA records.  Environments without IPv6 can have a bad time due to network unreachable errors.

Also reworded the compression changelog to be more explicit.