### PR TITLE
Cloudprovider cache failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+7.0.0
+-----
+- Fix a bug in the cache provider where transient failures were replacing good cache
+- Started passing around a logger, not used everywhere yet
+- Documentation fixes
+
 6.1.2
 -----
 - Build with Go 1.10.2

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Sending metrics
 ---------------
 The server listens for UDP packets on the address given by the `--metrics-addr` flag,
 aggregates them, then sends them to the backend servers given by the `--backends`
-flag (comma separated list of backend names).
+flag (space separated list of backend names).
 
 Currently supported backends are:
 

--- a/cloudprovider.go
+++ b/cloudprovider.go
@@ -3,11 +3,12 @@ package gostatsd
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 // CloudProviderFactory is a function that returns a CloudProvider.
-type CloudProviderFactory func(*viper.Viper) (CloudProvider, error)
+type CloudProviderFactory func(v *viper.Viper, logger logrus.FieldLogger) (CloudProvider, error)
 
 // Instance represents a cloud instance.
 type Instance struct {

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/cloudproviders"
 	"github.com/atlassian/gostatsd/pkg/statsd"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"
@@ -48,14 +48,14 @@ func main() {
 		if err == pflag.ErrHelp {
 			return
 		}
-		log.Fatalf("Error while parsing configuration: %v", err)
+		logrus.Fatalf("Error while parsing configuration: %v", err)
 	}
 	if version {
 		fmt.Printf("Version: %s - Commit: %s - Date: %s\n", Version, GitCommit, BuildDate)
 		return
 	}
 	if err := run(v); err != nil {
-		log.Fatalf("%v", err)
+		logrus.Fatalf("%v", err)
 	}
 }
 
@@ -63,11 +63,11 @@ func run(v *viper.Viper) error {
 	profileAddr := v.GetString(ParamProfile)
 	if profileAddr != "" {
 		go func() {
-			log.Errorf("Profiler server failed: %v", http.ListenAndServe(profileAddr, nil))
+			logrus.Errorf("Profiler server failed: %v", http.ListenAndServe(profileAddr, nil))
 		}()
 	}
 
-	log.Info("Starting server")
+	logrus.Info("Starting server")
 	s, err := constructServer(v)
 	if err != nil {
 		return err
@@ -84,8 +84,11 @@ func run(v *viper.Viper) error {
 }
 
 func constructServer(v *viper.Viper) (*statsd.Server, error) {
+	// Logger
+	logger := logrus.StandardLogger()
+
 	// Cloud provider
-	cloud, err := cloudproviders.Init(v.GetString(statsd.ParamCloudProvider), v)
+	cloud, err := cloudproviders.Init(v.GetString(statsd.ParamCloudProvider), v, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -211,9 +214,9 @@ func setupConfiguration() (*viper.Viper, bool, error) {
 
 func setupLogger(v *viper.Viper) {
 	if v.GetBool(ParamVerbose) {
-		log.SetLevel(log.DebugLevel)
+		logrus.SetLevel(logrus.DebugLevel)
 	}
 	if v.GetBool(ParamJSON) {
-		log.SetFormatter(&log.JSONFormatter{})
+		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 }

--- a/pkg/cloudproviders/cloudproviders.go
+++ b/pkg/cloudproviders/cloudproviders.go
@@ -6,41 +6,41 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 // All registered cloud providers.
 var providers = map[string]gostatsd.CloudProviderFactory{
-	aws.ProviderName: aws.NewProviderFromViper,
+	aws.ProviderName:  aws.NewProviderFromViper,
 }
 
 // Get creates an instance of the named provider, or nil if
 // the name is not known.  The error return is only used if the named provider
 // was known but failed to initialize.
-func Get(name string, v *viper.Viper) (gostatsd.CloudProvider, error) {
+func Get(name string, v *viper.Viper, logger logrus.FieldLogger) (gostatsd.CloudProvider, error) {
 	f, found := providers[name]
 	if !found {
 		return nil, nil
 	}
-	return f(v)
+	return f(v, logger)
 }
 
 // Init creates an instance of the named cloud provider.
-func Init(name string, v *viper.Viper) (gostatsd.CloudProvider, error) {
+func Init(name string, v *viper.Viper, logger logrus.FieldLogger) (gostatsd.CloudProvider, error) {
 	if name == "" {
-		log.Info("No cloud provider specified")
+		logrus.Info("No cloud provider specified")
 		return nil, nil
 	}
 
-	provider, err := Get(name, v)
+	provider, err := Get(name, v, logger.WithField("cloud_provider", name))
 	if err != nil {
 		return nil, fmt.Errorf("could not init cloud provider %q: %v", name, err)
 	}
 	if provider == nil {
 		return nil, fmt.Errorf("unknown cloud provider %q", name)
 	}
-	log.Infof("Initialised cloud provider %q", name)
+	logrus.Infof("Initialised cloud provider %q", name)
 
 	return provider, nil
 }

--- a/pkg/cloudproviders/cloudproviders.go
+++ b/pkg/cloudproviders/cloudproviders.go
@@ -12,7 +12,7 @@ import (
 
 // All registered cloud providers.
 var providers = map[string]gostatsd.CloudProviderFactory{
-	aws.ProviderName:  aws.NewProviderFromViper,
+	aws.ProviderName: aws.NewProviderFromViper,
 }
 
 // Get creates an instance of the named provider, or nil if

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,6 +42,62 @@ func BenchmarkCloudHandlerDispatchMetric(b *testing.B) {
 			ch.DispatchMetric(ctxBackground, &m)
 		}
 	})
+}
+
+func TestTransientInstanceFailure(t *testing.T) {
+	t.Parallel()
+	fpt := &fakeProviderTransient{
+		failureMode: []int{
+			0, // success, prime the cache
+			1, // soft failure, data should remain in cache
+		},
+	}
+
+	counting := &countingHandler{}
+
+	ch := NewCloudHandler(fpt, counting, counting, rate.NewLimiter(100, 120), &CacheOptions{
+		CacheRefreshPeriod:        50 * time.Millisecond,
+		CacheEvictAfterIdlePeriod: 1 * time.Minute,
+		CacheTTL:                  1 * time.Millisecond,
+		CacheNegativeTTL:          1 * time.Millisecond,
+	})
+
+	// t+0: instance is queried, goes in cache
+	// t+50ms: instance refreshed (failure)
+	// t+100ms: instance is queried, must be in cache
+
+	var wg wait.Group
+	defer wg.Wait()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	wg.StartWithContext(ctx, ch.Run)
+	m1 := sm1()
+	m2 := sm1()
+
+	// t+0: prime the cache
+	if err := ch.DispatchMetric(ctx, &m1); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	// t+50: refresh
+	time.Sleep(50 * time.Millisecond)
+
+	// t+100ms: read from cache, must still be valid
+	if err := ch.DispatchMetric(ctx, &m2); err != nil {
+		t.Fatal(err)
+	}
+	cancelFunc()
+	wg.Wait()
+
+	expectedMetrics := []gostatsd.Metric{
+		sm1(), sm1(),
+	}
+
+	expectedMetrics[0].Tags = gostatsd.Tags{"a1", "tag:value"}
+	expectedMetrics[1].Tags = gostatsd.Tags{"a1", "tag:value"}
+
+	assert.Equal(t, expectedMetrics, counting.metrics)
 }
 
 func TestCloudHandlerExpirationAndRefresh(t *testing.T) {
@@ -367,4 +424,60 @@ func (fp *fakeFailingProvider) Name() string {
 func (fp *fakeFailingProvider) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
 	fp.count(ips...)
 	return nil, errors.New("clear skies, no clouds available")
+}
+
+type fakeProviderTransient struct {
+	call        uint64
+	failureMode []int
+}
+
+func (fpt *fakeProviderTransient) Name() string {
+	return "fakeProviderTransient"
+}
+
+func (fpt *fakeProviderTransient) EstimatedTags() int {
+	return 1
+}
+
+func (fpt *fakeProviderTransient) MaxInstancesBatch() int {
+	return 1
+}
+
+func (fpt *fakeProviderTransient) SelfIP() (gostatsd.IP, error) {
+	return gostatsd.UnknownIP, nil
+}
+
+// Instance emulates a lookup based on the supplied criteria.
+// A failure mode of 0 is a successful lookup
+// A failure mode of 1 is nil instance, no error (lookup failure)
+// A failure mode of 2 is nil instance, with error
+// Repeats the last specified failure mode
+func (fpt *fakeProviderTransient) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
+	r := make(map[gostatsd.IP]*gostatsd.Instance)
+
+	c := atomic.AddUint64(&fpt.call, 1) - 1
+	if c >= uint64(len(fpt.failureMode)) {
+		c = uint64(len(fpt.failureMode) - 1)
+	}
+	switch fpt.failureMode[c] {
+	case 0:
+		for _, ip := range ips {
+			r[ip] = &gostatsd.Instance{
+				ID:   string(ip),
+				Tags: gostatsd.Tags{"tag:value"},
+			}
+		}
+		return r, nil
+	case 1:
+		for _, ip := range ips {
+			r[ip] = nil
+		}
+		return r, nil
+	case 2:
+		for _, ip := range ips {
+			r[ip] = nil
+		}
+		return r, errors.New("failure mode 2")
+	}
+	return nil, nil
 }

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -115,7 +115,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	ip := gostatsd.UnknownIP
 	var cloudHandler *CloudHandler
 	if s.CloudProvider != nil {
-		cloudHandler = NewCloudHandler(s.CloudProvider, metrics, events, s.Limiter, &s.CacheOptions)
+		cloudHandler = NewCloudHandler(s.CloudProvider, metrics, events, log.StandardLogger(), s.Limiter, &s.CacheOptions)
 		metrics = cloudHandler
 		events = cloudHandler
 		stage = stgr.NextStage()

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -2,7 +2,6 @@ package statsd
 
 import (
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -160,14 +159,14 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Duration(ParamCacheNegativeTTL, DefaultCacheNegativeTTL, "Cloud cache TTL for failed lookups")
 	fs.String(ParamMetricsAddr, DefaultMetricsAddr, "Address on which to listen for metrics")
 	fs.String(ParamNamespace, "", "Namespace all metrics")
-	fs.StringSlice(ParamBackends, DefaultBackends, "Comma-separated list of backends")
+	fs.StringSlice(ParamBackends, DefaultBackends, "Space separated list of backends")
 	fs.Int(ParamMaxCloudRequests, DefaultMaxCloudRequests, "Maximum number of cloud provider requests per second")
 	fs.Int(ParamBurstCloudRequests, DefaultBurstCloudRequests, "Burst number of cloud provider requests per second")
-	fs.String(ParamDefaultTags, strings.Join(DefaultTags, ","), "Comma-separated list of tags to add to all metrics")
-	fs.String(ParamInternalTags, strings.Join(DefaultInternalTags, ","), "Comma-separated list of tags to add to internal metrics")
+	fs.StringSlice(ParamDefaultTags, DefaultTags, "Space separated list of tags to add to all metrics")
+	fs.StringSlice(ParamInternalTags, DefaultInternalTags, "Space separated list of tags to add to internal metrics")
 	fs.String(ParamInternalNamespace, DefaultInternalNamespace, "Namespace for internal metrics, may be \"\"")
 	fs.String(ParamStatserType, DefaultStatserType, "Statser type to be used for sending metrics")
-	fs.String(ParamPercentThreshold, strings.Join(toStringSlice(DefaultPercentThreshold), ","), "Comma-separated list of percentiles")
+	fs.StringSlice(ParamPercentThreshold, toStringSlice(DefaultPercentThreshold), "Space separated list of percentiles")
 	fs.Bool(ParamHeartbeatEnabled, DefaultHeartbeatEnabled, "Enables heartbeat")
 	fs.Int(ParamReceiveBatchSize, DefaultReceiveBatchSize, "The number of datagrams to read in each receive batch")
 	fs.Bool(ParamConnPerReader, DefaultConnPerReader, "Create a separate connection per reader (requires system support for reusing addresses)")


### PR DESCRIPTION
It's probably worth looking at the commits in isolation, especially as the logger reworking gets everywhere and is noisy.

The actual bug is when we have no instance and no error, we overwrite a valid instance with a nil instance.  No idea why AWS is returning no data for valid instances, but based on the cache metric behavior I suspect it's always happened and we've just noticed recently.  Something something eventual consistency.

c546769 - add some troubleshooting and logs to figure out what is going on, also starts the FieldLogger update
9497b6c / 30184a0 - the actual fix.  Our call has a single error, and we're attaching that error to every instance in the event of failure.  Now we log a single error for the batch, and the actual result is either an instance or no instance (no error state)
b1e5e4b - changelog and #181 