### PR TITLE
Performance work 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+5.2.1
+-----
+- Performance work, round 3
+
 5.2.0
 -----
 - Performance work, round 2

--- a/metrics.go
+++ b/metrics.go
@@ -41,6 +41,7 @@ type Metric struct {
 	Name        string     // The name of the metric
 	Value       float64    // The numeric value of the metric
 	Tags        Tags       // The tags for the metric
+	TagsKey     string     // The tags rendered as a string to uniquely identify the tagset in a map
 	StringValue string     // The string value for some metrics e.g. Set
 	Hostname    string     // Hostname of the source of the metric
 	SourceIP    IP         // IP of the source of the metric
@@ -53,6 +54,7 @@ func (m *Metric) Reset() {
 	m.Name = ""
 	m.Value = 0
 	m.Tags = m.Tags[:0]
+	m.TagsKey = ""
 	m.StringValue = ""
 	m.Hostname = ""
 	m.SourceIP = ""

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -308,7 +308,7 @@ func (a *MetricAggregator) receiveSet(m *gostatsd.Metric, tagsKey string, now go
 // Receive aggregates an incoming metric.
 func (a *MetricAggregator) Receive(m *gostatsd.Metric, now time.Time) {
 	a.metricsReceived++
-	tagsKey := formatTagsKey(m.Tags, m.Hostname)
+	tagsKey := m.TagsKey
 	nowNano := gostatsd.Nanotime(now.UnixNano())
 
 	switch m.Type {
@@ -324,12 +324,4 @@ func (a *MetricAggregator) Receive(m *gostatsd.Metric, now time.Time) {
 		log.Errorf("Unknow metric type %s for %s", m.Type, m.Name)
 	}
 	m.Done()
-}
-
-func formatTagsKey(tags gostatsd.Tags, hostname string) string {
-	t := tags.SortedString()
-	if hostname == "" {
-		return t
-	}
-	return t + "," + gostatsd.StatsdSourceID + ":" + hostname
 }

--- a/pkg/statsd/aggregator_test.go
+++ b/pkg/statsd/aggregator_test.go
@@ -292,7 +292,7 @@ func TestIsExpired(t *testing.T) {
 }
 
 func metricsFixtures() []gostatsd.Metric {
-	return []gostatsd.Metric{
+	ms := []gostatsd.Metric{
 		{Name: "foo.bar.baz", Value: 2, Type: gostatsd.COUNTER},
 		{Name: "abc.def.g", Value: 3, Type: gostatsd.GAUGE},
 		{Name: "abc.def.g", Value: 8, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"foo:bar", "baz"}},
@@ -307,6 +307,10 @@ func metricsFixtures() []gostatsd.Metric {
 		{Name: "uniq.usr", StringValue: "john", Type: gostatsd.SET},
 		{Name: "uniq.usr", StringValue: "john", Type: gostatsd.SET, Tags: gostatsd.Tags{"foo:bar", "baz"}},
 	}
+	for i, m := range ms {
+		ms[i].TagsKey = formatTagsKey(m.Tags, m.Hostname)
+	}
+	return ms
 }
 
 func TestReceive(t *testing.T) {

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -110,6 +110,7 @@ func (bh *BackendHandler) EstimatedTags() int {
 
 // DispatchMetric dispatches metric to a corresponding Aggregator.
 func (bh *BackendHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+	m.TagsKey = formatTagsKey(m.Tags, m.Hostname)
 	w := bh.workers[m.Bucket(bh.numWorkers)]
 	select {
 	case <-ctx.Done():
@@ -174,4 +175,12 @@ func (bh *BackendHandler) dispatchEvent(ctx context.Context, backend gostatsd.Ba
 	if err := backend.SendEvent(ctx, e); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		logrus.Errorf("Sending event to backend failed: %v", err)
 	}
+}
+
+func formatTagsKey(tags gostatsd.Tags, hostname string) string {
+	t := tags.SortedString()
+	if hostname == "" {
+		return t
+	}
+	return t + "," + gostatsd.StatsdSourceID + ":" + hostname
 }


### PR DESCRIPTION
The gostatsd pipeline consists of the following process (names are not actual internal processes):

Receiver ->  Parser -> AggregatorStorage ->  AggregatorFlush -> Backend

AggregatorStorage has goroutine affinity based on metric name and source host.  Parser has no goroutine affinity.

Currently one of the largest CPU sinks is calculating the tagsKey in the AggregatorStorage step.  If there's a hot metric the storage can't keep up and stops reading from its channel, causing all the Parsers to get backed up, despite there being CPU available.

This moves the computation to the Parser, allowing it to utilize all available goroutines.

```
    Before: BenchmarkHotMetric-4     1000000              4427 ns/op            1856 B/op         24 allocs/op
    After:  BenchmarkHotMetric-4     2000000              2501 ns/op            1856 B/op         24 allocs/op
```

Still not sure what to do about the allocation (ignoring the stuff in the benchmark itself), it's all the sorting and string joining.