### PR TITLE
Add flags for explicit ipv4/ipv6 control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 3.x.x
 -----
 - BREAKING: use space instead of comma to specify multiple values for the following parameters: `backends`,
-`percent-threshold`, `default-tags` and `internal-tags`.
+  `percent-threshold`, `default-tags` and `internal-tags`.
+- BREAKING: Removed Datadog `dual_stack` option in favor of explicit network selection.
+- New Datadog option: `network` allows control of the network protocol used, typical values are `tcp`,
+  `tcp4`, or `tcp6`.  Defaults `tcp`.  See [Dial](https://golang.org/pkg/net/#Dial) for further information.
 
 2.4.2
 -----

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -37,7 +37,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", defaultMetricsPerBatch, true, false, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", defaultMetricsPerBatch, true, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -66,7 +66,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", 1, true, false, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", 1, true, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -118,7 +118,7 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	cli, err := NewClient(ts.URL, "apiKey123", 1000, true, false, 1*time.Second, 2*time.Second)
+	cli, err := NewClient(ts.URL, "apiKey123", "tcp", 1000, true, 1*time.Second, 2*time.Second)
 	require.NoError(t, err)
 	cli.now = func() time.Time {
 		return time.Unix(100, 0)


### PR DESCRIPTION
Happy eyeballs might be good for browsers, but at this volume it is better to be explicit than to guess.