### PR TITLE
Optionally disable internal metric collection with NullStatser

### DIFF
--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/atlassian/gostatsd"
 	stats "github.com/atlassian/gostatsd/pkg/statser"
+	"github.com/gostatsd/pkg/statser"
 
 	"github.com/ash2k/stager"
-	"github.com/jbenet/go-reuseport"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"
@@ -21,30 +21,31 @@ import (
 // Server encapsulates all of the parameters necessary for starting up
 // the statsd server. These can either be set via command line or directly.
 type Server struct {
-	Backends            []gostatsd.Backend
-	CloudProvider       gostatsd.CloudProvider
-	Limiter             *rate.Limiter
-	InternalTags        gostatsd.Tags
-	InternalNamespace   string
-	DefaultTags         gostatsd.Tags
-	ExpiryInterval      time.Duration
-	FlushInterval       time.Duration
-	MaxReaders          int
-	MaxParsers          int
-	MaxWorkers          int
-	MaxQueueSize        int
-	MaxConcurrentEvents int
-	MaxEventQueueSize   int
-	EstimatedTags       int
-	MetricsAddr         string
-	Namespace           string
-	PercentThreshold    []float64
-	IgnoreHost          bool
-	ConnPerReader       bool
-	HeartbeatEnabled    bool
-	HeartbeatTags       gostatsd.Tags
-	ReceiveBatchSize    int
-	DisabledSubTypes    gostatsd.TimerSubtypes
+	Backends               []gostatsd.Backend
+	CloudProvider          gostatsd.CloudProvider
+	DisableInternalMetrics bool
+	Limiter                *rate.Limiter
+	InternalTags           gostatsd.Tags
+	InternalNamespace      string
+	DefaultTags            gostatsd.Tags
+	ExpiryInterval         time.Duration
+	FlushInterval          time.Duration
+	MaxReaders             int
+	MaxParsers             int
+	MaxWorkers             int
+	MaxQueueSize           int
+	MaxConcurrentEvents    int
+	MaxEventQueueSize      int
+	EstimatedTags          int
+	MetricsAddr            string
+	Namespace              string
+	PercentThreshold       []float64
+	IgnoreHost             bool
+	ConnPerReader          bool
+	HeartbeatEnabled       bool
+	HeartbeatTags          gostatsd.Tags
+	ReceiveBatchSize       int
+	DisabledSubTypes       gostatsd.TimerSubtypes
 	CacheOptions
 	Viper *viper.Viper
 }
@@ -138,8 +139,12 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	}
 
 	bufferSize := 1000 // Estimating this is hard, and tends to cause loss under adverse conditions
-	statser := stats.NewInternalStatser(bufferSize, s.InternalTags, namespace, hostname, metrics, events)
-	// TODO: Make internal metric dispatch configurable
+	var statser statser.Statser
+	if s.DisableInternalMetrics {
+		statser = stats.NewNullStatser()
+	} else {
+		statser = stats.NewInternalStatser(bufferSize, s.InternalTags, namespace, hostname, metrics, events)
+	}
 	// statser := stats.NewLoggingStatser(s.InternalTags, log.NewEntry(log.New()))
 	stage = stgr.NextStage()
 	stage.StartWithContext(statser.Run)

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -36,6 +36,8 @@ const (
 	DefaultMaxCloudRequests = 10
 	// DefaultBurstCloudRequests is the burst number of cloud provider requests per second.
 	DefaultBurstCloudRequests = DefaultMaxCloudRequests + 5
+	// DefaultDisableInternalMetrics is the default value for whether internal metrics should be disabled.
+	DefaultDisableInternalMetrics = false
 	// DefaultExpiryInterval is the default expiry interval for metrics.
 	DefaultExpiryInterval = 5 * time.Minute
 	// DefaultFlushInterval is the default metrics flush interval.
@@ -73,6 +75,8 @@ const (
 	ParamBackends = "backends"
 	// ParamCloudProvider is the name of parameter with the name of cloud provider.
 	ParamCloudProvider = "cloud-provider"
+	// ParamDisableInternalMetrics is the name of parameter indicating if internal metrics should be disabled.
+	ParamDisableInternalMetrics = "disable-internal-metrics"
 	// ParamMaxCloudRequests is the name of parameter with maximum number of cloud provider requests per second.
 	ParamMaxCloudRequests = "max-cloud-requests"
 	// ParamBurstCloudRequests is the name of parameter with burst number of cloud provider requests per second.
@@ -126,6 +130,7 @@ const (
 // AddFlags adds flags to the specified FlagSet.
 func AddFlags(fs *pflag.FlagSet) {
 	fs.String(ParamCloudProvider, "", "If set, use the cloud provider to retrieve metadata about the sender")
+	fs.Bool(ParamDisableInternalMetrics, DefaultDisableInternalMetrics, "Disable internal metrics from being collected")
 	fs.Duration(ParamExpiryInterval, DefaultExpiryInterval, "After how long do we expire metrics (0 to disable)")
 	fs.Duration(ParamFlushInterval, DefaultFlushInterval, "How often to flush metrics to the backends")
 	fs.Bool(ParamIgnoreHost, DefaultIgnoreHost, "Ignore the source for populating the hostname field of metrics")


### PR DESCRIPTION
If a server configuration has `DisableInternalMetrics: true` use `NullStatser` in place of `InternalStatser` to disable the internal metrics collected.

Closes #167 

Signed-off-by: Nikki Attea <nikki@sensu.io>