### PR TITLE
Performance work 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+5.x.x
+-----
+- Performance work, round 2
+
 5.1.1
 -----
 - Fix index out of range error and tag corruption in AWS CP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 5.x.x
 -----
 - Performance work, round 2
+- Add new flag `--estimated-tags`, pre-allocates the Tags array.  Defaults to `4`.
 
 5.1.1
 -----

--- a/cloudprovider.go
+++ b/cloudprovider.go
@@ -27,4 +27,6 @@ type CloudProvider interface {
 	MaxInstancesBatch() int
 	// SelfIP returns host's IPv4 address.
 	SelfIP() (IP, error)
+	// EstimatedTags returns a guess of how many tags are likely to be added by the CloudProvider
+	EstimatedTags() int
 }

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -120,6 +120,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		MaxWorkers:          v.GetInt(statsd.ParamMaxWorkers),
 		MaxQueueSize:        v.GetInt(statsd.ParamMaxQueueSize),
 		MaxConcurrentEvents: v.GetInt(statsd.ParamMaxConcurrentEvents),
+		EstimatedTags:       v.GetInt(statsd.ParamEstimatedTags),
 		MetricsAddr:         v.GetString(statsd.ParamMetricsAddr),
 		Namespace:           v.GetString(statsd.ParamNamespace),
 		PercentThreshold:    pt,

--- a/counters.go
+++ b/counters.go
@@ -11,7 +11,7 @@ type Counter struct {
 
 // NewCounter initialises a new counter.
 func NewCounter(timestamp Nanotime, value int64, hostname string, tags Tags) Counter {
-	return Counter{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags}
+	return Counter{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy()}
 }
 
 // Counters stores a map of counters by tags.

--- a/gauges.go
+++ b/gauges.go
@@ -10,7 +10,7 @@ type Gauge struct {
 
 // NewGauge initialises a new gauge.
 func NewGauge(timestamp Nanotime, value float64, hostname string, tags Tags) Gauge {
-	return Gauge{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags}
+	return Gauge{Value: value, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy()}
 }
 
 // Gauges stores a map of gauges by tags.

--- a/metrics.go
+++ b/metrics.go
@@ -48,6 +48,17 @@ type Metric struct {
 	DoneFunc    func()     // Returns the metric to the pool. May be nil. Call Metric.Done(), not this.
 }
 
+// Reset is used to reset a metric to as clean state, called on re-use from the pool.
+func (m *Metric) Reset() {
+	m.Name = ""
+	m.Value = 0
+	m.Tags = m.Tags[:0]
+	m.StringValue = ""
+	m.Hostname = ""
+	m.SourceIP = ""
+	m.Type = 0
+}
+
 // Bucket will pick a distribution bucket for this metric to land in.  max is exclusive.
 func (m *Metric) Bucket(max int) int {
 	bucket := adler32.Checksum([]byte(m.Name))

--- a/metrics.go
+++ b/metrics.go
@@ -45,6 +45,7 @@ type Metric struct {
 	Hostname    string     // Hostname of the source of the metric
 	SourceIP    IP         // IP of the source of the metric
 	Type        MetricType // The type of metric
+	DoneFunc    func()     // Returns the metric to the pool. May be nil. Call Metric.Done(), not this.
 }
 
 // Bucket will pick a distribution bucket for this metric to land in.  max is exclusive.
@@ -58,6 +59,13 @@ func (m *Metric) Bucket(max int) int {
 
 func (m *Metric) String() string {
 	return fmt.Sprintf("{%s, %s, %f, %s, %v}", m.Type, m.Name, m.Value, m.StringValue, m.Tags)
+}
+
+// Done invokes DoneFunc if it's set, returning the metric to the pool.
+func (m *Metric) Done() {
+	if m.DoneFunc != nil {
+		m.DoneFunc()
+	}
 }
 
 // AggregatedMetrics is an interface for aggregated metrics.

--- a/pkg/cloudproviders/aws/aws.go
+++ b/pkg/cloudproviders/aws/aws.go
@@ -45,6 +45,10 @@ type Provider struct {
 	MaxInstances int
 }
 
+func (p *Provider) EstimatedTags() int {
+	return 10 + 1 // 10 for EC2 tags, 1 for the region
+}
+
 func (p *Provider) RunMetrics(ctx context.Context, statser stats.Statser) {
 	flushed, unregister := statser.RegisterFlush()
 	defer unregister()

--- a/pkg/pool/datagram_buffer_pool.go
+++ b/pkg/pool/datagram_buffer_pool.go
@@ -1,0 +1,29 @@
+package pool
+
+import (
+	"sync"
+)
+
+// DatabramBufferPool is a strongly typed wrapper around a sync.Pool for *[][]byte
+type DatagramBufferPool struct {
+	p sync.Pool
+}
+
+func NewDatagramBufferPool(bufferSize int) *DatagramBufferPool {
+	return &DatagramBufferPool{
+		p: sync.Pool{
+			New: func() interface{} {
+				b := [][]byte{make([]byte, bufferSize)}
+				return &b
+			},
+		},
+	}
+}
+
+func (p *DatagramBufferPool) Get() *[][]byte {
+	return p.p.Get().(*[][]byte)
+}
+
+func (p *DatagramBufferPool) Put(b *[][]byte) {
+	p.p.Put(b)
+}

--- a/pkg/pool/metric_pool.go
+++ b/pkg/pool/metric_pool.go
@@ -1,0 +1,45 @@
+package pool
+
+import (
+	"sync"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// MetricPool is a strongly typed wrapper around a sync.Pool for *gostatsd.Metric, it provides
+// two main benefits: 1) metrics are very short lived and we create a lot of them, 2) reuse
+// of the tags buffer
+type MetricPool struct {
+	p             sync.Pool
+}
+
+// NewMetricPool returns a new metric pool.
+func NewMetricPool() *MetricPool {
+	return &MetricPool{
+		p: sync.Pool{
+			New: func() interface{} {
+				return &gostatsd.Metric{}
+			},
+		},
+	}
+}
+
+// Get returns a *gostatsd.Metric suitable for holding a metric.  The DoneFunc should be called
+// when the metric is no longer required.  It must not be called earlier, and the Tags field may
+// be reused.
+func (mp *MetricPool) Get() *gostatsd.Metric {
+	m := mp.p.Get().(*gostatsd.Metric)
+	if m.DoneFunc != nil { // it was re-used, and the data needs cleaning
+		m.Name = ""
+		m.Value = 0
+		m.Tags = m.Tags[:0]
+		m.StringValue = ""
+		m.Hostname = ""
+		m.SourceIP = ""
+	} else {
+		m.DoneFunc = func() {
+			mp.p.Put(m)
+		}
+	}
+	return m
+}

--- a/pkg/pool/metric_pool.go
+++ b/pkg/pool/metric_pool.go
@@ -11,16 +11,18 @@ import (
 // of the tags buffer
 type MetricPool struct {
 	p             sync.Pool
+	estimatedTags int
 }
 
 // NewMetricPool returns a new metric pool.
-func NewMetricPool() *MetricPool {
+func NewMetricPool(estimatedTags int) *MetricPool {
 	return &MetricPool{
 		p: sync.Pool{
 			New: func() interface{} {
 				return &gostatsd.Metric{}
 			},
 		},
+		estimatedTags: estimatedTags,
 	}
 }
 
@@ -39,6 +41,9 @@ func (mp *MetricPool) Get() *gostatsd.Metric {
 	} else {
 		m.DoneFunc = func() {
 			mp.p.Put(m)
+		}
+		if mp.estimatedTags != 0 {
+			m.Tags = make(gostatsd.Tags, 0, mp.estimatedTags)
 		}
 	}
 	return m

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -323,6 +323,7 @@ func (a *MetricAggregator) Receive(m *gostatsd.Metric, now time.Time) {
 	default:
 		log.Errorf("Unknow metric type %s for %s", m.Type, m.Name)
 	}
+	m.Done()
 }
 
 func formatTagsKey(tags gostatsd.Tags, hostname string) string {

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -103,6 +103,11 @@ func (bh *BackendHandler) RunMetrics(ctx context.Context, statser stats.Statser)
 	wg.StartWithContext(ctx, csw.Run)
 }
 
+// EstimatedTags returns a guess for how many tags to pre-allocate
+func (bh *BackendHandler) EstimatedTags() int {
+	return 0
+}
+
 // DispatchMetric dispatches metric to a corresponding Aggregator.
 func (bh *BackendHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	w := bh.workers[m.Bucket(bh.numWorkers)]

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -76,6 +76,8 @@ type CloudHandler struct {
 
 	rw    sync.RWMutex // Protects cache
 	cache map[gostatsd.IP]*instanceHolder
+
+	estimatedTags int
 }
 
 // NewCloudHandler initialises a new cloud handler.
@@ -92,7 +94,13 @@ func NewCloudHandler(cloud gostatsd.CloudProvider, metrics MetricHandler, events
 		awaitingEvents:  make(map[gostatsd.IP][]*gostatsd.Event),
 		awaitingMetrics: make(map[gostatsd.IP][]*gostatsd.Metric),
 		cache:           make(map[gostatsd.IP]*instanceHolder),
+		estimatedTags:   metrics.EstimatedTags() + cloud.EstimatedTags(),
 	}
+}
+
+// EstimatedTags returns a guess for how many tags to pre-allocate
+func (ch *CloudHandler) EstimatedTags() int {
+	return ch.estimatedTags
 }
 
 func (ch *CloudHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -243,6 +243,10 @@ func se2() gostatsd.Event {
 
 type nopHandler struct{}
 
+func (nh *nopHandler) EstimatedTags() int {
+	return 0
+}
+
 func (nh *nopHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	return nil
 }
@@ -258,6 +262,10 @@ type countingHandler struct {
 	mu      sync.Mutex
 	metrics []gostatsd.Metric
 	events  gostatsd.Events
+}
+
+func (ch *countingHandler) EstimatedTags() int {
+	return 0
 }
 
 func (ch *countingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
@@ -286,6 +294,10 @@ type fakeCountingProvider struct {
 	mu          sync.Mutex
 	ips         []gostatsd.IP
 	invocations uint64
+}
+
+func (fp *fakeCountingProvider) EstimatedTags() int {
+	return 0
 }
 
 func (fp *fakeCountingProvider) MaxInstancesBatch() int {

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -269,7 +269,7 @@ func (ch *countingHandler) EstimatedTags() int {
 }
 
 func (ch *countingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
-	m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data
+	m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data which interferes with the tests
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	ch.metrics = append(ch.metrics, *m)

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -261,6 +261,7 @@ type countingHandler struct {
 }
 
 func (ch *countingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+	m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	ch.metrics = append(ch.metrics, *m)

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -7,18 +7,25 @@ import (
 )
 
 type TagHandler struct {
-	metrics MetricHandler
-	events  EventHandler
-	tags    gostatsd.Tags // Tags to add to all metrics
+	metrics       MetricHandler
+	events        EventHandler
+	tags          gostatsd.Tags // Tags to add to all metrics
+	estimatedTags int
 }
 
 // NewTagHandler initialises a new handler which adds tags and sends metrics/events to the next handler
 func NewTagHandler(metrics MetricHandler, events EventHandler, tags gostatsd.Tags) *TagHandler {
 	return &TagHandler{
-		metrics: metrics,
-		events:  events,
-		tags:    tags,
+		metrics:       metrics,
+		events:        events,
+		tags:          tags,
+		estimatedTags: len(tags) + metrics.EstimatedTags(),
 	}
+}
+
+// EstimatedTags returns a guess for how many tags to pre-allocate
+func (th *TagHandler) EstimatedTags() int {
+	return th.estimatedTags
 }
 
 // DispatchMetric adds the tags from the TagHandler to the metric and passes it to the next stage in the pipeline

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -13,6 +13,10 @@ type TagCapturingHandler struct {
 	e []*gostatsd.Event
 }
 
+func (tch *TagCapturingHandler) EstimatedTags() int {
+	return 0
+}
+
 func (tch *TagCapturingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	tch.m = append(tch.m, m)
 	return nil

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/pool"
 )
 
 type lexer struct {
@@ -22,6 +23,8 @@ type lexer struct {
 	namespace     string
 	err           error
 	sampling      float64
+
+	metricPool *pool.MetricPool
 }
 
 // assumes we don't have \x00 bytes in input.
@@ -106,7 +109,7 @@ func lexSpecial(l *lexer) stateFn {
 		return nil
 	default:
 		l.pos--
-		l.m = new(gostatsd.Metric)
+		l.m = l.metricPool.Get()
 		return lexKeySep
 	}
 }

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -110,6 +110,8 @@ func lexSpecial(l *lexer) stateFn {
 	default:
 		l.pos--
 		l.m = l.metricPool.Get()
+		// Pull the tags from the metric, because it may have an empty buffer we can reuse.
+		l.tags = l.m.Tags
 		return lexKeySep
 	}
 }

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -153,7 +153,7 @@ func compareMetric(t *testing.T, tests map[string]gostatsd.Metric, namespace str
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 			result, _, err := parseLine([]byte(input), namespace)
-			result.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data
+			result.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data which interferes with the tests
 			require.NoError(t, err)
 			assert.Equal(t, &expected, result)
 		})

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -141,7 +141,7 @@ func TestInvalidEventsLexer(t *testing.T) {
 
 func parseLine(input []byte, namespace string) (*gostatsd.Metric, *gostatsd.Event, error) {
 	l := lexer{
-		metricPool: pool.NewMetricPool(),
+		metricPool: pool.NewMetricPool(0),
 	}
 	return l.run(input, namespace)
 }
@@ -165,7 +165,7 @@ var parselineBlackhole *gostatsd.Metric
 func benchmarkLexer(dp *DatagramParser, input string, b *testing.B) {
 	slice := []byte(input)
 	var r *gostatsd.Metric
-	dp.metricPool = pool.NewMetricPool()
+	dp.metricPool = pool.NewMetricPool(0)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/pool"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,7 +140,9 @@ func TestInvalidEventsLexer(t *testing.T) {
 }
 
 func parseLine(input []byte, namespace string) (*gostatsd.Metric, *gostatsd.Event, error) {
-	l := lexer{}
+	l := lexer{
+		metricPool: pool.NewMetricPool(),
+	}
 	return l.run(input, namespace)
 }
 
@@ -150,6 +153,7 @@ func compareMetric(t *testing.T, tests map[string]gostatsd.Metric, namespace str
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 			result, _, err := parseLine([]byte(input), namespace)
+			result.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data
 			require.NoError(t, err)
 			assert.Equal(t, &expected, result)
 		})
@@ -161,10 +165,12 @@ var parselineBlackhole *gostatsd.Metric
 func benchmarkLexer(dp *DatagramParser, input string, b *testing.B) {
 	slice := []byte(input)
 	var r *gostatsd.Metric
+	dp.metricPool = pool.NewMetricPool()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r, _, _ = dp.parseLine(slice)
+		r.Done()
 	}
 	parselineBlackhole = r
 }

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -36,7 +36,7 @@ type DatagramParser struct {
 }
 
 // NewDatagramParser initialises a new DatagramParser.
-func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metrics MetricHandler, events EventHandler, statser statser.Statser) *DatagramParser {
+func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, estimatedTags int, metrics MetricHandler, events EventHandler, statser statser.Statser) *DatagramParser {
 	return &DatagramParser{
 		in:         in,
 		ignoreHost: ignoreHost,
@@ -44,7 +44,7 @@ func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metric
 		events:     events,
 		namespace:  ns,
 		statser:    statser,
-		metricPool: pool.NewMetricPool(metrics.EstimatedTags()),
+		metricPool: pool.NewMetricPool(estimatedTags + metrics.EstimatedTags()),
 	}
 }
 

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/pool"
 	"github.com/atlassian/gostatsd/pkg/statser"
 
 	log "github.com/sirupsen/logrus"
@@ -29,6 +30,8 @@ type DatagramParser struct {
 	namespace  string // Namespace to prefix all metrics
 	statser    statser.Statser
 
+	metricPool *pool.MetricPool
+
 	in <-chan []*Datagram // Input chan of datagram batches to parse
 }
 
@@ -41,6 +44,7 @@ func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metric
 		events:     events,
 		namespace:  ns,
 		statser:    statser,
+		metricPool: pool.NewMetricPool(),
 	}
 }
 
@@ -156,6 +160,8 @@ func (dp *DatagramParser) handleDatagram(ctx context.Context, ip gostatsd.IP, ms
 
 // parseLine with lexer idpl.
 func (dp *DatagramParser) parseLine(line []byte) (*gostatsd.Metric, *gostatsd.Event, error) {
-	l := lexer{}
+	l := lexer{
+		metricPool: dp.metricPool,
+	}
 	return l.run(line, dp.namespace)
 }

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -44,7 +44,7 @@ func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metric
 		events:     events,
 		namespace:  ns,
 		statser:    statser,
-		metricPool: pool.NewMetricPool(),
+		metricPool: pool.NewMetricPool(metrics.EstimatedTags()),
 	}
 }
 

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -30,7 +30,7 @@ func TestParseEmptyDatagram(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", false, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", false, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), gostatsd.UnknownIP, inp)
 			require.NoError(t, err)
 			assert.Zero(t, len(ch.events), ch.events)
@@ -89,7 +89,7 @@ func TestParseDatagram(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", false, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", false, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			assert.NoError(t, err)
 			for i, e := range ch.events {
@@ -159,7 +159,7 @@ func TestParseDatagramIgnoreHost(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", true, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", true, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			assert.NoError(t, err)
 			for i, e := range ch.events {

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -35,6 +35,7 @@ type Server struct {
 	MaxQueueSize        int
 	MaxConcurrentEvents int
 	MaxEventQueueSize   int
+	EstimatedTags       int
 	MetricsAddr         string
 	Namespace           string
 	PercentThreshold    []float64
@@ -170,7 +171,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	// Open receiver <-> parser chan
 	datagrams := make(chan []*Datagram)
 
-	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, metrics, events, statser)
+	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, metrics, events, statser)
 	stage = stgr.NextStage()
 	stage.StartWithContext(parser.RunMetrics)
 	for r := 0; r < s.MaxParsers; r++ {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -62,6 +62,8 @@ const (
 	DefaultHeartbeatEnabled = false
 	// DefaultReceiveBatchSize is the number of datagrams to read in each receive batch
 	DefaultReceiveBatchSize = 50
+	// DefaultEstimatedTags is the estimated number of expected tags on an individual metric submitted externally
+	DefaultEstimatedTags = 4
 	// DefaultConnPerReader is the default for whether to create a connection per reader
 	DefaultConnPerReader = false
 )
@@ -97,6 +99,8 @@ const (
 	ParamMaxQueueSize = "max-queue-size"
 	// ParamMaxConcurrentEvents is the name of parameter with maximum number of events sent concurrently.
 	ParamMaxConcurrentEvents = "max-concurrent-events"
+	// ParamEstimatedTags is the name of parameter with estimated number of tags per metric
+	ParamEstimatedTags = "estimated-tags"
 	// ParamCacheRefreshPeriod is the name of parameter with cache refresh period.
 	ParamCacheRefreshPeriod = "cloud-cache-refresh-period"
 	// ParamCacheEvictAfterIdlePeriod is the name of parameter with idle cache eviction period.
@@ -130,6 +134,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Int(ParamMaxWorkers, DefaultMaxWorkers, "Maximum number of workers to process metrics")
 	fs.Int(ParamMaxQueueSize, DefaultMaxQueueSize, "Maximum number of buffered metrics per worker")
 	fs.Int(ParamMaxConcurrentEvents, DefaultMaxConcurrentEvents, "Maximum number of events sent concurrently")
+	fs.Int(ParamEstimatedTags, DefaultEstimatedTags, "Estimated number of expected tags on an individual metric submitted externally")
 	fs.Duration(ParamCacheRefreshPeriod, DefaultCacheRefreshPeriod, "Cloud cache refresh period")
 	fs.Duration(ParamCacheEvictAfterIdlePeriod, DefaultCacheEvictAfterIdlePeriod, "Idle cloud cache eviction period")
 	fs.Duration(ParamCacheTTL, DefaultCacheTTL, "Cloud cache TTL for successful lookups")

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -38,6 +38,7 @@ func TestStatsdThroughput(t *testing.T) {
 		MaxParsers:       DefaultMaxParsers,
 		MaxWorkers:       DefaultMaxWorkers,
 		MaxQueueSize:     DefaultMaxQueueSize,
+		EstimatedTags:    1, // Travis has limited memory
 		PercentThreshold: DefaultPercentThreshold,
 		HeartbeatEnabled: DefaultHeartbeatEnabled,
 		ReceiveBatchSize: DefaultReceiveBatchSize,
@@ -111,7 +112,7 @@ type fakeProvider struct {
 }
 
 func (fp *fakeProvider) EstimatedTags() int {
-	return 0
+	return len(fp.instance.Tags)
 }
 
 func (fp *fakeProvider) Name() string {

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -110,6 +110,10 @@ type fakeProvider struct {
 	instance *gostatsd.Instance
 }
 
+func (fp *fakeProvider) EstimatedTags() int {
+	return 0
+}
+
 func (fp *fakeProvider) Name() string {
 	return "fakeProvider"
 }

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -10,6 +10,8 @@ import (
 
 // MetricHandler can be used to handle metrics
 type MetricHandler interface {
+	// EstimatedTags returns a guess for how many tags to pre-allocate
+	EstimatedTags() int
 	// DispatchMetric dispatches a metric to the next step in a pipeline.
 	DispatchMetric(ctx context.Context, m *gostatsd.Metric) error
 }

--- a/sets.go
+++ b/sets.go
@@ -10,7 +10,7 @@ type Set struct {
 
 // NewSet initialises a new set.
 func NewSet(timestamp Nanotime, values map[string]struct{}, hostname string, tags Tags) Set {
-	return Set{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags}
+	return Set{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy()}
 }
 
 // Sets stores a map of sets by tags.

--- a/tags.go
+++ b/tags.go
@@ -45,6 +45,9 @@ func (tags Tags) Concat(additional Tags) Tags {
 
 // Copy returns a copy of the Tags
 func (tags Tags) Copy() Tags {
+	if tags == nil {
+		return nil
+	}
 	tagCopy := make(Tags, len(tags))
 	copy(tagCopy, tags)
 	return tagCopy

--- a/timers.go
+++ b/timers.go
@@ -20,7 +20,7 @@ type Timer struct {
 
 // NewTimer initialises a new timer.
 func NewTimer(timestamp Nanotime, values []float64, hostname string, tags Tags) Timer {
-	return Timer{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags}
+	return Timer{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy()}
 }
 
 // Timers stores a map of timers by tags.


### PR DESCRIPTION
Two main changes here, both aimed at addressing memory reuse, based on an 894 cpu second sample.

The first one targets object (metric) allocation in the lexer: 15.5 cpu seconds.  It looks like the lexer itself may also escape to the heap.

The second targets slice growth for tags: 35.7 cpu seconds in cloud handler, 21.9 cpu seconds in tag handler, and 23.5 cpu seconds in lexing.

There is also 112 seconds of GC, some of which should be reduced, but that's harder to quantify.

Changes are broken up by commits.