### PR TITLE
Disables the bad line rate-limiter if zero (default) is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.0.1
+-----
+- Fixes rate limiter on bad lines.  A value <= 0 will disable entirely.
+
 6.0.0
 -----
 - Parses histogram metrics as timers

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -173,7 +173,10 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	// 7. Start the Parser
 	// Open receiver <-> parser chan
 	datagrams := make(chan []*Datagram)
-	limiter := rate.NewLimiter(s.BadLineRateLimitPerSecond, 1)
+	limiter := &rate.Limiter{}
+	if s.BadLineRateLimitPerSecond > 0 {
+		limiter = rate.NewLimiter(s.BadLineRateLimitPerSecond, 1)
+	}
 
 	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, metrics, events, statser, limiter)
 	stage = stgr.NextStage()


### PR DESCRIPTION
I thought I had tested this corner case, but it turns out I had not.