### PR TITLE
(#15) Handle histograms by aliasing to timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /cmd/tester/statsd-tester*
 /test-report.xml
 build/dev/data/
+/.vscode
+*.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+6.0.0
+-----
+- Parses histogram metrics as timers
+- Log bad lines with rate limit
+- Add new flag `--bad-lines-per-minute`, controls the rate limit on logging lines which fail to parse.  Defaults
+  to `0`.  Supports floats.
+
 5.4.1
 -----
 - Memory/GC optimisation with buffers being reused in the Datadog backend

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -137,8 +137,9 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 			fmt.Sprintf("version:%s", Version),
 			fmt.Sprintf("commit:%s", GitCommit),
 		},
-		DisabledSubTypes: gostatsd.DisabledSubMetrics(v),
-		Viper:            v,
+		DisabledSubTypes:          gostatsd.DisabledSubMetrics(v),
+		BadLineRateLimitPerSecond: rate.Limit(v.GetFloat64(statsd.ParamBadLinesPerMinute) / 60.0),
+		Viper: v,
 	}, nil
 }
 

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -375,6 +375,10 @@ func lexType(l *lexer) stateFn {
 		l.start = l.pos
 		l.m.Type = gostatsd.TIMER
 		return lexTypeSep
+	case 'h':
+		l.start = l.pos
+		l.m.Type = gostatsd.TIMER
+		return lexTypeSep
 	case 's':
 		l.m.Type = gostatsd.SET
 		l.start = l.pos

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -16,6 +16,8 @@ func TestMetricsLexer(t *testing.T) {
 		"foo.bar.baz:2|c":               {Name: "foo.bar.baz", Value: 2, Type: gostatsd.COUNTER},
 		"abc.def.g:3|g":                 {Name: "abc.def.g", Value: 3, Type: gostatsd.GAUGE},
 		"def.g:10|ms":                   {Name: "def.g", Value: 10, Type: gostatsd.TIMER},
+		"def.h:10|h":                    {Name: "def.h", Value: 10, Type: gostatsd.TIMER},
+		"def.i:10|h|#foo":               {Name: "def.i", Value: 10, Type: gostatsd.TIMER, Tags: gostatsd.Tags{"foo"}},
 		"smp.rte:5|c|@0.1":              {Name: "smp.rte", Value: 50, Type: gostatsd.COUNTER},
 		"smp.rte:5|c|@0.1|#foo:bar,baz": {Name: "smp.rte", Value: 50, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"foo:bar", "baz"}},
 		"smp.rte:5|c|#foo:bar,baz":      {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"foo:bar", "baz"}},

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -66,6 +66,8 @@ const (
 	DefaultEstimatedTags = 4
 	// DefaultConnPerReader is the default for whether to create a connection per reader
 	DefaultConnPerReader = false
+	// DefaultBadLinesPerMinute is the default number of bad lines to allow to log per minute
+	DefaultBadLinesPerMinute = 0
 )
 
 const (
@@ -121,6 +123,8 @@ const (
 	ParamReceiveBatchSize = "receive-batch-size"
 	// ParamConnPerReader is the name of the parameter indicating whether to create a connection per reader
 	ParamConnPerReader = "conn-per-reader"
+	// ParamBadLineRateLimitPerMinute is the name of the parameter indicating how many bad lines can be logged per minute
+	ParamBadLinesPerMinute = "bad-lines-per-minute"
 )
 
 // AddFlags adds flags to the specified FlagSet.


### PR DESCRIPTION
This is really more of a 'handle bad lines' better.  This is done through:

- Logging bad lines with a rate limiter (defaults to not logging them)
- Supporting histograms, which are believed to be the majority of bad lines, by aliasing them to timers.