### PR TITLE
Add node tracking as start of clustering support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ METALINTER_CONCURRENCY ?= 4
 GOVERSION := 1.9
 GP := /gopath
 MAIN_PKG := github.com/atlassian/gostatsd/cmd/gostatsd
+CLUSTER_PKG := github.com/atlassian/gostatsd/cmd/cluster
 
 setup: setup-ci
 	go get -u github.com/githubnemo/CompileDaemon
@@ -23,6 +24,9 @@ setup-ci:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 	glide install --strip-vendor
+
+build-cluster: fmt
+	go build -i -v -o build/bin/$(ARCH)/cluster $(GOBUILD_VERSION_ARGS) $(CLUSTER_PKG)
 
 build: fmt
 	go build -i -v -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS) $(MAIN_PKG)

--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	// BuildDate is the date when the binary was built.
+	BuildDate string
+	// GitCommit is the commit hash that built the binary.
+	GitCommit string
+	// Version is the version.
+	Version string
+)
+
+func main() {
+	fmt.Printf("Version: %s - Commit: %s - Date: %s\n", Version, GitCommit, BuildDate)
+	rand.Seed(time.Now().UnixNano())
+	c := newCluster()
+	c.AddFlags(pflag.CommandLine)
+	pflag.Parse()
+	c.Run()
+}

--- a/cmd/cluster/server.go
+++ b/cmd/cluster/server.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/atlassian/gostatsd/pkg/cluster/nodes"
+	"github.com/spf13/pflag"
+)
+
+// Cluster is everything for running a single node in a cluster
+type Cluster struct {
+	RedisAddr      string
+	Namespace      string
+	Target         string
+	UpdateInterval time.Duration
+	ExpiryInterval time.Duration
+}
+
+// newCluster will create a new Cluster with default values.
+func newCluster() *Cluster {
+	local, _ := nodes.LocalAddress("1.1.1.1:1")
+
+	return &Cluster{
+		RedisAddr:      "127.0.0.1:6379",
+		Namespace:      "namespace",
+		Target:         local.String() + ":8125",
+		UpdateInterval: time.Second,
+		ExpiryInterval: 30 * time.Second,
+	}
+}
+
+// AddFlags adds flags for a specific Server to the specified FlagSet.
+func (c *Cluster) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&c.RedisAddr, "redis-addr", c.RedisAddr, "Redis address")
+	fs.StringVar(&c.Namespace, "namespace", c.Namespace, "Namespace")
+	fs.StringVar(&c.Target, "target", c.Target, "Target port")
+	fs.DurationVar(&c.UpdateInterval, "update-interval", c.UpdateInterval, "Cluster update interval")
+	fs.DurationVar(&c.ExpiryInterval, "expiry-interval", c.ExpiryInterval, "Cluster expiry interval")
+}
+
+// Run runs the specified Cluster.
+func (c *Cluster) Run() error {
+	rnt := nodes.NewRedisNodeTracker(c.RedisAddr, c.Namespace, c.Target, c.UpdateInterval, c.ExpiryInterval)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rnt.Run(ctx)
+
+	t := time.NewTicker(time.Second)
+
+	for range t.C {
+		nodes := rnt.List()
+		fmt.Printf("%v\n", nodes)
+	}
+
+	return nil
+}

--- a/cmd/cluster/server.go
+++ b/cmd/cluster/server.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atlassian/gostatsd/pkg/cluster/nodes"
 	"github.com/spf13/pflag"
+
+	"github.com/atlassian/gostatsd/pkg/cluster/nodes"
 )
 
 // Cluster is everything for running a single node in a cluster
@@ -48,6 +49,7 @@ func (c *Cluster) Run() error {
 	go rnt.Run(ctx)
 
 	t := time.NewTicker(time.Second)
+	defer t.Stop()
 
 	for range t.C {
 		nodes := rnt.List()

--- a/cover.sh
+++ b/cover.sh
@@ -16,9 +16,9 @@ declare -a packages=('' \
     'pkg/backends' 'pkg/backends/sender'
     'pkg/backends/datadog' 'pkg/backends/graphite' 'pkg/backends/null' \
     'pkg/backends/statsdaemon' 'pkg/backends/stdout' \
-    'pkg/cloudproviders' 'pkg/cloudproviders//aws' \
+    'pkg/cloudproviders' 'pkg/cloudproviders/aws' \
     'pkg/fakesocket' 'pkg/statsd' \
-    'pkg/statser' );
+    'pkg/statser' 'pkg/cluster/nodes' );
 
 # Test each package and append coverage profile info to coverage.out
 for pkg in "${packages[@]}"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fdf4018ae9b84733c195dada851eac7cb7c89df73d8acbf994fe3c42ca872554
-updated: 2017-09-11T21:24:04.582401251+10:00
+hash: e7ebc0bc29af8173d4988df8fa078f3b6548c38ccac8711bb06e9d103eb9aa30
+updated: 2017-09-14T16:48:26.199245523+10:00
 imports:
 - name: github.com/ash2k/stager
   version: 6e9c7b0eacd465286fac042bfb29a170aa8c2c3f
@@ -37,9 +37,17 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-ini/ini
-  version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
+  version: c787282c39ac1fc618827141a1f762240def08a3
+- name: github.com/go-redis/redis
+  version: fdafb11e5fa5d52d965e12073c8a58468c98ebe2
+  subpackages:
+  - internal
+  - internal/consistenthash
+  - internal/hashtag
+  - internal/pool
+  - internal/proto
 - name: github.com/hashicorp/hcl
-  version: 8f6b1344a92ff8877cf24a5de9177bf7d0a2a187
+  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -50,25 +58,25 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/jmespath/go-jmespath
-  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/magiconair/properties
-  version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
+  version: be5ece7dd465ab0765a9682137865547526d1dfb
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/pelletier/go-toml
-  version: 1d6b12b7cb290426e27e6b4e38b89fcda3aeef03
+  version: 4692b8f9babfc93db58cc592ba2689d8736781de
 - name: github.com/sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
 - name: github.com/spf13/afero
-  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
+  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/jwalterweatherman
-  version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
+  version: 0efa5202c04663c757d84f90f5219c1250baf94f
 - name: github.com/spf13/pflag
-  version: dabebe21bf790f782ea4c7bbd2efc430de182afd
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/testify
@@ -76,6 +84,10 @@ imports:
   subpackages:
   - assert
   - require
+- name: golang.org/x/crypto
+  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
@@ -84,9 +96,10 @@ imports:
   - http2/hpack
   - lex/httplex
 - name: golang.org/x/sys
-  version: 002cbb5f952456d0c50e0d2aff17ea5eca716979
+  version: 43e60d72a8e2bd92ee98319ba9a384a0e9837c08
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,5 @@ import:
   subpackages:
   - http2
 - package: github.com/ash2k/stager
+- package: github.com/go-redis/redis
+  version: ^6.6.1

--- a/pkg/cluster/nodes/nodes.go
+++ b/pkg/cluster/nodes/nodes.go
@@ -1,0 +1,49 @@
+package nodes
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// NodeTracker is an interface for tracking and selecting nodes in a cluster
+type NodeTracker interface {
+	// Runs the node tracker until the context is closed.
+	Run(ctx context.Context)
+
+	// List returns a list of all nodes being tracked.  The list returned will be
+	// a copy of the underlying list of nodes.  Intended for admin interfaces,
+	// not performance critical code.  Thread safe.
+	List() []string
+
+	// Select will use the provided key to pick a node from the list of tracked
+	// nodes and return it.  Returns an error if there are no nodes available.
+	// Thread safe.
+	Select(key uint64) (string, error)
+}
+
+type node struct {
+	nodeid string
+	expiry time.Time
+}
+
+type nodeList []*node
+
+func (nl nodeList) Len() int           { return len(nl) }
+func (nl nodeList) Swap(i, j int)      { nl[i], nl[j] = nl[j], nl[i] }
+func (nl nodeList) Less(i, j int) bool { return nl[i].nodeid < nl[j].nodeid }
+
+// LocalAddress is a helper function to return the local IP address that would
+// be used to connect to a specified target.  Useful to get the IP that should
+// be advertised externally.
+func LocalAddress(target string) (net.IP, error) {
+	// Mostly lifted from https://stackoverflow.com/questions/23558425/how-do-i-get-the-local-ip-address-in-go
+	conn, err := net.Dial("udp", target)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP, nil
+}

--- a/pkg/cluster/nodes/nodes_redis.go
+++ b/pkg/cluster/nodes/nodes_redis.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	errNoNodes = errors.New("No nodes available")
+	errNoNodes = errors.New("no nodes available")
 )
 
 type redisNodeTracker struct {

--- a/pkg/cluster/nodes/nodes_redis.go
+++ b/pkg/cluster/nodes/nodes_redis.go
@@ -1,0 +1,167 @@
+package nodes
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	errNoNodes = errors.New("No nodes available")
+)
+
+type redisNodeTracker struct {
+	client    *redis.Client
+	namespace string
+	nodeid    string
+	nodes     nodeList
+
+	updateInterval time.Duration
+	expiryInterval time.Duration
+
+	rw sync.RWMutex // protects the nodes list, not the individual members in the list
+
+	// for testing
+	now func() time.Time
+}
+
+// NewRedisNodeTracker returns a NodeTracker based on a Redis backend
+func NewRedisNodeTracker(redisAddr, namespace, nodeid string, updateInterval, expiryInterval time.Duration) NodeTracker {
+	options := &redis.Options{
+		Addr: redisAddr,
+		DB:   0,
+	}
+
+	return &redisNodeTracker{
+		client:    redis.NewClient(options),
+		namespace: namespace,
+		nodeid:    nodeid,
+		nodes:     make(nodeList, 0, 10),
+
+		updateInterval: updateInterval,
+		expiryInterval: expiryInterval,
+
+		now: time.Now,
+	}
+}
+
+// Run will track nodes via Redis PubSub until the context is closed.
+func (rnt *redisNodeTracker) Run(ctx context.Context) {
+	pubsub := rnt.client.Subscribe(rnt.namespace)
+	defer pubsub.Close()
+
+	ticker := time.NewTicker(rnt.updateInterval)
+	defer ticker.Stop()
+
+	psChan := pubsub.Channel() // Closed when pubsub is Closed
+
+	rnt.emitPresence()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rnt.expireNodes()
+			if rnt.nodeid != "" {
+				err := rnt.emitPresence()
+				if err != nil {
+					logrus.Warningf("Failed to check in to cluster")
+				}
+			}
+		case msg := <-psChan:
+			// TODO: Validate msg
+			rnt.updateNode(msg.Payload)
+		}
+	}
+}
+
+// List returns a list of all the nodes currently tracked.  Intended for admin
+// interface, not general usage.  It is more expensive than Select.  Thread safe.
+func (rnt *redisNodeTracker) List() []string {
+	// Does not talk to Redis
+	rnt.rw.RLock()
+	defer rnt.rw.RUnlock()
+	nodes := make([]string, len(rnt.nodes))
+	for idx, node := range rnt.nodes {
+		nodes[idx] = node.nodeid
+	}
+	return nodes
+}
+
+// Select will use the provided key to pick a node and return it.  An error will
+// be returned if no nodes are available.  Thread safe.
+func (rnt *redisNodeTracker) Select(key uint64) (string, error) {
+	// Does not talk to Redis
+	rnt.rw.RLock()
+	defer rnt.rw.RUnlock()
+	if len(rnt.nodes) == 0 {
+		return "", errNoNodes
+	}
+	return rnt.nodes[key%uint64(len(rnt.nodes))].nodeid, nil
+}
+
+// expireNodes will expire nodes which have not updated recently enough. Thread safe,
+// but takes the write lock.
+func (rnt *redisNodeTracker) expireNodes() {
+	// Does not talk to Redis
+	now := rnt.now()
+	rnt.rw.Lock()
+	defer rnt.rw.Unlock()
+
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	nodes := rnt.nodes[:0]
+	for _, node := range rnt.nodes {
+		if now.Before(node.expiry) {
+			// 	Keep it
+			nodes = append(nodes, node)
+		}
+	}
+	rnt.nodes = nodes
+}
+
+// updateNode will attempt to update the expiry on an existing node, if it
+// doesn't exist, it will be added under the write lock.
+func (rnt *redisNodeTracker) updateNode(nodeid string) {
+	// Does not talk to Redis
+	if rnt.tryUpdateExistingNode(nodeid) {
+		return
+	}
+
+	node := &node{
+		nodeid: nodeid,
+		expiry: rnt.now().Add(5 * time.Second),
+	}
+
+	rnt.rw.Lock()
+	defer rnt.rw.Unlock()
+	rnt.nodes = append(rnt.nodes, node)
+	sort.Sort(rnt.nodes)
+}
+
+// tryUpdateExistingNode will update a nodes expiry time in place if it exists
+// and returns true if it succeeds.  Prevents taking the write lock.
+func (rnt *redisNodeTracker) tryUpdateExistingNode(nodeid string) bool {
+	// Does not talk to redis
+	rnt.rw.RLock()
+	defer rnt.rw.RUnlock()
+	for _, node := range rnt.nodes {
+		if node.nodeid == nodeid {
+			node.expiry = rnt.now().Add(5 * time.Second)
+			return true
+		}
+	}
+	return false
+}
+
+// emitPresence will announce the presence of this node to the PubSub endpoint
+func (rnt *redisNodeTracker) emitPresence() error {
+	// Talks to redis
+	cmd := rnt.client.Publish(rnt.namespace, rnt.nodeid)
+	return cmd.Err()
+}

--- a/pkg/cluster/nodes/nodes_redis_test.go
+++ b/pkg/cluster/nodes/nodes_redis_test.go
@@ -23,6 +23,8 @@ func (ft *fakeTime) Now() time.Time {
 }
 
 func TestLearnNode(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 
 	rnt := &redisNodeTracker{
@@ -50,6 +52,8 @@ func TestLearnNode(t *testing.T) {
 }
 
 func TestLearnMultipleNodes(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 
 	rnt := &redisNodeTracker{
@@ -79,6 +83,8 @@ func TestLearnMultipleNodes(t *testing.T) {
 }
 
 func TestForgetNodes(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 
 	rnt := &redisNodeTracker{
@@ -113,6 +119,8 @@ func TestForgetNodes(t *testing.T) {
 }
 
 func TestUpdateExistingNode(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 
 	rnt := &redisNodeTracker{

--- a/pkg/cluster/nodes/nodes_redis_test.go
+++ b/pkg/cluster/nodes/nodes_redis_test.go
@@ -1,0 +1,212 @@
+package nodes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeTime struct {
+	samples []time.Time
+	next    int
+}
+
+func (ft *fakeTime) Now() time.Time {
+	t := ft.samples[ft.next]
+	ft.next = (ft.next + 1) % len(ft.samples)
+	fmt.Printf("%v\n", t)
+	return t
+}
+
+func TestLearnNode(t *testing.T) {
+	now := time.Now()
+
+	rnt := &redisNodeTracker{
+		updateInterval: 1 * time.Second,
+		expiryInterval: 5 * time.Second,
+		now: (&fakeTime{
+			samples: []time.Time{
+				now.Add(time.Second),
+			},
+		}).Now,
+	}
+
+	// Empty
+	node, err := rnt.Select(0)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", node)
+
+	// Update internal tracking
+	rnt.updateNode("127.0.0.1:80")
+
+	// Present
+	node, err = rnt.Select(0)
+	assert.Nil(t, err)
+	assert.Equal(t, "127.0.0.1:80", node)
+}
+
+func TestLearnMultipleNodes(t *testing.T) {
+	now := time.Now()
+
+	rnt := &redisNodeTracker{
+		updateInterval: 1 * time.Second,
+		expiryInterval: 5 * time.Second,
+		now: (&fakeTime{
+			samples: []time.Time{
+				now.Add(time.Second),
+			},
+		}).Now,
+	}
+
+	// Empty
+	node, err := rnt.Select(0)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", node)
+
+	// Update internal tracking with multiple nodes (out of sort order)
+	rnt.updateNode("127.0.0.2:80")
+	rnt.updateNode("127.0.0.1:80")
+
+	nodes := rnt.List()
+	assert.Equal(t, nodes, []string{
+		"127.0.0.1:80",
+		"127.0.0.2:80",
+	})
+}
+
+func TestForgetNodes(t *testing.T) {
+	now := time.Now()
+
+	rnt := &redisNodeTracker{
+		updateInterval: 1 * time.Second,
+		expiryInterval: 5 * time.Second,
+		now: (&fakeTime{
+			samples: []time.Time{
+				now,
+				now.Add(1000 * time.Millisecond),
+				now.Add(5500 * time.Millisecond),
+			},
+		}).Now,
+	}
+
+	// Empty
+	node, err := rnt.Select(0)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", node)
+
+	// Update internal tracking with multiple nodes
+	rnt.updateNode("127.0.0.1:80") // time.sample[0] - will expire
+	rnt.updateNode("127.0.0.2:80") // time.sample[1] - will not expire
+	rnt.expireNodes()              // time.sample[2]
+
+	node, err = rnt.Select(0)
+	assert.Nil(t, err)
+	assert.Equal(t, "127.0.0.2:80", node)
+
+	node, err = rnt.Select(1)
+	assert.Nil(t, err)
+	assert.Equal(t, "127.0.0.2:80", node)
+}
+
+func TestUpdateExistingNode(t *testing.T) {
+	now := time.Now()
+
+	rnt := &redisNodeTracker{
+		updateInterval: 1 * time.Second,
+		expiryInterval: 5 * time.Second,
+		now: (&fakeTime{
+			samples: []time.Time{
+				now,
+				now.Add(1000 * time.Millisecond),
+				now.Add(5500 * time.Millisecond),
+			},
+		}).Now,
+	}
+
+	// Empty
+	node, err := rnt.Select(0)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", node)
+
+	// Update internal tracking with multiple nodes
+	rnt.updateNode("127.0.0.1:80") // time.sample[0] - now
+	rnt.updateNode("127.0.0.1:80") // time.sample[1] - now+1 - refreshes timestamp
+	rnt.expireNodes()              // time.sample[2] - now+5.5
+
+	// Make sure only one node
+	nodes := rnt.List()
+	assert.Equal(t, nodes, []string{
+		"127.0.0.1:80",
+	})
+}
+
+var s string
+var e error
+var ss []string
+
+func BenchmarkSelects(b *testing.B) {
+	rnt := &redisNodeTracker{
+		now: time.Now,
+	}
+
+	rnt.updateNode("127.0.0.1:80")
+	rnt.updateNode("127.0.0.2:80")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		s, e = rnt.Select(uint64(n))
+	}
+}
+
+func BenchmarkLists(b *testing.B) {
+	rnt := &redisNodeTracker{
+		now: time.Now,
+	}
+
+	rnt.updateNode("127.0.0.1:80")
+	rnt.updateNode("127.0.0.2:80")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ss = rnt.List()
+	}
+}
+
+func BenchmarkParallelSelects(b *testing.B) {
+	rnt := &redisNodeTracker{
+		now: time.Now,
+	}
+
+	rnt.updateNode("127.0.0.1:80")
+	rnt.updateNode("127.0.0.2:80")
+
+	// Create contention on the lock
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				rnt.updateNode("127.0.0.1:80")
+				rnt.updateNode("127.0.0.2:80")
+			}
+		}
+	}()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		s, e = rnt.Select(uint64(n))
+	}
+	b.StopTimer()
+
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
Start of adding clustering.  The cluster binary is a place where things can live for now.

No metrics emitted yet, because I need to understand what sending metrics from a cluster FE/BE actually looks like.