### PR TITLE
MetricReceiver.Receive batch read optimisation

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -9,6 +9,8 @@ This documents the metrics and tags emitted by gostatsd, their type, tags, and i
 | events_received              | counter |                 | The number of events received
 | metrics_received             | counter |                 | The number of metrics received
 | packets_received             | counter |                 | The number of packets received
+| avg_packets_in_batch         | gauge   |                 | The average number of packets read in a batch (up to receive-batch-size).
+|                              |         |                 | This can be used to tweak receive-batch-size if necessary to reduce memory usage
 | channel.capacity             | gauge   | channel         | The capacity of the channel
 | channel.queued               | gauge   | channel         | The absolute amount of items in a channel
 | channel.pct_used             | gauge   | channel         | The percentage of how full a channel is

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Running the server
 defaults. You can use `make run` to run the server with just the `stdout` backend
 to display info on screen.
 You can also run through `docker` by running `make run-docker` which will use `docker-compose`
-to run `gostatsd` with a graphite backend and a grafana dashboard. 
+to run `gostatsd` with a graphite backend and a grafana dashboard.
 
 Configuring backends and cloud providers
 ----------------------------------------
@@ -106,6 +106,15 @@ Load balancing and scaling out
 ------------------------------
 It is possible to run multiple versions of `gostatsd` behind a load balancer by having them
 send their metrics to another `gostatsd` backend which will then send to the final backends.
+
+Memory allocation for read buffers
+----------------------------------
+By default `gostatsd` will batch read multiple packets to optimise read performance. The amount of memory allocated
+for these read buffers is determined by the config options:
+
+    max-readers * receive-batch-size * 64KB (max packet size)
+
+The metric `avg_packets_in_batch` can be used to tune this memory usage if necessary.
 
 Using the library
 -----------------

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -123,6 +123,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		Namespace:           v.GetString(statsd.ParamNamespace),
 		PercentThreshold:    pt,
 		HeartbeatInterval:   v.GetDuration(statsd.ParamHeartbeatInterval),
+		ReceiveBatchSize:    v.GetInt(statsd.ParamReceiveBatchSize),
 		CacheOptions: statsd.CacheOptions{
 			CacheRefreshPeriod:        v.GetDuration(statsd.ParamCacheRefreshPeriod),
 			CacheEvictAfterIdlePeriod: v.GetDuration(statsd.ParamCacheEvictAfterIdlePeriod),

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -44,6 +44,7 @@ func main() {
 			MaxWorkers:       statsd.DefaultMaxWorkers,
 			MaxQueueSize:     statsd.DefaultMaxQueueSize,
 			PercentThreshold: statsd.DefaultPercentThreshold,
+			ReceiveBatchSize: statsd.DefaultReceiveBatchSize,
 			Viper:            viper.New(),
 		}
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(s.Benchmark)*time.Second)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e7ebc0bc29af8173d4988df8fa078f3b6548c38ccac8711bb06e9d103eb9aa30
-updated: 2017-09-14T16:48:26.199245523+10:00
+hash: 048701c983fc0bb8c64675fce1fb524a612062529e2db1f12dfde1545f2647f8
+updated: 2017-09-28T18:15:21.699780645+10:00
 imports:
 - name: github.com/ash2k/stager
   version: 6e9c7b0eacd465286fac042bfb29a170aa8c2c3f
@@ -33,13 +33,13 @@ imports:
   - service/ec2
   - service/sts
 - name: github.com/cenkalti/backoff
-  version: 61153c768f31ee5f130071d08fc82b85208528de
+  version: 61ba96c4d1002f22e06acb8e34a7650611125a63
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-ini/ini
   version: c787282c39ac1fc618827141a1f762240def08a3
 - name: github.com/go-redis/redis
-  version: fdafb11e5fa5d52d965e12073c8a58468c98ebe2
+  version: 975882d73d21759d45a4eb49652064083bc23e61
   subpackages:
   - internal
   - internal/consistenthash
@@ -47,7 +47,7 @@ imports:
   - internal/pool
   - internal/proto
 - name: github.com/hashicorp/hcl
-  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
+  version: 68e816d1c783414e79bc65b3994d9ab6b0a722ab
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -60,23 +60,23 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
+  version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/pelletier/go-toml
-  version: 4692b8f9babfc93db58cc592ba2689d8736781de
+  version: 16398bac157da96aa88f98a2df640c7f32af1da2
 - name: github.com/sirupsen/logrus
-  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
-  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
+  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/jwalterweatherman
-  version: 0efa5202c04663c757d84f90f5219c1250baf94f
+  version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 7aff26db30c1be810f9de5038ec5ef96ac41fd7c
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/testify
@@ -85,32 +85,39 @@ imports:
   - assert
   - require
 - name: golang.org/x/crypto
-  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  version: c84b36c635ad003a10f0c755dff5685ceef18c71
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: 0a9397675ba34b2845f758fe3cd68828369c6517
   subpackages:
+  - bpf
   - context
   - http2
   - http2/hpack
+  - idna
+  - internal/iana
+  - internal/socket
+  - ipv6
   - lex/httplex
 - name: golang.org/x/sys
-  version: 43e60d72a8e2bd92ee98319ba9a384a0e9837c08
+  version: 314a259e304ff91bd6985da2a7149bbf91237993
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
   subpackages:
+  - secure/bidirule
   - transform
+  - unicode/bidi
   - unicode/norm
 - name: golang.org/x/time
-  version: 8be79e1e0910c292df4e79c241bb7e8f7e725959
+  version: 6dc17368e09b0e8634d71cac8168d853e869a0c7
   subpackages:
   - rate
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports:
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,6 +20,7 @@ import:
 - package: golang.org/x/net
   subpackages:
   - http2
+  - ipv6
 - package: github.com/ash2k/stager
 - package: github.com/go-redis/redis
   version: ^6.6.1

--- a/pkg/fakesocket/fake.go
+++ b/pkg/fakesocket/fake.go
@@ -21,7 +21,7 @@ var FakeAddr = &net.UDPAddr{
 var ErrClosedConnection = errors.New("Connection is closed")
 var ErrAlreadyClosedConnection = errors.New("Connection is already closed")
 
-// FakePacketConn is a fake net.PacketConn providing FakeMetric when read from.
+// FakePacketConn is a fake net.PacketConn (and net.Conn) providing FakeMetric when read from.
 type FakePacketConn struct {
 	closed chan struct{}
 }
@@ -73,6 +73,23 @@ func (fpc *FakePacketConn) SetReadDeadline(t time.Time) error { return nil }
 
 // SetWriteDeadline dummy impl.
 func (fpc *FakePacketConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// Read copies FakeMetric into b
+// To satisfy net.Conn
+func (fpc *FakePacketConn) Read(b []byte) (int, error) {
+	n, _, err := fpc.ReadFrom(b)
+	return n, err
+}
+
+// WriteTo dummy impl.
+// To satisfy net.Conn
+func (fpc *FakePacketConn) Write(b []byte) (int, error) {
+	return fpc.WriteTo(b, FakeAddr)
+}
+
+// RemoteAddr dummy impl.
+// To satisfy net.Conn
+func (fpc *FakePacketConn) RemoteAddr() net.Addr { return FakeAddr }
 
 // FakeRandomPacketConn is a fake net.PacketConn providing random fake metrics.
 type FakeRandomPacketConn struct {

--- a/pkg/statsd/batched_reader.go
+++ b/pkg/statsd/batched_reader.go
@@ -1,0 +1,71 @@
+package statsd
+
+import (
+	"net"
+
+	"golang.org/x/net/ipv6"
+)
+
+type Message struct {
+	Buffers [][]byte
+	Addr    net.Addr
+	N       int
+}
+
+type BatchReader interface {
+	ReadBatch(ms []Message) (int, error)
+}
+
+type V6BatchReader struct {
+	conn *ipv6.PacketConn
+}
+
+type GenericBatchReader struct {
+	conn net.PacketConn
+}
+
+func NewBatchReader(conn net.PacketConn) BatchReader {
+	switch c := conn.(type) {
+	case *net.UDPConn:
+		return &V6BatchReader{
+			conn: ipv6.NewPacketConn(c),
+		}
+	default:
+		return &GenericBatchReader{
+			conn: conn,
+		}
+	}
+}
+
+func (br *V6BatchReader) ReadBatch(ms []Message) (int, error) {
+	ms6 := make([]ipv6.Message, len(ms))
+	for i, m := range ms {
+		ms6[i].Buffers = m.Buffers
+	}
+	count, err := br.conn.ReadBatch(ms6, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	for i := 0; i < count; i++ {
+		ms[i].Addr = ms6[i].Addr
+		ms[i].N = ms6[i].N
+	}
+
+	return count, nil
+}
+
+func (gbr *GenericBatchReader) ReadBatch(ms []Message) (int, error) {
+	if len(ms) == 0 {
+		// This tends to happen in test code when the batch size is not set,
+		// if production code starts at all, then a panic won't be a hazard.
+		panic("attempt to read 0 packets")
+	}
+	nbytes, addr, err := gbr.conn.ReadFrom(ms[0].Buffers[0])
+	if err != nil {
+		return 0, err
+	}
+	ms[0].Addr = addr
+	ms[0].N = nbytes
+	return 1, nil
+}

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -58,11 +58,15 @@ func (mr *MetricReceiver) RunMetrics(ctx context.Context) {
 			return
 		case <-ticker.C:
 			packetsReceived := float64(atomic.SwapUint64(&mr.packetsReceived, 0))
+			batchesRead := atomic.SwapUint64(&mr.batchesRead, 0)
+			if batchesRead == 0 {
+				batchesRead = 1
+			}
 			mr.statser.Count("packets_received", packetsReceived, nil)
 			mr.statser.Count("metrics_received", float64(atomic.SwapUint64(&mr.metricsReceived, 0)), nil)
 			mr.statser.Count("events_received", float64(atomic.SwapUint64(&mr.eventsReceived, 0)), nil)
 			mr.statser.Count("bad_lines_seen", float64(atomic.SwapUint64(&mr.badLines, 0)), nil)
-			mr.statser.Gauge("avg_packets_in_batch", packetsReceived/float64(atomic.SwapUint64(&mr.batchesRead, 0)), nil)
+			mr.statser.Gauge("avg_packets_in_batch", packetsReceived/float64(batchesRead), nil)
 		}
 	}
 }

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -59,14 +59,17 @@ func (mr *MetricReceiver) RunMetrics(ctx context.Context) {
 		case <-ticker.C:
 			packetsReceived := float64(atomic.SwapUint64(&mr.packetsReceived, 0))
 			batchesRead := atomic.SwapUint64(&mr.batchesRead, 0)
+			var avgPacketsInBatch float64
 			if batchesRead == 0 {
-				batchesRead = 1
+				avgPacketsInBatch = 0
+			} else {
+				avgPacketsInBatch = packetsReceived / float64(batchesRead)
 			}
 			mr.statser.Count("packets_received", packetsReceived, nil)
 			mr.statser.Count("metrics_received", float64(atomic.SwapUint64(&mr.metricsReceived, 0)), nil)
 			mr.statser.Count("events_received", float64(atomic.SwapUint64(&mr.eventsReceived, 0)), nil)
 			mr.statser.Count("bad_lines_seen", float64(atomic.SwapUint64(&mr.badLines, 0)), nil)
-			mr.statser.Gauge("avg_packets_in_batch", packetsReceived/float64(batchesRead), nil)
+			mr.statser.Gauge("avg_packets_in_batch", avgPacketsInBatch, nil)
 		}
 	}
 }

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -3,7 +3,6 @@ package statsd
 import (
 	"context"
 	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/atlassian/gostatsd"
@@ -175,21 +174,6 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 			assert.Equal(t, mAndE.events, ch.events)
 			assert.Equal(t, mAndE.metrics, ch.metrics)
 		})
-	}
-}
-
-func BenchmarkReceive(b *testing.B) {
-	mr := &MetricReceiver{
-		handler: nopHandler{},
-	}
-	c := fakesocket.NewFakePacketConn()
-	ctx := context.Background()
-	var wg sync.WaitGroup
-	wg.Add(b.N)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		mr.Receive(ctx, c)
 	}
 }
 

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -178,7 +178,7 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 	}
 }
 
-func BenchmarkReceiveX(b *testing.B) {
+func BenchmarkReceive(b *testing.B) {
 	mr := &MetricReceiver{
 		handler:          nopHandler{},
 		receiveBatchSize: 1,

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -31,7 +31,7 @@ func TestReceiveEmptyPacket(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser())
+			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser(), 50)
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, inp)
 			require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestReceivePacket(t *testing.T) {
 		t.Run(packet, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser())
+			mr := NewMetricReceiver("", false, ch, statser.NewNullStatser(), 50)
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 			assert.NoError(t, err)
@@ -162,7 +162,7 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 		t.Run(packet, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewMetricReceiver("", true, ch, statser.NewNullStatser())
+			mr := NewMetricReceiver("", true, ch, statser.NewNullStatser(), 50)
 
 			err := mr.handlePacket(context.Background(), fakesocket.FakeAddr, []byte(packet))
 			assert.NoError(t, err)

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -176,16 +176,3 @@ func TestReceivePacketIgnoreHost(t *testing.T) {
 		})
 	}
 }
-
-type nopHandler struct{}
-
-func (h nopHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
-	return context.Canceled // Stops receiver after first read is done
-}
-
-func (h nopHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
-	return context.Canceled // Stops receiver after first read is done
-}
-
-func (h nopHandler) WaitForEvents() {
-}

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -38,6 +38,7 @@ type Server struct {
 	PercentThreshold    []float64
 	HeartbeatInterval   time.Duration
 	HeartbeatTags       gostatsd.Tags
+	ReceiveBatchSize    int
 	CacheOptions
 	Viper *viper.Viper
 }
@@ -137,7 +138,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 		}
 	}()
 
-	receiver := NewMetricReceiver(s.Namespace, s.IgnoreHost, handler, statser)
+	receiver := NewMetricReceiver(s.Namespace, s.IgnoreHost, handler, statser, s.ReceiveBatchSize)
 	stage.StartWithContext(receiver.RunMetrics)
 	for r := 0; r < s.MaxReaders; r++ {
 		stage.StartWithContext(func(ctx context.Context) {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -8,8 +8,6 @@ import (
 	"github.com/atlassian/gostatsd"
 
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"golang.org/x/time/rate"
 )
 
 // DefaultBackends is the list of default backends' names.
@@ -111,31 +109,6 @@ const (
 	// ParamReceiveBatchSize is the name of the parameter with the number of packets to read in each receive batch
 	ParamReceiveBatchSize = "receive-batch-size"
 )
-
-// NewServer will create a new Server with the default configuration.
-func NewServer() *Server {
-	return &Server{
-		Limiter:             rate.NewLimiter(DefaultMaxCloudRequests, DefaultBurstCloudRequests),
-		DefaultTags:         DefaultTags,
-		ExpiryInterval:      DefaultExpiryInterval,
-		FlushInterval:       DefaultFlushInterval,
-		IgnoreHost:          DefaultIgnoreHost,
-		MaxReaders:          DefaultMaxReaders,
-		MaxWorkers:          DefaultMaxWorkers,
-		MaxQueueSize:        DefaultMaxQueueSize,
-		MaxConcurrentEvents: DefaultMaxConcurrentEvents,
-		MetricsAddr:         DefaultMetricsAddr,
-		PercentThreshold:    DefaultPercentThreshold,
-		HeartbeatInterval:   DefaultHeartbeatInterval,
-		CacheOptions: CacheOptions{
-			CacheRefreshPeriod:        DefaultCacheRefreshPeriod,
-			CacheEvictAfterIdlePeriod: DefaultCacheEvictAfterIdlePeriod,
-			CacheTTL:                  DefaultCacheTTL,
-			CacheNegativeTTL:          DefaultCacheNegativeTTL,
-		},
-		Viper: viper.New(),
-	}
-}
 
 // AddFlags adds flags to the specified FlagSet.
 func AddFlags(fs *pflag.FlagSet) {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -59,6 +59,8 @@ const (
 	DefaultInternalNamespace = "statsd"
 	// DefaultHeartbeatInterval is the default heartbeat interval (0 for disabled)
 	DefaultHeartbeatInterval = time.Duration(0)
+	// DefaultReceiveBatchSize is the number of packets to read in each receive batch
+	DefaultReceiveBatchSize = 50
 )
 
 const (
@@ -106,6 +108,8 @@ const (
 	ParamPercentThreshold = "percent-threshold"
 	// ParamHeartbeatInterval is the name of the parameter with the heartbeat interval
 	ParamHeartbeatInterval = "heartbeat-interval"
+	// ParamReceiveBatchSize is the name of the parameter with the number of packets to read in each receive batch
+	ParamReceiveBatchSize = "receive-batch-size"
 )
 
 // NewServer will create a new Server with the default configuration.
@@ -157,4 +161,5 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.String(ParamInternalNamespace, DefaultInternalNamespace, "Namespace for internal metrics, may be \"\"")
 	fs.String(ParamPercentThreshold, strings.Join(toStringSlice(DefaultPercentThreshold), ","), "Comma-separated list of percentiles")
 	fs.Duration(ParamHeartbeatInterval, DefaultHeartbeatInterval, "Heartbeat interval (0s to disable)")
+	fs.Int(ParamReceiveBatchSize, DefaultReceiveBatchSize, "The number of packets to read in each receive batch")
 }

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -42,7 +42,7 @@ const (
 	// DefaultIgnoreHost is the default value for whether the source should be used as the host
 	DefaultIgnoreHost = false
 	// DefaultMetricsAddr is the default address on which to listen for metrics.
-	DefaultMetricsAddr = ":8125"
+	DefaultMetricsAddr = "[::]:8125"
 	// DefaultMaxQueueSize is the default maximum number of buffered metrics per worker.
 	DefaultMaxQueueSize = 10000 // arbitrary
 	// DefaultMaxConcurrentEvents is the default maximum number of events sent concurrently.
@@ -147,7 +147,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Duration(ParamCacheEvictAfterIdlePeriod, DefaultCacheEvictAfterIdlePeriod, "Idle cloud cache eviction period")
 	fs.Duration(ParamCacheTTL, DefaultCacheTTL, "Cloud cache TTL for successful lookups")
 	fs.Duration(ParamCacheNegativeTTL, DefaultCacheNegativeTTL, "Cloud cache TTL for failed lookups")
-	fs.String(ParamMetricsAddr, DefaultMetricsAddr, "Address on which to listen for metrics")
+	fs.String(ParamMetricsAddr, DefaultMetricsAddr, "IPv6 Address on which to listen for metrics")
 	fs.String(ParamNamespace, "", "Namespace all metrics")
 	fs.StringSlice(ParamBackends, DefaultBackends, "Comma-separated list of backends")
 	fs.Int(ParamMaxCloudRequests, DefaultMaxCloudRequests, "Maximum number of cloud provider requests per second")

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -40,7 +40,7 @@ const (
 	// DefaultIgnoreHost is the default value for whether the source should be used as the host
 	DefaultIgnoreHost = false
 	// DefaultMetricsAddr is the default address on which to listen for metrics.
-	DefaultMetricsAddr = "[::]:8125"
+	DefaultMetricsAddr = ":8125"
 	// DefaultMaxQueueSize is the default maximum number of buffered metrics per worker.
 	DefaultMaxQueueSize = 10000 // arbitrary
 	// DefaultMaxConcurrentEvents is the default maximum number of events sent concurrently.
@@ -124,7 +124,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Duration(ParamCacheEvictAfterIdlePeriod, DefaultCacheEvictAfterIdlePeriod, "Idle cloud cache eviction period")
 	fs.Duration(ParamCacheTTL, DefaultCacheTTL, "Cloud cache TTL for successful lookups")
 	fs.Duration(ParamCacheNegativeTTL, DefaultCacheNegativeTTL, "Cloud cache TTL for failed lookups")
-	fs.String(ParamMetricsAddr, DefaultMetricsAddr, "IPv6 Address on which to listen for metrics")
+	fs.String(ParamMetricsAddr, DefaultMetricsAddr, "Address on which to listen for metrics")
 	fs.String(ParamNamespace, "", "Namespace all metrics")
 	fs.StringSlice(ParamBackends, DefaultBackends, "Comma-separated list of backends")
 	fs.Int(ParamMaxCloudRequests, DefaultMaxCloudRequests, "Maximum number of cloud provider requests per second")

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -40,6 +40,7 @@ func TestStatsdThroughput(t *testing.T) {
 		MaxQueueSize:      DefaultMaxQueueSize,
 		PercentThreshold:  DefaultPercentThreshold,
 		HeartbeatInterval: DefaultHeartbeatInterval,
+		ReceiveBatchSize:  DefaultReceiveBatchSize,
 		CacheOptions: CacheOptions{
 			CacheRefreshPeriod:        DefaultCacheRefreshPeriod,
 			CacheEvictAfterIdlePeriod: DefaultCacheEvictAfterIdlePeriod,


### PR DESCRIPTION
Update MetricReceiver.Receive to batch read packets. In experimentation we found this to significantly increase performance. 

This implementation does not allow fallback to single read, and forces listening on IPv6. This is because the BatchRead api is protocol specific. This is an issue for backwards compatibility. 

Options I can see: 
- Setup this functionality to be configurable. I'd say a flag to enable or disable batch read. Could also potentially allow a flag to enable IPv4 bind instead... but perhaps overkill?
- Major version bump 

What would be preferable?
