### PR TITLE
Fix -race build

### DIFF
--- a/build/Dockerfile-glibc
+++ b/build/Dockerfile-glibc
@@ -1,4 +1,4 @@
-FROM ubuntu:16.10
+FROM ubuntu:16.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
Looks like 16.10 isn't on the supported list, and something got pulled.