### PR TITLE
Handle zero-value expiry interval

### DIFF
--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -175,7 +175,7 @@ func (a *MetricAggregator) isExpired(now, ts gostatsd.Nanotime) bool {
 		return true
 	}
 
-	return a.expiryInterval != 0 && time.Duration(now-ts) > a.expiryInterval
+	return time.Duration(now-ts) > a.expiryInterval
 }
 
 func deleteMetric(key, tagsKey string, metrics gostatsd.AggregatedMetrics) {

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -171,6 +171,10 @@ func (a *MetricAggregator) Process(f ProcessFunc) {
 }
 
 func (a *MetricAggregator) isExpired(now, ts gostatsd.Nanotime) bool {
+	if a.expiryInterval == 0 {
+		return true
+	}
+
 	return a.expiryInterval != 0 && time.Duration(now-ts) > a.expiryInterval
 }
 

--- a/pkg/statsd/aggregator_test.go
+++ b/pkg/statsd/aggregator_test.go
@@ -270,7 +270,7 @@ func TestIsExpired(t *testing.T) {
 	now := gostatsd.Nanotime(time.Now().UnixNano())
 
 	ma := &MetricAggregator{expiryInterval: 0}
-	assrt.Equal(false, ma.isExpired(now, now))
+	assrt.Equal(true, ma.isExpired(now, now))
 
 	ma.expiryInterval = 10 * time.Second
 


### PR DESCRIPTION
The `ParamExpiryInterval` flag says that setting it to zero should disable the expiry interval for metrics, immediately expiring them. However, setting it to zero effectively makes it an infinite interval, sending a zero-valued metric on every flush interval indefinitely.

Current logic says an expiryInterval of zero is never expired. Added quick check to handle zero, which sends the metric once without repeating zero-value sends.