### PR TITLE
Add estimated-tags on the command line, and re-use the Tags in the lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 5.x.x
 -----
 - Performance work, round 2
+- Add new flag `--estimated-tags`, pre-allocates the Tags array.  Defaults to `4`.
 
 5.1.1
 -----

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -120,6 +120,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		MaxWorkers:          v.GetInt(statsd.ParamMaxWorkers),
 		MaxQueueSize:        v.GetInt(statsd.ParamMaxQueueSize),
 		MaxConcurrentEvents: v.GetInt(statsd.ParamMaxConcurrentEvents),
+		EstimatedTags:       v.GetInt(statsd.ParamEstimatedTags),
 		MetricsAddr:         v.GetString(statsd.ParamMetricsAddr),
 		Namespace:           v.GetString(statsd.ParamNamespace),
 		PercentThreshold:    pt,

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -110,6 +110,8 @@ func lexSpecial(l *lexer) stateFn {
 	default:
 		l.pos--
 		l.m = l.metricPool.Get()
+		// Pull the tags from the metric, because it may have a buffer we can reuse.
+		l.tags = l.m.Tags
 		return lexKeySep
 	}
 }

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -110,7 +110,7 @@ func lexSpecial(l *lexer) stateFn {
 	default:
 		l.pos--
 		l.m = l.metricPool.Get()
-		// Pull the tags from the metric, because it may have a buffer we can reuse.
+		// Pull the tags from the metric, because it may have an empty buffer we can reuse.
 		l.tags = l.m.Tags
 		return lexKeySep
 	}

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -36,7 +36,7 @@ type DatagramParser struct {
 }
 
 // NewDatagramParser initialises a new DatagramParser.
-func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metrics MetricHandler, events EventHandler, statser statser.Statser) *DatagramParser {
+func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, estimatedTags int, metrics MetricHandler, events EventHandler, statser statser.Statser) *DatagramParser {
 	return &DatagramParser{
 		in:         in,
 		ignoreHost: ignoreHost,
@@ -44,7 +44,7 @@ func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, metric
 		events:     events,
 		namespace:  ns,
 		statser:    statser,
-		metricPool: pool.NewMetricPool(metrics.EstimatedTags()),
+		metricPool: pool.NewMetricPool(estimatedTags + metrics.EstimatedTags()),
 	}
 }
 

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -30,7 +30,7 @@ func TestParseEmptyDatagram(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", false, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", false, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), gostatsd.UnknownIP, inp)
 			require.NoError(t, err)
 			assert.Zero(t, len(ch.events), ch.events)
@@ -89,7 +89,7 @@ func TestParseDatagram(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", false, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", false, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			assert.NoError(t, err)
 			for i, e := range ch.events {
@@ -159,7 +159,7 @@ func TestParseDatagramIgnoreHost(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			ch := &countingHandler{}
-			mr := NewDatagramParser(nil, "", true, ch, ch, statser.NewNullStatser())
+			mr := NewDatagramParser(nil, "", true, 0, ch, ch, statser.NewNullStatser())
 			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			assert.NoError(t, err)
 			for i, e := range ch.events {

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -35,6 +35,7 @@ type Server struct {
 	MaxQueueSize        int
 	MaxConcurrentEvents int
 	MaxEventQueueSize   int
+	EstimatedTags       int
 	MetricsAddr         string
 	Namespace           string
 	PercentThreshold    []float64
@@ -170,7 +171,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	// Open receiver <-> parser chan
 	datagrams := make(chan []*Datagram)
 
-	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, metrics, events, statser)
+	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, metrics, events, statser)
 	stage = stgr.NextStage()
 	stage.StartWithContext(parser.RunMetrics)
 	for r := 0; r < s.MaxParsers; r++ {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -62,6 +62,8 @@ const (
 	DefaultHeartbeatEnabled = false
 	// DefaultReceiveBatchSize is the number of datagrams to read in each receive batch
 	DefaultReceiveBatchSize = 50
+	// DefaultEstimatedTags is the estimated number of expected tags on an individual metric submitted externally
+	DefaultEstimatedTags = 4
 	// DefaultConnPerReader is the default for whether to create a connection per reader
 	DefaultConnPerReader = false
 )
@@ -97,6 +99,8 @@ const (
 	ParamMaxQueueSize = "max-queue-size"
 	// ParamMaxConcurrentEvents is the name of parameter with maximum number of events sent concurrently.
 	ParamMaxConcurrentEvents = "max-concurrent-events"
+	// ParamEstimatedTags is the name of parameter with estimated number of tags per metric
+	ParamEstimatedTags = "estimated-tags"
 	// ParamCacheRefreshPeriod is the name of parameter with cache refresh period.
 	ParamCacheRefreshPeriod = "cloud-cache-refresh-period"
 	// ParamCacheEvictAfterIdlePeriod is the name of parameter with idle cache eviction period.
@@ -130,6 +134,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Int(ParamMaxWorkers, DefaultMaxWorkers, "Maximum number of workers to process metrics")
 	fs.Int(ParamMaxQueueSize, DefaultMaxQueueSize, "Maximum number of buffered metrics per worker")
 	fs.Int(ParamMaxConcurrentEvents, DefaultMaxConcurrentEvents, "Maximum number of events sent concurrently")
+	fs.Int(ParamEstimatedTags, DefaultEstimatedTags, "Estimated number of expected tags on an individual metric submitted externally")
 	fs.Duration(ParamCacheRefreshPeriod, DefaultCacheRefreshPeriod, "Cloud cache refresh period")
 	fs.Duration(ParamCacheEvictAfterIdlePeriod, DefaultCacheEvictAfterIdlePeriod, "Idle cloud cache eviction period")
 	fs.Duration(ParamCacheTTL, DefaultCacheTTL, "Cloud cache TTL for successful lookups")

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -38,6 +38,7 @@ func TestStatsdThroughput(t *testing.T) {
 		MaxParsers:       DefaultMaxParsers,
 		MaxWorkers:       DefaultMaxWorkers,
 		MaxQueueSize:     DefaultMaxQueueSize,
+		EstimatedTags:    DefaultEstimatedTags,
 		PercentThreshold: DefaultPercentThreshold,
 		HeartbeatEnabled: DefaultHeartbeatEnabled,
 		ReceiveBatchSize: DefaultReceiveBatchSize,
@@ -111,7 +112,7 @@ type fakeProvider struct {
 }
 
 func (fp *fakeProvider) EstimatedTags() int {
-	return 0
+	return 3
 }
 
 func (fp *fakeProvider) Name() string {

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -38,7 +38,7 @@ func TestStatsdThroughput(t *testing.T) {
 		MaxParsers:       DefaultMaxParsers,
 		MaxWorkers:       DefaultMaxWorkers,
 		MaxQueueSize:     DefaultMaxQueueSize,
-		EstimatedTags:    DefaultEstimatedTags,
+		EstimatedTags:    1, // Travis has limited memory
 		PercentThreshold: DefaultPercentThreshold,
 		HeartbeatEnabled: DefaultHeartbeatEnabled,
 		ReceiveBatchSize: DefaultReceiveBatchSize,
@@ -112,7 +112,7 @@ type fakeProvider struct {
 }
 
 func (fp *fakeProvider) EstimatedTags() int {
-	return 3
+	return len(fp.instance.Tags)
 }
 
 func (fp *fakeProvider) Name() string {


### PR DESCRIPTION
This provides improvements more in-line with what I expected:

Before (master):
     statsd_test.go:63: Processed metrics: 239965
                        TotalAlloc: 4468756296 (18622 per metric)
                        HeapObjects: 1232201
                        Mallocs: 85311296 (355 per metric)
                        NumGC: 87
                        GCCPUFraction: 0.113637

After:
     statsd_test.go:64: Processed metrics: 279938
                        TotalAlloc: 3635926720 (12988 per metric)
                        HeapObjects: 775769
                        Mallocs: 74816124 (267 per metric)
                        NumGC: 70
                        GCCPUFraction: 0.082639

Significant improvements in GC and number of metrics processed.