### PR TITLE
Save the timer buffer

### DIFF
--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -206,6 +206,7 @@ func (a *MetricAggregator) Reset() {
 				Timestamp: timer.Timestamp,
 				Hostname:  timer.Hostname,
 				Tags:      timer.Tags,
+				Values:    timer.Values[:0],
 			}
 		}
 	})

--- a/pkg/statsd/aggregator_test.go
+++ b/pkg/statsd/aggregator_test.go
@@ -167,7 +167,7 @@ func TestReset(t *testing.T) {
 
 	expected = newFakeAggregator()
 	expected.Timers["some"] = map[string]gostatsd.Timer{
-		"thing": gostatsd.NewTimer(nowNano, nil, host, nil),
+		"thing": gostatsd.NewTimer(nowNano, []float64{}, host, nil),
 	}
 	expected.now = nowFn
 


### PR DESCRIPTION
There's some performance impact from GC, this keeps Timer buffers around for a bit longer.  They'll eventually expire if they need to though.