### PR TITLE
Make timer aggregations optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.3.0
+-----
+- Uses the default EC2 credentials
+- Timer sub-metrics now have a configuration option for opt-out.  See README.md for details.
+
 5.2.2
 -----
 - Build -race on ubuntu:16.04 instead of 16.10

--- a/README.md
+++ b/README.md
@@ -59,6 +59,62 @@ are interested in. Configuration file might look like this:
 	max_retries = 4
 ```
 
+
+Configuring timer sub-metrics
+-----------------------------
+By default, timer metrics will result in aggregated metrics of the form (exact name varies by backend):
+```
+<base>.Count
+<base>.CountPerSecond
+<base>.Mean
+<base>.Median
+<base>.Lower
+<base>.Upper
+<base>.StdDev
+<base>.Sum
+<base>.SumSquares
+```
+
+
+In addition, the following aggregated metrics will be emitted for each configured percentile:
+```
+<base>.Count_XX
+<base>.Mean_XX
+<base>.Sum_XX
+<base>.SumSquares_XX
+<base>.Upper_XX - for positive only
+<base>.Lower_-XX - for negative only
+```
+
+
+These can be controlled through the `disabled-sub-metrics` configuration section:
+```
+[disabled-sub-metrics]
+# Regular metrics
+count=false
+count-per-second=false
+mean=false
+median=false
+lower=false
+upper=false
+stddev=false
+sum=false
+sum-squares=false
+
+# Percentile metrics
+count-pct=false
+mean-pct=false
+sum-pct=false
+sum-squares-pct=false
+lower-pct=false
+upper-pct=false
+```
+
+
+By default (for compatibility), they are all false and the metrics will be emitted.
+
+
+
 Sending metrics
 ---------------
 The server listens for UDP packets on the address given by the `--metrics-addr` flag,
@@ -99,13 +155,8 @@ A simple way to test your installation or send metrics from a script is to use
 
 Monitoring
 ----------
-Currently you can get some basic idea of the status of the server by visiting the
-address given by the `--console-addr` option with your web browser.
-
-Load balancing and scaling out
-------------------------------
-It is possible to run multiple versions of `gostatsd` behind a load balancer by having them
-send their metrics to another `gostatsd` backend which will then send to the final backends.
+Many metrics for the internal processes are emitted.  See METRICS.md for details.  Go expvar is also
+exposed if the `--profile` flag is used.
 
 Memory allocation for read buffers
 ----------------------------------

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -137,7 +137,8 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 			fmt.Sprintf("version:%s", Version),
 			fmt.Sprintf("commit:%s", GitCommit),
 		},
-		Viper: v,
+		DisabledSubTypes: gostatsd.DisabledSubMetrics(v),
+		Viper:            v,
 	}, nil
 }
 

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -37,7 +37,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", "tcp", defaultMetricsPerBatch, defaultMaxRequests, true, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", defaultMetricsPerBatch, defaultMaxRequests, true, 1*time.Second, 2*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -66,7 +66,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", "tcp", 1, defaultMaxRequests, true, 1*time.Second, 2*time.Second)
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", 1, defaultMaxRequests, true, 1*time.Second, 2*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -118,7 +118,7 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	cli, err := NewClient(ts.URL, "apiKey123", "tcp", 1000, defaultMaxRequests, true, 1*time.Second, 2*time.Second)
+	cli, err := NewClient(ts.URL, "apiKey123", "tcp", 1000, defaultMaxRequests, true, 1*time.Second, 2*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	cli.now = func() time.Time {
 		return time.Unix(100, 0)

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -26,7 +26,7 @@ func TestPreparePayload(t *testing.T) {
 	input := []testData{
 		{
 			config: &Config{
-			// Use defaults
+				// Use defaults
 			},
 			result: []byte("stats_counts.stat1 5 1234\n" +
 				"stats.stat1 1.100000 1234\n" +
@@ -98,7 +98,7 @@ func TestPreparePayload(t *testing.T) {
 		td := td
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
-			cl, err := NewClient(td.config)
+			cl, err := NewClient(td.config, gostatsd.TimerSubtypes{})
 			require.NoError(t, err)
 			b := cl.preparePayload(metrics, time.Unix(1234, 0))
 			assert.Equal(t, string(td.result), b.String(), "test %d", i)
@@ -114,7 +114,7 @@ func TestSendMetricsAsync(t *testing.T) {
 	addr := l.Addr().String()
 	c, err := NewClient(&Config{
 		Address: &addr,
-	})
+	}, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 
 	var acceptWg sync.WaitGroup

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -44,6 +44,7 @@ type Server struct {
 	HeartbeatEnabled    bool
 	HeartbeatTags       gostatsd.Tags
 	ReceiveBatchSize    int
+	DisabledSubTypes    gostatsd.TimerSubtypes
 	CacheOptions
 	Viper *viper.Viper
 }
@@ -93,6 +94,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	factory := agrFactory{
 		percentThresholds: s.PercentThreshold,
 		expiryInterval:    s.ExpiryInterval,
+		disabledSubtypes:  s.DisabledSubTypes,
 	}
 
 	backendHandler := NewBackendHandler(s.Backends, uint(s.MaxConcurrentEvents), s.MaxWorkers, s.MaxQueueSize, &factory)
@@ -260,10 +262,11 @@ func getHost() string {
 type agrFactory struct {
 	percentThresholds []float64
 	expiryInterval    time.Duration
+	disabledSubtypes  gostatsd.TimerSubtypes
 }
 
 func (af *agrFactory) Create() Aggregator {
-	return NewMetricAggregator(af.percentThresholds, af.expiryInterval)
+	return NewMetricAggregator(af.percentThresholds, af.expiryInterval, af.disabledSubtypes)
 }
 
 func toStringSlice(fs []float64) []string {

--- a/timers.go
+++ b/timers.go
@@ -1,5 +1,7 @@
 package gostatsd
 
+import "github.com/spf13/viper"
+
 // Timer is used for storing aggregated values for timers.
 type Timer struct {
 	Count       int         // The number of timers in the series
@@ -53,4 +55,46 @@ func (t Timers) Each(f func(string, string, Timer)) {
 			f(key, tags, timer)
 		}
 	}
+}
+
+func DisabledSubMetrics(viper *viper.Viper) TimerSubtypes {
+	subViper := viper.Sub("disabled-sub-metrics")
+	if subViper == nil {
+		return TimerSubtypes{}
+	}
+
+	subViper.SetDefault("lower", false)
+	subViper.SetDefault("lower-pct", false)
+	subViper.SetDefault("upper", false)
+	subViper.SetDefault("upper-pct", false)
+	subViper.SetDefault("count", false)
+	subViper.SetDefault("count-pct", false)
+	subViper.SetDefault("count-per-second", false)
+	subViper.SetDefault("mean", false)
+	subViper.SetDefault("mean-pct", false)
+	subViper.SetDefault("median", false)
+	subViper.SetDefault("std", false)
+	subViper.SetDefault("sum", false)
+	subViper.SetDefault("sum-pct", false)
+	subViper.SetDefault("sum-squares", false)
+	subViper.SetDefault("sum-squares-pct", false)
+
+	return TimerSubtypes{
+		Lower:          subViper.GetBool("lower"),
+		LowerPct:       subViper.GetBool("lower-pct"),
+		Upper:          subViper.GetBool("upper"),
+		UpperPct:       subViper.GetBool("upper-pct"),
+		Count:          subViper.GetBool("count"),
+		CountPct:       subViper.GetBool("count-pct"),
+		CountPerSecond: subViper.GetBool("count-per-second"),
+		Mean:           subViper.GetBool("mean"),
+		MeanPct:        subViper.GetBool("mean-pct"),
+		Median:         subViper.GetBool("median"),
+		StdDev:         subViper.GetBool("stddev"),
+		Sum:            subViper.GetBool("sum"),
+		SumPct:         subViper.GetBool("sum-pct"),
+		SumSquares:     subViper.GetBool("sum-squares"),
+		SumSquaresPct:  subViper.GetBool("sum-squares-pct"),
+	}
+
 }

--- a/types.go
+++ b/types.go
@@ -12,3 +12,21 @@ type IP string
 const UnknownIP IP = ""
 
 type Wait func()
+
+type TimerSubtypes struct {
+	Lower          bool
+	LowerPct       bool // pct
+	Upper          bool
+	UpperPct       bool // pct
+	Count          bool
+	CountPct       bool // pct
+	CountPerSecond bool
+	Mean           bool
+	MeanPct        bool // pct
+	Median         bool
+	StdDev         bool
+	Sum            bool
+	SumPct         bool // pct
+	SumSquares     bool
+	SumSquaresPct  bool // pct
+}


### PR DESCRIPTION
It also polishes the README.md a bit, as it's a little stale.

This doesn't do any "don't calculate" work, only "don't emit".  I could add that, but the logic gets pretty messy because things depend on other things, etc.  In practice, the math is not a significant amount of work, compared to things like sending data upstream.