### PR TITLE
Fix a "leak" in the cloudprovider cache metrics

### DIFF
--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -308,6 +308,11 @@ func (ch *CloudHandler) handleLookupResult(ctx context.Context, lr *lookupResult
 			newHolder.instance = currentHolder.instance
 			ch.statsCacheRefreshNegative++
 		} else {
+			if currentHolder.instance == nil && newHolder.instance != nil {
+				// An entry has flipped from invalid to valid
+				ch.statsCacheNegative--
+				ch.statsCachePositive++
+			}
 			ch.statsCacheRefreshPositive++
 		}
 	}


### PR DESCRIPTION
This has been haunting me since I added the metrics.  Finally managed to get a repro by hacking up one of the tests.

Writing tests to handle this will be a nightmare and are likely to be flaky until a virtual clock is added (#111), so no tests.