### PR TITLE
Add a flag to control http2 usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.2.0
+-----
+- Added `enable-http2` flag for Datadog backend to control HTTP/2 support, defaults to `false`
+
 6.1.2
 -----
 - Build with Go 1.10.2

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -37,7 +37,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", "tcp", defaultMetricsPerBatch, defaultMaxRequests, true, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", defaultMetricsPerBatch, defaultMaxRequests, true, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -66,7 +66,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, "apiKey123", "tcp", 1, defaultMaxRequests, true, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+	client, err := NewClient(ts.URL, "apiKey123", "tcp", 1, defaultMaxRequests, true, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
 	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
@@ -116,7 +116,7 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	cli, err := NewClient(ts.URL, "apiKey123", "tcp", 1000, defaultMaxRequests, true, 1*time.Second, 2*time.Second, 1100*time.Millisecond, gostatsd.TimerSubtypes{})
+	cli, err := NewClient(ts.URL, "apiKey123", "tcp", 1000, defaultMaxRequests, true, false, 1*time.Second, 2*time.Second, 1100*time.Millisecond, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	cli.now = func() time.Time {
 		return time.Unix(100, 0)


### PR DESCRIPTION
This gives us a flag for http2 to Datadog, defaulting to off.  I'll likely change it to default to on if the previous issues we had are gone.