### PR TITLE
Datadog experimental backend (feedback only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 /build/bin/
 /vendor/
-/coverage.out
-/profile.out
 /cmd/tester/statsd-tester*
 /test-report.xml
 build/dev/data/
 /.vscode
 *.toml
+/*.out
+/*.test

--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,7 @@ package gostatsd
 
 import (
 	"context"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -20,7 +21,7 @@ type Backend interface {
 	Name() string
 	// SendMetricsAsync flushes the metrics to the backend, preparing payload synchronously but doing the send asynchronously.
 	// Must not read/write MetricMap asynchronously.
-	SendMetricsAsync(context.Context, *MetricMap, SendCallback)
+	SendMetricsAsync(ctx context.Context, metrics *MetricMap, flushTime time.Time, done SendCallback)
 	// SendEvent sends event to the backend.
 	SendEvent(context.Context, *Event) error
 }

--- a/counters.go
+++ b/counters.go
@@ -45,3 +45,22 @@ func (c Counters) Each(f func(string, string, Counter)) {
 		}
 	}
 }
+
+// copy returns a deep-ish copy of this Counters object
+func (c Counters) copy() Counters {
+	cNew := Counters{}
+	for name, value := range c {
+		c := map[string]Counter{}
+		for tagsKey, counter := range value {
+			c[tagsKey] = Counter{
+				PerSecond: counter.PerSecond,
+				Value:     counter.Value,
+				// Timestamp: counter.Timestamp, // Timestamp is not required
+				Hostname: counter.Hostname,
+				Tags:     counter.Tags, // shallow copy is acceptable
+			}
+		}
+		cNew[name] = c
+	}
+	return cNew
+}

--- a/counters.go
+++ b/counters.go
@@ -48,11 +48,11 @@ func (c Counters) Each(f func(string, string, Counter)) {
 
 // copy returns a deep-ish copy of this Counters object
 func (c Counters) copy() Counters {
-	cNew := Counters{}
+	cNew := make(Counters, len(c))
 	for name, value := range c {
-		c := map[string]Counter{}
+		m := make(map[string]Counter, len(value))
 		for tagsKey, counter := range value {
-			c[tagsKey] = Counter{
+			m[tagsKey] = Counter{
 				PerSecond: counter.PerSecond,
 				Value:     counter.Value,
 				// Timestamp: counter.Timestamp, // Timestamp is not required
@@ -60,7 +60,7 @@ func (c Counters) copy() Counters {
 				Tags:     counter.Tags, // shallow copy is acceptable
 			}
 		}
-		cNew[name] = c
+		cNew[name] = m
 	}
 	return cNew
 }

--- a/gauges.go
+++ b/gauges.go
@@ -44,3 +44,21 @@ func (g Gauges) Each(f func(string, string, Gauge)) {
 		}
 	}
 }
+
+// copy returns a deep-ish copy of this Gauges object
+func (g Gauges) copy() Gauges {
+	gNew := Gauges{}
+	for name, value := range g {
+		g := map[string]Gauge{}
+		for tagsKey, gauge := range value {
+			g[tagsKey] = Gauge{
+				Value: gauge.Value,
+				// Timestamp: counter.Timestamp, // Timestamp is not required
+				Hostname: gauge.Hostname,
+				Tags:     gauge.Tags, // shallow copy is acceptable
+			}
+		}
+		gNew[name] = g
+	}
+	return gNew
+}

--- a/gauges.go
+++ b/gauges.go
@@ -47,18 +47,18 @@ func (g Gauges) Each(f func(string, string, Gauge)) {
 
 // copy returns a deep-ish copy of this Gauges object
 func (g Gauges) copy() Gauges {
-	gNew := Gauges{}
+	gNew := make(Gauges, len(g))
 	for name, value := range g {
-		g := map[string]Gauge{}
+		m := make(map[string]Gauge, len(value))
 		for tagsKey, gauge := range value {
-			g[tagsKey] = Gauge{
+			m[tagsKey] = Gauge{
 				Value: gauge.Value,
 				// Timestamp: counter.Timestamp, // Timestamp is not required
 				Hostname: gauge.Hostname,
 				Tags:     gauge.Tags, // shallow copy is acceptable
 			}
 		}
-		gNew[name] = g
+		gNew[name] = m
 	}
 	return gNew
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5acefdf002068f8153f132c5fb12cb2d955786d4d5f03a6492d92fddffebfbae
-updated: 2017-11-14T10:21:02.689006454+11:00
+hash: 91c15a40e40710a8d622b8a0ce841bed9b1e0279eca2bfef4adf969bf041e4bc
+updated: 2018-06-29T22:01:48.290193288+10:00
 imports:
 - name: github.com/ash2k/stager
   version: 6e9c7b0eacd465286fac042bfb29a170aa8c2c3f
@@ -33,28 +33,31 @@ imports:
   - service/ec2
   - service/sts
 - name: github.com/cenkalti/backoff
-  version: 61ba96c4d1002f22e06acb8e34a7650611125a63
+  version: f756bc9a37f808627c8c1b26d2d6ea40c468440b
 - name: github.com/fsnotify/fsnotify
-  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: cec2bdc49009247305a260b082a18e802d0fe292
 - name: github.com/go-redis/redis
-  version: d0f86971b5d61de9cebd2616b932acb7ba14d957
+  version: 83fb42932f6145ce52df09860384a4653d2d332a
   subpackages:
   - internal
   - internal/consistenthash
   - internal/hashtag
   - internal/pool
   - internal/proto
+  - internal/singleflight
+  - internal/util
 - name: github.com/gxed/eventfd
   version: 80a92cca79a8041496ccc9dd773fcb52a57ec6f9
 - name: github.com/gxed/GoEndian
   version: 0f5c6873267e5abf306ffcdfcfa4bf77517ef4a7
 - name: github.com/hashicorp/hcl
-  version: 68e816d1c783414e79bc65b3994d9ab6b0a722ab
+  version: ef8a98b0bbce4a65b5aa4c368430a80ddc533168
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/printer
   - hcl/scanner
   - hcl/strconv
   - hcl/token
@@ -66,87 +69,93 @@ imports:
 - name: github.com/jbenet/go-reuseport
   version: 7b4e9d23b569c604ed9be4439a2e9ada26774b4f
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/json-iterator/go
-  version: 6240e1e7983a85228f7fd9c3e1b6932d46ec58e2
+  version: ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4
 - name: github.com/libp2p/go-reuseport
-  version: 7b4e9d23b569c604ed9be4439a2e9ada26774b4f
+  version: c2c3368efe65c8b85ddff6b278df5bef3ce235e2
   subpackages:
   - poll
   - singlepoll
 - name: github.com/libp2p/go-sockaddr
-  version: 9ad2a49ab6a4f3e1ac08dffb3aa1f110dc062807
+  version: 3c898fbfff40e5933d76362819727708dae6da97
   subpackages:
   - net
 - name: github.com/magiconair/properties
-  version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
+  version: c2353362d570a7bfa228149c62842019201cfb71
   subpackages:
   - assert
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 58118c1ea9161250907268a484af4dd6ed314280
 - name: github.com/pelletier/go-toml
-  version: 16398bac157da96aa88f98a2df640c7f32af1da2
+  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
 - name: github.com/sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/spf13/afero
-  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
+  version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/jwalterweatherman
-  version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
+  version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: 7aff26db30c1be810f9de5038ec5ef96ac41fd7c
+  version: 3ebe029320b2676d667ae88da602a5f854788a8a
 - name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+  version: 15738813a09db5c8e5b60a19d67d3f9bd38da3a4
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
+- name: github.com/tilinna/clock
+  version: 74440910e8079f06acc329aa13666873e93980ea
 - name: github.com/whyrusleeping/go-logging
   version: 0457bb6b88fc1973573aaf6b5145d8d3ae972390
 - name: golang.org/x/crypto
-  version: c84b36c635ad003a10f0c755dff5685ceef18c71
+  version: 7f39a6fea4fe9364fb61e1def6a268a51b4f3a06
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 0a9397675ba34b2845f758fe3cd68828369c6517
+  version: db08ff08e8622530d9ed3a0e8ac279f6d4c02196
   subpackages:
   - bpf
   - context
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
   - internal/iana
   - internal/socket
   - ipv6
-  - lex/httplex
 - name: golang.org/x/sys
-  version: 314a259e304ff91bd6985da2a7149bbf91237993
+  version: ad87a3a340fa7f3bed189293fbfa7a9b7e021ae1
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
+  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/time
-  version: 6dc17368e09b0e8634d71cac8168d853e869a0c7
+  version: fbb02b2291d28baffd63558aa44b4b56f178d650
   subpackages:
   - rate
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,3 +26,4 @@ import:
   version: ^6.6.1
 - package: github.com/json-iterator/go
   version: ^1.0.3
+- package: github.com/tilinna/clock

--- a/metrics.go
+++ b/metrics.go
@@ -97,6 +97,18 @@ type MetricMap struct {
 	Sets     Sets
 }
 
+// Copy returns a deep-ish copy of the MetricMap.  It is not a complete copy, and only data required post-aggregation
+// is copied.
+func (m *MetricMap) Copy() *MetricMap {
+	mNew := &MetricMap{
+		Counters: m.Counters.copy(),
+		Timers:   m.Timers.copy(),
+		Gauges:   m.Gauges.copy(),
+		Sets:     m.Sets.copy(),
+	}
+	return mNew
+}
+
 func (m *MetricMap) String() string {
 	buf := new(bytes.Buffer)
 	m.Counters.Each(func(k, tags string, counter Counter) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,83 @@
+package gostatsd
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+// benchmarkMetricMapCopy runs a benchmark copying a map of size b.N of every type.  Due to memory
+// constraints, b.N is scaled down by an arbitrary amount, and the copy is ran multiple times.
+func benchmarkMetricMapCopy(b *testing.B, iterations, nameLimit int) {
+	mm := MetricMap{
+		Counters: Counters{},
+		Timers:   Timers{},
+		Gauges:   Gauges{},
+		Sets:     Sets{},
+	}
+	rnd := rand.New(rand.NewSource(0))
+	mapSize := b.N / iterations
+
+	// Create counters
+	for i := 0; i < mapSize; i++ {
+		name := strconv.Itoa(int(rnd.Int31n(int32(nameLimit))))
+		c := strconv.Itoa(len(mm.Counters[name]))
+		if mm.Counters[name] == nil {
+			mm.Counters[name] = map[string]Counter{}
+		}
+		mm.Counters[name]["tag.value.s."+c] = Counter{}
+	}
+
+	// Create timers
+	for i := 0; i < mapSize; i++ {
+		name := strconv.Itoa(int(rnd.Int31n(int32(nameLimit))))
+		c := strconv.Itoa(len(mm.Timers[name]))
+		if mm.Timers[name] == nil {
+			mm.Timers[name] = map[string]Timer{}
+		}
+		mm.Timers[name]["tag.value.s."+c] = Timer{}
+	}
+
+	// Create gauges
+	for i := 0; i < mapSize; i++ {
+		name := strconv.Itoa(int(rnd.Int31n(int32(nameLimit))))
+		c := strconv.Itoa(len(mm.Gauges[name]))
+		if mm.Gauges[name] == nil {
+			mm.Gauges[name] = map[string]Gauge{}
+		}
+		mm.Gauges[name]["tag.value.s."+c] = Gauge{}
+	}
+
+	// Create sets
+	for i := 0; i < mapSize; i++ {
+		name := strconv.Itoa(int(rnd.Int31n(int32(nameLimit))))
+		c := strconv.Itoa(len(mm.Sets[name]))
+		if mm.Sets[name] == nil {
+			mm.Sets[name] = map[string]Set{}
+		}
+		mm.Sets[name]["tag.value.s."+c] = Set{}
+	}
+
+	b.ReportAllocs()
+
+	b.ResetTimer()
+	for i := 0; i < iterations; i++ {
+		_ = mm.Copy()
+	}
+}
+
+func BenchmarkMetricBatch(b *testing.B) {
+	for nameLimit := 1000; nameLimit <= 100000; nameLimit *= 10 {
+		//for iterations := 1; iterations <= 10; iterations++ {
+
+		// Experimentation indicates that iterations is not too important.  A value of 1 is more costly and indicative
+		// of real world, but Travis may not have memory to run the test.
+		iterations := 2
+		b.Run(fmt.Sprintf("%d-names-%d-iterations", nameLimit, iterations), func(b *testing.B) {
+			benchmarkMetricMapCopy(b, iterations, nameLimit)
+		})
+
+		//}
+	}
+}

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/datadog"
+	"github.com/atlassian/gostatsd/pkg/backends/datadogexp"
 	"github.com/atlassian/gostatsd/pkg/backends/graphite"
 	"github.com/atlassian/gostatsd/pkg/backends/null"
 	"github.com/atlassian/gostatsd/pkg/backends/statsdaemon"
@@ -17,6 +18,7 @@ import (
 // All known backends.
 var backends = map[string]gostatsd.BackendFactory{
 	datadog.BackendName:     datadog.NewClientFromViper,
+	datadogexp.BackendName:  datadogexp.NewClientFromViper,
 	graphite.BackendName:    graphite.NewClientFromViper,
 	null.BackendName:        null.NewClientFromViper,
 	statsdaemon.BackendName: statsdaemon.NewClientFromViper,

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -90,7 +90,7 @@ type event struct {
 }
 
 // SendMetricsAsync flushes the metrics to Datadog, preparing payload synchronously but doing the send asynchronously.
-func (d *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+func (d *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
 	counter := 0
 	results := make(chan error)
 	d.processMetrics(metrics, func(ts *timeSeries) {

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -40,7 +40,7 @@ func TestRetries(t *testing.T) {
 	client, err := NewClient(ts.URL, "apiKey123", "agent", "tcp", defaultMetricsPerBatch, defaultMaxRequests, true, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
-	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
+	client.SendMetricsAsync(context.Background(), twoCounters(), time.Now(), func(errs []error) {
 		res <- errs
 	})
 	errs := <-res
@@ -69,7 +69,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	client, err := NewClient(ts.URL, "apiKey123", "agent", "tcp", 1, defaultMaxRequests, true, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 	res := make(chan []error, 1)
-	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
+	client.SendMetricsAsync(context.Background(), twoCounters(), time.Now(), func(errs []error) {
 		res <- errs
 	})
 	errs := <-res
@@ -122,7 +122,7 @@ func TestSendMetrics(t *testing.T) {
 		return time.Unix(100, 0)
 	}
 	res := make(chan []error, 1)
-	cli.SendMetricsAsync(context.Background(), metricsOneOfEach(), func(errs []error) {
+	cli.SendMetricsAsync(context.Background(), metricsOneOfEach(), time.Now(), func(errs []error) {
 		res <- errs
 	})
 	errs := <-res

--- a/pkg/backends/datadogexp/batch_serializer.go
+++ b/pkg/backends/datadogexp/batch_serializer.go
@@ -1,0 +1,96 @@
+package datadogexp
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+
+	"github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+)
+
+// renderedBody represents a ddTimeSeries serialized to a []byte, with optional zlib compression applied.
+type renderedBody struct {
+	body       []byte
+	compressed bool
+}
+
+type batchSerializer struct {
+	logger   logrus.FieldLogger
+	compress bool
+
+	receiveBatch <-chan ddTimeSeries
+	submitBody   chan<- *renderedBody
+
+	json jsoniter.API
+}
+
+func (bs *batchSerializer) Run(ctx context.Context) {
+	bs.logger.Info("Starting")
+	defer bs.logger.Info("Terminating")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case batch := <-bs.receiveBatch:
+			var renderedBody *renderedBody
+			var err error
+			if bs.compress {
+				renderedBody, err = bs.processBatchCompress(batch)
+			} else {
+				renderedBody, err = bs.processBatch(batch)
+			}
+			if err == nil {
+				select {
+				case <-ctx.Done():
+					return
+				case bs.submitBody <- renderedBody:
+				}
+			} else {
+				bs.logger.WithFields(logrus.Fields{
+					"error": err,
+					"size":  len(batch.Series),
+				}).Error("failed to serialize batch")
+			}
+		}
+	}
+}
+
+func (bs *batchSerializer) processBatch(batch ddTimeSeries) (*renderedBody, error) {
+	buf := &bytes.Buffer{}
+	jsonWriter := bs.json.BorrowStream(buf)
+	jsonWriter.WriteVal(batch)
+	err := jsonWriter.Flush()
+	bs.json.ReturnStream(jsonWriter)
+	if err != nil {
+		return nil, err
+	}
+	return &renderedBody{
+		body:       buf.Bytes(),
+		compressed: false,
+	}, nil
+}
+
+func (bs *batchSerializer) processBatchCompress(batch ddTimeSeries) (*renderedBody, error) {
+	buf := &bytes.Buffer{}
+	compressor, err := zlib.NewWriterLevel(buf, zlib.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	jsonWriter := bs.json.BorrowStream(compressor)
+	jsonWriter.WriteVal(batch)
+	err = jsonWriter.Flush()
+	bs.json.ReturnStream(jsonWriter)
+	if err != nil {
+		return nil, err
+	}
+	err = compressor.Close()
+	if err != nil {
+		return nil, err
+	}
+	return &renderedBody{
+		body:       buf.Bytes(),
+		compressed: true,
+	}, nil
+}

--- a/pkg/backends/datadogexp/batch_serializer_test.go
+++ b/pkg/backends/datadogexp/batch_serializer_test.go
@@ -1,0 +1,62 @@
+package datadogexp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func batchSerialize(t *testing.T, compress bool, ts ddTimeSeries) *renderedBody {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	sendBatch := make(chan ddTimeSeries)
+	recvBatch := make(chan *renderedBody)
+	bs := &batchSerializer{
+		logger:       logrus.StandardLogger(),
+		compress:     compress,
+		receiveBatch: sendBatch,
+		submitBody:   recvBatch,
+		json: jsoniter.Config{
+			EscapeHTML:  false,
+			SortMapKeys: false,
+		}.Froze(),
+	}
+
+	go bs.Run(ctx)
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout submitting timeseries")
+	case sendBatch <- ts:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout receiving body")
+	case rb := <-recvBatch:
+		return rb
+	}
+	return nil
+}
+
+var emptyBlob = []byte(`{"series":null}`)
+
+func TestBatchSerializerCompress(t *testing.T) {
+	rb := batchSerialize(t, true, ddTimeSeries{})
+	// Exactly what it looks like may vary, so make sure it doesn't match an empty blob
+	require.NotEqual(t, emptyBlob, rb.body)
+	require.Equal(t, true, rb.compressed)
+}
+
+func TestBatchSerializerNoCompress(t *testing.T) {
+	rb := batchSerialize(t, false, ddTimeSeries{})
+	require.Equal(t, emptyBlob, rb.body)
+	require.Equal(t, false, rb.compressed)
+}
+
+//func TestBatchSerializer

--- a/pkg/backends/datadogexp/body_writer.go
+++ b/pkg/backends/datadogexp/body_writer.go
@@ -1,0 +1,159 @@
+package datadogexp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"fmt"
+	"strings"
+
+	"github.com/cenkalti/backoff"
+	"github.com/sirupsen/logrus"
+	"github.com/tilinna/clock"
+)
+
+type bodyWriter struct {
+	logger logrus.FieldLogger
+
+	userAgent   string
+	upstreamURL string
+	apiKey      string
+	newBackOff  func() backoff.BackOff
+
+	client *http.Client
+
+	// tracer *tracer
+
+	receiveBody <-chan *renderedBody
+}
+
+func newBodyWriter(
+	logger logrus.FieldLogger,
+	userAgent string,
+	upstreamURL string,
+	apiKey string,
+	client *http.Client,
+	newBackOff func() backoff.BackOff,
+	receiveBody <-chan *renderedBody,
+) (*bodyWriter, error) {
+
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("api_key", apiKey)
+	u.RawQuery = q.Encode()
+	u.Path = "/api/v1/series"
+
+	// tracer := newTracer(logger)
+
+	return &bodyWriter{
+		logger: logger,
+		// tracer:      tracer,
+		userAgent:   userAgent,
+		upstreamURL: u.String(),
+		apiKey:      apiKey,
+		client:      client,
+		receiveBody: receiveBody,
+		newBackOff:  newBackOff,
+	}, nil
+}
+
+func (bw *bodyWriter) Run(ctx context.Context) {
+	bw.logger.Info("Starting")
+	defer bw.logger.Info("Terminating")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case renderedBody := <-bw.receiveBody:
+			/*
+				// Simulate a delay, not perfect because it doesn't keep connections open, etc.
+				delay := rand.Int31n(300)
+				delay = 0
+				bw.logger.Infof("Received body, pausing for %d seconds", delay)
+
+				t := clock.NewTimer(ctx, time.Duration(delay)*time.Second)
+				select {
+				case <-t.C:
+				case <-ctx.Done():
+					t.Stop()
+					return
+				}
+			*/
+			bw.submitWithRetries(ctx, renderedBody)
+		}
+	}
+}
+
+func (bw *bodyWriter) submitWithRetries(ctx context.Context, renderedBody *renderedBody) {
+	backOff := bw.newBackOff()
+	for {
+		err := bw.submitBody(ctx, renderedBody)
+		if err == nil {
+			return
+		}
+
+		err = errors.New(strings.Replace(err.Error(), bw.apiKey, "*****", -1))
+
+		next := backOff.NextBackOff()
+		if next == backoff.Stop {
+			bw.logger.WithError(err).Error("Failed to send (hard)")
+			return
+		}
+		bw.logger.WithError(err).Warnf("Failed to send (retry in %v)", next.Seconds())
+
+		t := clock.NewTimer(ctx, next)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+		}
+	}
+}
+
+func (bw *bodyWriter) submitBody(ctx context.Context, rb *renderedBody) error {
+	// Must not log, only returns errors up.  Keep API key sanitization in one place.
+	req, err := http.NewRequest("POST", bw.upstreamURL, bytes.NewReader(rb.body))
+	if err != nil {
+		return err
+	}
+
+	req = req.WithContext(ctx)
+	// req = bw.tracer.WithTrace(req)
+
+	req.Header.Set("Content-Type", "application/json")
+	// req.Header.Set("DD-Dogstatsd-Version", "5.6.3")
+	req.Header.Set("User-Agent", bw.userAgent)
+	if rb.compressed {
+		req.Header.Set("Content-Encoding", "deflate")
+	}
+
+	/*
+		// For testing only.  This logs secrets.
+		r, _ := httputil.DumpRequest(req, true)
+		bw.logger.WithField("req", string(r)).Info("body")
+	*/
+
+	resp, err := bw.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusNoContent {
+		return errors.New(fmt.Sprintf("bad status code: %d", resp.StatusCode))
+	}
+	return nil
+
+}

--- a/pkg/backends/datadogexp/body_writer_test.go
+++ b/pkg/backends/datadogexp/body_writer_test.go
@@ -1,0 +1,235 @@
+package datadogexp
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBodyWriter(ctx context.Context, t *testing.T, mux *http.ServeMux) (*bodyWriter, *httptest.Server, chan<- *renderedBody) {
+	ts := httptest.NewServer(mux)
+	renderBody := make(chan *renderedBody)
+
+	client := &http.Client{}
+
+	logger := logrus.New()
+
+	bw, err := newBodyWriter(
+		logger,
+		"gostatsd",
+		ts.URL,
+		"1234",
+		client,
+		func() backoff.BackOff {
+			return backoff.WithMaxRetries(&backoff.ZeroBackOff{}, 3)
+		},
+		renderBody,
+	)
+	require.NoError(t, err, "failed to create bodyWriter")
+
+	go bw.Run(ctx)
+
+	return bw, ts, renderBody
+}
+
+func TestBodyWriterRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	calls := int64(0)
+
+	done := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/series", func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+
+		require.NoError(t, err, "error reading body")
+		_ = r.Body.Close()
+
+		require.Equal(t, "body", string(body), "unexpected body")
+
+		if atomic.AddInt64(&calls, 1) == 3 {
+			w.WriteHeader(http.StatusAccepted)
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "timeout submitting done")
+			case done <- struct{}{}:
+			}
+		} else {
+			w.WriteHeader(http.StatusForbidden)
+		}
+		logrus.Info("Request")
+	})
+
+	_, ts, rb := newTestBodyWriter(ctx, t, mux)
+	defer ts.Close()
+
+	b := &renderedBody{
+		[]byte("body"),
+		false,
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout submitting body")
+	case rb <- b:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout waiting for done")
+	case <-done:
+	}
+
+	require.EqualValues(t, 3, calls, "unexpected retry count")
+}
+
+func TestBodyWriterSetsCompressionHeader(t *testing.T) {
+	// Does not test for actual compressed content, as it is not responsible for compressing.
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/series", func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "error reading body")
+		_ = r.Body.Close()
+
+		require.Equal(t, "body", string(body), "unexpected body")
+		require.Equal(t, "deflate", r.Header.Get("Content-Encoding"), "invalid encoding")
+		w.WriteHeader(http.StatusAccepted)
+
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "timeout submitting done")
+		case done <- struct{}{}:
+		}
+	})
+
+	_, ts, rb := newTestBodyWriter(ctx, t, mux)
+	defer ts.Close()
+
+	b := &renderedBody{
+		[]byte("body"),
+		true,
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout submitting body")
+	case rb <- b:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout waiting for done")
+	case <-done:
+	}
+}
+
+func TestBodyWriterSkipsCompressionHeader(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/series", func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "error reading body")
+		_ = r.Body.Close()
+
+		require.Equal(t, "body", string(body), "unexpected body")
+		require.Equal(t, "", r.Header.Get("Content-Encoding"), "invalid encoding")
+		w.WriteHeader(http.StatusAccepted)
+
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "timeout submitting done")
+		case done <- struct{}{}:
+		}
+	})
+
+	_, ts, rb := newTestBodyWriter(ctx, t, mux)
+	defer ts.Close()
+
+	b := &renderedBody{
+		[]byte("body"),
+		false,
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout submitting body")
+	case rb <- b:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout waiting for done")
+	case <-done:
+	}
+}
+
+func TestBodyWriterSetsCommonHeaders(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/series", func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "error reading body")
+		_ = r.Body.Close()
+
+		require.Equal(t, "body", string(body), "unexpected body")
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"), "invalid content-type")
+		w.WriteHeader(http.StatusAccepted)
+
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "timeout submitting done")
+		case done <- struct{}{}:
+		}
+	})
+
+	_, ts, rb := newTestBodyWriter(ctx, t, mux)
+	defer ts.Close()
+
+	b := &renderedBody{
+		[]byte("body"),
+		false,
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout submitting body")
+	case rb <- b:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout waiting for done")
+	case <-done:
+	}
+}

--- a/pkg/backends/datadogexp/body_writer_tracer.go
+++ b/pkg/backends/datadogexp/body_writer_tracer.go
@@ -1,0 +1,50 @@
+package datadogexp
+
+import (
+	"net/http"
+	"net/http/httptrace"
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+)
+
+type tracer struct {
+	count  uint64
+	logger logrus.FieldLogger
+	trace  *httptrace.ClientTrace
+}
+
+const uMinus1 = ^uint64(0)
+
+func newTracer(logger logrus.FieldLogger) *tracer {
+	t := &tracer{
+		logger: logger,
+	}
+	t.trace = &httptrace.ClientTrace{
+		GotConn:     t.traceGotConn,
+		PutIdleConn: t.tracePutIdleConn,
+	}
+	return t
+}
+
+func (t *tracer) traceGotConn(gci httptrace.GotConnInfo) {
+	if gci.WasIdle {
+		c := atomic.AddUint64(&t.count, uMinus1)
+		t.logger.WithField("count", c).Info("Borrowed")
+	} else {
+		t.logger.Info("Created")
+	}
+}
+
+func (t *tracer) tracePutIdleConn(err error) {
+	if err != nil {
+		t.logger.Info("Failed to put")
+	} else {
+		c := atomic.AddUint64(&t.count, 1)
+		t.logger.WithField("count", c).Info("Returned")
+	}
+}
+
+func (t *tracer) WithTrace(r *http.Request) *http.Request {
+	return r.WithContext(httptrace.WithClientTrace(r.Context(), t.trace))
+}

--- a/pkg/backends/datadogexp/datadog.go
+++ b/pkg/backends/datadogexp/datadog.go
@@ -1,0 +1,312 @@
+package datadogexp
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+	stats "github.com/atlassian/gostatsd/pkg/statser"
+
+	"github.com/ash2k/stager"
+	"github.com/atlassian/gostatsd/pkg/statsd"
+	"github.com/cenkalti/backoff"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+const (
+	BackendName                  = "datadogexp"
+	defaultUpstreamURL           = "https://app.datadoghq.com"
+	defaultUserAgent             = "gostatsd"
+	defaultMaxRequestElapsedTime = 15 * time.Second
+	defaultClientTimeout         = 9 * time.Second
+	defaultMetricsPerBatch       = 1000
+	defaultNumWriters            = 40 // TODO: f(cores)
+	defaultNumSerializers        = 40 // TODO: f(cores)
+	defaultBufferIntervals       = 24 // assuming 10s interval, gives 240s / 4m
+
+	defaultEnableHttp2 = false
+)
+
+// datadogClient represents an experimental Datadog client.
+type datadogClient struct {
+	logger         logrus.FieldLogger
+	numWriters     int
+	numSerializers int
+
+	// metrics pathway
+	metricsQueue    chan<- *batchMessage
+	metricBuffer    *metricBuffer
+	metricBatcher   *metricBatcher
+	batchSerializer *batchSerializer
+	bodyWriter      *bodyWriter
+
+	// events pathway
+	// ...
+}
+
+func (d *datadogClient) Run(ctx context.Context) {
+	d.logger.Info("Starting")
+	defer d.logger.Info("Terminating")
+	stgr := stager.New()
+	stage := stgr.NextStage()
+	for i := 0; i < d.numWriters; i++ {
+		stage.StartWithContext(d.bodyWriter.Run) // Network bound
+	}
+	stage = stgr.NextStage()
+	for i := 0; i < d.numSerializers; i++ {
+		stage.StartWithContext(d.batchSerializer.Run) // CPU bound
+	}
+	stage = stgr.NextStage()
+	stage.StartWithContext(d.metricBatcher.Run) // Single instance
+	stage = stgr.NextStage()
+	stage.StartWithContext(d.metricBuffer.Run) // Single instance
+	<-ctx.Done()
+	stgr.Shutdown()
+}
+
+// SendMetricsAsync will send metrics asynchronously, invoking cb once the map is no longer used.
+func (d *datadogClient) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
+	bm := &batchMessage{
+		metrics:   metrics.Copy(), // metrics may not be accessed after this function returns
+		flushTime: flushTime,
+		done:      cb,
+	}
+
+	select {
+	case <-ctx.Done():
+	case d.metricsQueue <- bm:
+	}
+}
+
+func (d *datadogClient) RunMetrics(ctx context.Context, statser stats.Statser) {
+	statser = statser.WithTags(gostatsd.Tags{"backend:datadogexp"})
+
+	flushed, unregister := statser.RegisterFlush()
+	defer unregister()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-flushed:
+		}
+	}
+}
+
+// SendEvent sends an event to Datadog.
+// TODO
+func (d *datadogClient) SendEvent(ctx context.Context, e *gostatsd.Event) error {
+	/*
+		return d.post(ctx, buffer, "/api/v1/events", "events", &event{
+			Title:          e.Title,
+			Text:           e.Text,
+			DateHappened:   e.DateHappened,
+			Hostname:       e.Hostname,
+			AggregationKey: e.AggregationKey,
+			SourceTypeName: e.SourceTypeName,
+			Tags:           e.Tags,
+			Priority:       e.Priority.StringWithEmptyDefault(),
+			AlertType:      e.AlertType.StringWithEmptyDefault(),
+		})
+	*/
+	return nil
+}
+
+// Name returns the name of the backend.
+func (d *datadogClient) Name() string {
+	return BackendName
+}
+
+// NewClientFromViper returns a new Datadog API client.
+func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
+	dd := getSubViper(v, "datadogexp")
+	dd.SetDefault("api-endpoint", defaultUpstreamURL)
+	dd.SetDefault("user-agent", defaultUserAgent)
+	dd.SetDefault("network", "tcp")
+	dd.SetDefault("metrics-per-batch", defaultMetricsPerBatch)
+	dd.SetDefault("num-writers", defaultNumWriters)
+	dd.SetDefault("num-serializers", defaultNumSerializers)
+	dd.SetDefault("buffer-intervals", defaultBufferIntervals)
+	dd.SetDefault("compress-payload", true)
+	dd.SetDefault("client-timeout", defaultClientTimeout)
+	dd.SetDefault("max-request-elapsed-time", defaultMaxRequestElapsedTime)
+	dd.SetDefault("enable-http2", defaultEnableHttp2)
+
+	return NewClient(
+		logrus.StandardLogger(),
+		dd.GetString("api-endpoint"),
+		dd.GetString("api-key"),
+		dd.GetString("user-agent"),
+		dd.GetString("network"),
+		dd.GetInt("metrics-per-batch"),
+		v.GetInt(statsd.ParamMaxWorkers), // Main viper - num of aggregators
+		dd.GetInt("num-writers"),
+		dd.GetInt("num-serializers"),
+		dd.GetInt("buffer-intervals"),
+		dd.GetBool("compress-payload"),
+		dd.GetBool("enable-http2"),
+		dd.GetDuration("client-timeout"),
+		dd.GetDuration("max-request-elapsed-time"),
+		v.GetDuration(statsd.ParamFlushInterval), // Main viper
+		gostatsd.DisabledSubMetrics(v),
+	)
+}
+
+// NewClient returns a new experimental Datadog API client.
+func NewClient(
+	logger logrus.FieldLogger,
+	apiEndpoint, apiKey, userAgent, network string,
+	metricsPerBatch, numAggregators, numWriters, numSerializers, bufIntervals int,
+	compressPayload, enableHttp2 bool,
+	clientTimeout, maxRequestElapsedTime, flushInterval time.Duration,
+	disabled gostatsd.TimerSubtypes,
+) (*datadogClient, error) {
+	logger = logger.WithField("backend", BackendName) // TODO: Push this out
+
+	if apiEndpoint == "" {
+		return nil, fmt.Errorf("[%s] api-endpoint is required", BackendName)
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("[%s] api-key is required", BackendName)
+	}
+	if metricsPerBatch <= 0 {
+		return nil, fmt.Errorf("[%s] metrics-per-batch must be positive", BackendName)
+	}
+	if clientTimeout <= 0 {
+		return nil, fmt.Errorf("[%s] client-timeout must be positive", BackendName)
+	}
+	if maxRequestElapsedTime <= 0 {
+		return nil, fmt.Errorf("[%s] max-request-elapsed-time must be positive", BackendName)
+	}
+	if numWriters <= 0 {
+		return nil, fmt.Errorf("[%s] num-writers must be positive", BackendName)
+	}
+	if numSerializers <= 0 {
+		return nil, fmt.Errorf("[%s] num-serializers must be positive", BackendName)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"apiEndpoint":           apiEndpoint,
+		"userAgent":             userAgent,
+		"network":               network,
+		"metricsPerBatch":       metricsPerBatch,
+		"numWriters":            numWriters,
+		"numSerializers":        numSerializers,
+		"compressPayload":       compressPayload,
+		"enableHttp2":           enableHttp2,
+		"clientTimeout":         clientTimeout,
+		"maxRequestElapsedTime": maxRequestElapsedTime,
+	}).Info("backend starting")
+
+	dialer := &net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 3 * time.Second,
+		TLSClientConfig: &tls.Config{
+			// Can't use SSLv3 because of POODLE and BEAST
+			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+			// Can't use TLSv1.1 because of RC4 cipher usage
+			MinVersion: tls.VersionTLS12,
+		},
+		DialContext: func(ctx context.Context, _, address string) (net.Conn, error) {
+			// replace the network with our own
+			return dialer.DialContext(ctx, network, address)
+		},
+		MaxIdleConns:    50,
+		IdleConnTimeout: 1 * time.Minute,
+	}
+
+	if !enableHttp2 {
+		// A non-nil empty map used in TLSNextProto to disable HTTP/2 support in client.
+		// https://golang.org/doc/go1.6#http2
+		transport.TLSNextProto = map[string](func(string, *tls.Conn) http.RoundTripper){}
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   clientTimeout,
+	}
+
+	metricsQueue := make(chan *batchMessage, numAggregators)
+	bufferRequested := make(chan struct{})
+	bufferToBatcher := make(chan ddMetricMap)
+	batcherToSerializer := make(chan ddTimeSeries)
+	serializerToWriter := make(chan *renderedBody)
+
+	metricBuffer := &metricBuffer{
+		logger:           logger.WithField("component", "metricBuffer"),
+		disabledSubTypes: &disabled,
+		flushIntervalSec: flushInterval.Seconds(),
+		capacity:         bufIntervals,
+		metricsQueue:     metricsQueue,
+		bufferRequested:  bufferRequested,
+		bufferReady:      bufferToBatcher,
+	}
+
+	metricBatcher := &metricBatcher{
+		logger:          logger.WithField("component", "metricBatcher"),
+		interval:        flushInterval,
+		metricsPerBatch: metricsPerBatch,
+		requestData:     bufferRequested,
+		receiveData:     bufferToBatcher,
+		submitBatch:     batcherToSerializer,
+	}
+
+	batchSerializer := &batchSerializer{
+		logger:       logger.WithField("component", "batchSerializer"),
+		compress:     compressPayload,
+		receiveBatch: batcherToSerializer,
+		submitBody:   serializerToWriter,
+		json: jsoniter.Config{
+			EscapeHTML:  false,
+			SortMapKeys: false,
+		}.Froze(),
+	}
+
+	bodyWriter, err := newBodyWriter(
+		logger.WithField("component", "bodyWriter"),
+		userAgent,
+		apiEndpoint,
+		apiKey,
+		httpClient,
+		func() backoff.BackOff {
+			bo := backoff.NewExponentialBackOff()
+			bo.MaxElapsedTime = maxRequestElapsedTime
+			return bo
+		},
+		serializerToWriter,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("[%s] Unable to create bodyWriter: %v", BackendName, err)
+	}
+
+	return &datadogClient{
+		logger:         logger.WithField("component", "main"),
+		numWriters:     numWriters,
+		numSerializers: numSerializers,
+
+		metricsQueue:    metricsQueue,
+		metricBuffer:    metricBuffer,
+		metricBatcher:   metricBatcher,
+		batchSerializer: batchSerializer,
+		bodyWriter:      bodyWriter,
+	}, nil
+}
+
+func getSubViper(v *viper.Viper, key string) *viper.Viper {
+	n := v.Sub(key)
+	if n == nil {
+		n = viper.New()
+	}
+	return n
+}

--- a/pkg/backends/datadogexp/metric_batcher.go
+++ b/pkg/backends/datadogexp/metric_batcher.go
@@ -1,0 +1,101 @@
+package datadogexp
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tilinna/clock"
+)
+
+type metricBatcher struct {
+	logger logrus.FieldLogger
+
+	// interval is how often the metricBatcher should wake up and request more data to process.
+	interval time.Duration
+
+	// metricsPerBatch is how many individual metrics to put in a single ddTimeSeries batch.
+	metricsPerBatch int
+
+	// requestData is used to signal to a downstream component that the metricBatcher is idle and free to
+	// do work. It will never be written to in a blocking fashion.
+	requestData chan<- struct{}
+
+	// receiveData is where downstream components submit data to be processed in to batches of ddTimeSeries
+	// objects.  It should be unbuffered to create back pressure.
+	receiveData <-chan ddMetricMap
+
+	// submitBody is where upstream batches of metrics are sent for further processing.  It is not opinionated
+	// on whether this is buffered, but it is expected that for any single receive of receiveData, many sends
+	// will occur to submitBody.
+	submitBatch chan<- ddTimeSeries
+}
+
+var plz = struct{}{}
+
+// Run is responsible for periodically getting some data, packaging it in to ddTimeSeries
+// batches, and sending it upstream.
+func (mb *metricBatcher) Run(ctx context.Context) {
+	mb.logger.Info("Starting")
+	defer mb.logger.Info("Terminating")
+
+	t := clock.NewTicker(ctx, mb.interval)
+	defer t.Stop()
+
+	// Doing this at the start of the loop is mainly for tests
+	mb.requestMoreData()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			// wake up and loop
+			mb.requestMoreData()
+		case data := <-mb.receiveData:
+			mb.processData(ctx, data)
+		}
+	}
+}
+
+// requestMoreData will politely signal on the requestData channel that the metricBatcher has no data left to process.
+func (mb *metricBatcher) requestMoreData() {
+	select {
+	case mb.requestData <- plz:
+	default:
+	}
+}
+
+// processData will turn an indexable ddMetricMap in to ddTimeSeries batches, and sends them to the submitBatch channel.
+func (mb *metricBatcher) processData(ctx context.Context, data ddMetricMap) {
+	ts := ddTimeSeries{
+		Series: make([]*ddMetric, 0, mb.metricsPerBatch),
+	}
+
+	for _, mm := range data {
+		for _, m := range mm {
+			/* maybe we reuse things at some point.
+			if len(m.Points) == 0 {
+				continue
+			}
+			*/
+			ts.Series = append(ts.Series, m)
+			if len(ts.Series) == mb.metricsPerBatch {
+				select {
+				case <-ctx.Done():
+					return
+				case mb.submitBatch <- ts:
+				}
+				ts = ddTimeSeries{
+					Series: make([]*ddMetric, 0, mb.metricsPerBatch),
+				}
+			}
+		}
+	}
+
+	if len(ts.Series) > 0 {
+		select {
+		case <-ctx.Done():
+		case mb.submitBatch <- ts:
+		}
+	}
+}

--- a/pkg/backends/datadogexp/metric_batcher_test.go
+++ b/pkg/backends/datadogexp/metric_batcher_test.go
@@ -1,0 +1,236 @@
+package datadogexp
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	//"github.com/stretchr/testify/assert"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/tilinna/clock"
+)
+
+func makeTestBatcher(ctx context.Context, interval time.Duration, batchSize, reqBufSize int) (
+	*metricBatcher,
+	<-chan struct{},
+	chan<- ddMetricMap,
+	<-chan ddTimeSeries,
+) {
+	reqData := make(chan struct{}, reqBufSize)
+	rcvData := make(chan ddMetricMap)
+	subBatch := make(chan ddTimeSeries)
+
+	mb := &metricBatcher{
+		logger:          logrus.StandardLogger(),
+		interval:        interval,
+		metricsPerBatch: batchSize,
+		requestData:     reqData,
+		receiveData:     rcvData,
+		submitBatch:     subBatch,
+	}
+
+	go mb.Run(ctx)
+	return mb, reqData, rcvData, subBatch
+
+}
+
+func TestMetricBatcherRequestsDataMultipleTimes(t *testing.T) {
+	t.Parallel()
+
+	c := clock.NewMock(time.Unix(0, 0))
+	realCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx := clock.Context(realCtx, c)
+	defer cancel()
+
+	// It's possible the test isn't ready to receive from reqData by the time
+	// the metricBatcher is trying to signal, so make the channel buffered.
+	_, reqData, _, _ := makeTestBatcher(ctx, 10*time.Second, 1, 1)
+
+	// Put current time halfway between intervals to avoid dealing with < vs <=
+	c.Add(5 * time.Second)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-realCtx.Done():
+			require.Fail(t, "timeout waiting for pull")
+		case <-reqData:
+		}
+		c.Add(10 * time.Second)
+	}
+}
+
+func m1() *ddMetric {
+	return &ddMetric{
+		Host:     "hostname",
+		Interval: 10,
+		Metric:   "name",
+		Points: []ddPoint{
+			{0, 0},
+		},
+		Tags: nil,
+		Type: "gauge",
+	}
+}
+
+func m2() *ddMetric {
+	return &ddMetric{
+		Host:     "hostname",
+		Interval: 10,
+		Metric:   "name",
+		Points: []ddPoint{
+			{0, 0},
+		},
+		Tags: []string{"key:value"},
+		Type: "gauge",
+	}
+}
+
+func m3() *ddMetric {
+	return &ddMetric{
+		Host:     "hostname",
+		Interval: 10,
+		Metric:   "name.rate",
+		Points: []ddPoint{
+			{0, 0},
+		},
+		Tags: []string{"key:value"},
+		Type: "rate",
+	}
+}
+
+func TestMetricBatcherSplitsBatches(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	_, _, rcvData, subBatch := makeTestBatcher(ctx, 10*time.Second, 1, 0)
+
+	mm := ddMetricMap{
+		"name": {
+			"s.hostname":           m1(),
+			"key.value.s.hostname": m2(),
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pushing metric map")
+	case rcvData <- mm:
+	}
+
+	// order is non-determinstic, check if the result is in the array
+	expected := []ddTimeSeries{
+		{Series: []*ddMetric{m1()}},
+		{Series: []*ddMetric{m2()}},
+	}
+	var ts1, ts2 ddTimeSeries
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pulling batch 1")
+	case ts1 = <-subBatch:
+		require.Contains(t, expected, ts1, "not equal 1")
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pulling batch 2")
+	case ts2 = <-subBatch:
+		require.Contains(t, expected, ts2, "not equal 2")
+	}
+
+	// make sure we didn't get the same result twice
+	require.NotEqual(t, ts1, ts2, "received same ts twice")
+}
+
+func TestMetricBatcherSendsFinalBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	mb, _, rcvData, subBatch := makeTestBatcher(ctx, 10*time.Second, 2, 0)
+	mb.metricsPerBatch = 2
+
+	mm := ddMetricMap{
+		"name": {
+			"s.hostname":           m1(),
+			"key.value.s.hostname": m2(),
+		},
+		"name.rate": {
+			"key.value.s.hostname": m3(),
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pushing metric map")
+	case rcvData <- mm:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pulling batch 1")
+	case ts := <-subBatch:
+		require.Equal(t, 2, len(ts.Series), "expecting 2 metrics")
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout pulling batch 2")
+	case ts := <-subBatch:
+		require.Equal(t, 1, len(ts.Series), "expecting 1 metric")
+	}
+}
+
+func benchmarkMetricBatcher(b *testing.B, batchSize, nameLimit int) {
+	_, _, rcvData, subBatch := makeTestBatcher(context.Background(), 1*time.Second, batchSize, 0)
+
+	mm := ddMetricMap{}
+	rnd := rand.New(rand.NewSource(0))
+	for i := 0; i < b.N/batchSize; i++ {
+		name := strconv.Itoa(int(rnd.Int31n(int32(nameLimit))))
+		c := strconv.Itoa(len(mm[name]))
+		if mm[name] == nil {
+			mm[name] = map[string]*ddMetric{}
+		}
+		mm[name]["tag.value.s."+c] = &ddMetric{
+			Host:     c,
+			Interval: 10,
+			Metric:   name,
+			Points: []ddPoint{
+				{0, 0},
+			},
+			Tags: []string{"tag:value"},
+			Type: "rate",
+		}
+	}
+
+	b.ReportAllocs()
+
+	b.ResetTimer()
+	for i := 0; i < batchSize; i++ {
+		rcvData <- mm
+		rcvd := 0
+		for rcvd < b.N/batchSize {
+			ts := <-subBatch
+			rcvd += len(ts.Series)
+		}
+	}
+}
+
+func BenchmarkMetricBatch(b *testing.B) {
+	for nameLimit := 1000; nameLimit <= 100000; nameLimit *= 10 {
+		for batchSize := 499; batchSize < 1000; batchSize += 500 { // non-factor of b.N
+			b.Run(fmt.Sprintf("n%d-b%d", nameLimit, batchSize), func(b *testing.B) {
+				benchmarkMetricBatcher(b, batchSize, nameLimit)
+			})
+		}
+	}
+}

--- a/pkg/backends/datadogexp/metric_buffer.go
+++ b/pkg/backends/datadogexp/metric_buffer.go
@@ -1,0 +1,234 @@
+package datadogexp
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// metricBuffer will process aggregated data in to a single map, accumulating multiple points
+// for a timeseries.  If too many points are accumulated, it will attempt to push data to the
+// upstream buffer, blocking as required.
+type metricBuffer struct {
+	logger logrus.FieldLogger
+
+	disabledSubTypes *gostatsd.TimerSubtypes
+	timeSeriesBuffer ddMetricMap
+	flushIntervalSec float64
+	capacity         int
+
+	// metricsQueue is the channel via which batches of aggregated data is submitted to the metricBuffer.  The
+	// chan must be as deep as there is number of aggregators sending data, or the aggregators may block early.
+	// This is where backpressure enters the handler pipeline.  The batchMessage done function will be executed
+	// after being processed.
+	metricsQueue <-chan *batchMessage
+
+	// bufferRequested is a channel where an upstream component can notify the metricBuffer that it is idle.
+	// The metricBuffer may ignore a request for data.  It is the responsibility of the upstream to request
+	// data on a regular interval, even if none is provided.
+	bufferRequested <-chan struct{}
+
+	// bufferReady is where a metricBuffer will deliver a ddMetricMap for further processing.  This is expected
+	// to occur after a buffer is requested via bufferRequested, or when the metricBuffer has reached a threshold
+	// of too much data.  If the upstream handler is busy, this is where metricBuffer gets back pressure, which
+	// propagates through the system as reading of the metricsQueue will halt.
+	bufferReady chan<- ddMetricMap
+}
+
+// Run pulls data from the raw queue and accumulates it
+func (mb *metricBuffer) Run(ctx context.Context) {
+	mb.logger.Info("Starting")
+	defer mb.logger.Info("Terminating")
+
+	mb.timeSeriesBuffer = ddMetricMap{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case mm := <-mb.metricsQueue:
+			if mb.processMetricBuffer(ctx, mm) {
+				mb.logger.Info("Forcing flush")
+				mb.flush(ctx)
+			}
+		case <-mb.bufferRequested:
+			mb.logger.Info("Requested flush")
+			mb.flush(ctx)
+		}
+	}
+}
+
+func (mb *metricBuffer) processMetricBuffer(ctx context.Context, mm *batchMessage) bool {
+	timestamp := float64(mm.flushTime.Unix())
+
+	counters, forceFlushC := mb.processCounters(mm, timestamp)
+	timers, forceFlushT := mb.processTimers(mm, timestamp)
+	gauges, forceFlushG := mb.processGauges(mm, timestamp)
+	sets, forceFlushS := mb.processSets(mm, timestamp)
+
+	mb.logger.WithFields(logrus.Fields{
+		"counters": counters,
+		"timers":   timers,
+		"gauges":   gauges,
+		"sets":     sets,
+	}).Info("Processed metrics")
+
+	// Signal done
+	mm.done(nil)
+
+	return forceFlushC || forceFlushT || forceFlushG || forceFlushS
+}
+
+func (mb *metricBuffer) processCounters(mm *batchMessage, timestamp float64) (int, bool) {
+	counters := 0
+	forceFlush := false
+
+	mm.metrics.Counters.Each(func(metricName, tagsKey string, c gostatsd.Counter) {
+		counters++
+		if mb.addMetric(rate, ddPoint{timestamp, c.PerSecond}, c.Hostname, c.Tags, tagsKey, metricName) {
+			forceFlush = true
+		}
+		if mb.addMetric(gauge, ddPoint{timestamp, float64(c.Value)}, c.Hostname, c.Tags, tagsKey, metricName+".count") {
+			forceFlush = true
+		}
+	})
+
+	return counters, forceFlush
+}
+
+func (mb *metricBuffer) processTimers(mm *batchMessage, timestamp float64) (int, bool) {
+	timers := 0
+	forceFlush := false
+
+	disabled := mb.disabledSubTypes
+
+	mm.metrics.Timers.Each(func(metricName, tagsKey string, t gostatsd.Timer) {
+		timers++
+		if !disabled.Lower {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.Min}, t.Hostname, t.Tags, tagsKey, metricName+".lower") {
+				forceFlush = true
+			}
+		}
+		if !disabled.Upper {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.Max}, t.Hostname, t.Tags, tagsKey, metricName+".upper") {
+				forceFlush = true
+			}
+		}
+		if !disabled.Count {
+			if mb.addMetric(gauge, ddPoint{timestamp, float64(t.Count)}, t.Hostname, t.Tags, tagsKey, metricName+".count") {
+				forceFlush = true
+			}
+		}
+		if !disabled.CountPerSecond {
+			if mb.addMetric(rate, ddPoint{timestamp, t.PerSecond}, t.Hostname, t.Tags, tagsKey, metricName+".count_ps") {
+				forceFlush = true
+			}
+		}
+		if !disabled.Mean {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.Mean}, t.Hostname, t.Tags, tagsKey, metricName+".mean") {
+				forceFlush = true
+			}
+		}
+		if !disabled.Median {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.Median}, t.Hostname, t.Tags, tagsKey, metricName+".median") {
+				forceFlush = true
+			}
+		}
+		if !disabled.StdDev {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.StdDev}, t.Hostname, t.Tags, tagsKey, metricName+".std") {
+				forceFlush = true
+			}
+		}
+		if !disabled.Sum {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.Sum}, t.Hostname, t.Tags, tagsKey, metricName+".sum") {
+				forceFlush = true
+			}
+		}
+		if !disabled.SumSquares {
+			if mb.addMetric(gauge, ddPoint{timestamp, t.SumSquares}, t.Hostname, t.Tags, tagsKey, metricName+".sum_squares") {
+				forceFlush = true
+			}
+		}
+		for _, pct := range t.Percentiles {
+			if mb.addMetric(gauge, ddPoint{timestamp, pct.Float}, t.Hostname, t.Tags, tagsKey, metricName+"."+pct.Str) {
+				forceFlush = true
+			}
+		}
+	})
+
+	return timers, forceFlush
+}
+
+func (mb *metricBuffer) processGauges(mm *batchMessage, timestamp float64) (int, bool) {
+	gauges := 0
+	forceFlush := false
+
+	mm.metrics.Gauges.Each(func(metricName, tagsKey string, g gostatsd.Gauge) {
+		gauges++
+		if mb.addMetric(gauge, ddPoint{timestamp, g.Value}, g.Hostname, g.Tags, tagsKey, metricName) {
+			forceFlush = true
+		}
+	})
+
+	return gauges, forceFlush
+}
+
+func (mb *metricBuffer) processSets(mm *batchMessage, timestamp float64) (int, bool) {
+	sets := 0
+	forceFlush := false
+
+	mm.metrics.Sets.Each(func(metricName, tagsKey string, s gostatsd.Set) {
+		sets++
+		if mb.addMetric(gauge, ddPoint{timestamp, float64(len(s.Values))}, s.Hostname, s.Tags, tagsKey, metricName) {
+			forceFlush = true
+		}
+	})
+
+	return sets, forceFlush
+}
+
+func (mb *metricBuffer) flush(ctx context.Context) {
+	if len(mb.timeSeriesBuffer) == 0 {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case mb.bufferReady <- mb.timeSeriesBuffer:
+		mb.timeSeriesBuffer = ddMetricMap{}
+		mb.logger.Info("Data flushed")
+	}
+}
+
+func (mb *metricBuffer) newMetric(hostname, metricName string, tags gostatsd.Tags, metricType metricType) *ddMetric {
+	return &ddMetric{
+		Host:     hostname,
+		Interval: mb.flushIntervalSec,
+		Metric:   metricName,
+		Points:   make([]ddPoint, 0, mb.capacity),
+		Tags:     tags,
+		Type:     metricType,
+	}
+}
+
+func (mb *metricBuffer) addMetric(metricType metricType, point ddPoint, hostname string, tags gostatsd.Tags, tagsKey, metricName string) bool {
+	var metric *ddMetric
+
+	if tagMap, ok := mb.timeSeriesBuffer[metricName]; !ok {
+		// Name not found
+		metric = mb.newMetric(hostname, metricName, tags, metricType)
+		mb.timeSeriesBuffer[metricName] = map[string]*ddMetric{
+			tagsKey: metric,
+		}
+	} else if metric, ok = tagMap[tagsKey]; !ok { // Sets metric if it succeeds
+		// Tagset not found
+		metric = mb.newMetric(hostname, metricName, tags, metricType)
+		tagMap[tagsKey] = metric
+	}
+
+	metric.Points = append(metric.Points, point)
+	return len(metric.Points) >= mb.capacity
+}

--- a/pkg/backends/datadogexp/metric_buffer_test.go
+++ b/pkg/backends/datadogexp/metric_buffer_test.go
@@ -1,0 +1,564 @@
+package datadogexp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
+)
+
+func makeTestMetricBuffer(ctx context.Context, interval time.Duration, bufferSize int, disabled *gostatsd.TimerSubtypes) (
+	chan<- *batchMessage,
+	chan<- struct{},
+	<-chan ddMetricMap,
+) {
+	metricsQueue := make(chan *batchMessage, bufferSize)
+	bufferRequested := make(chan struct{})
+	bufferReady := make(chan ddMetricMap)
+
+	mb := &metricBuffer{
+		logger:           logrus.StandardLogger(),
+		disabledSubTypes: disabled,
+		flushIntervalSec: interval.Seconds(),
+		capacity:         10,
+		metricsQueue:     metricsQueue,
+		bufferRequested:  bufferRequested,
+		bufferReady:      bufferReady,
+	}
+
+	go mb.Run(ctx)
+	return metricsQueue, bufferRequested, bufferReady
+}
+
+func TestMetricBufferFlushesOnOverflow(t *testing.T) {
+	// Sends metrics forever without requesting a flush, ensure a flush still occurs.
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// unbuffered queue to make sure things are processed in a predictable order
+	mq, _, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 10, &gostatsd.TimerSubtypes{})
+
+	mm := &gostatsd.MetricMap{
+		Gauges: gostatsd.Gauges{
+			"metric": map[string]gostatsd.Gauge{
+				"key.value.s.hostname": {
+					Value:     1,
+					Timestamp: 0,
+					Hostname:  "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+	}
+
+	bm := &batchMessage{
+		mm,
+		time.Now(),
+		func(err []error) {},
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "timeout waiting for flush")
+		case mq <- bm:
+			// submitted
+		case b := <-bufReady:
+			require.EqualValues(t, 10, len(b["metric"]["key.value.s.hostname"].Points), "unexpected point count")
+			require.EqualValues(t, 10, cap(b["metric"]["key.value.s.hostname"].Points), "unexpected point cap")
+			return
+		}
+	}
+
+}
+
+func TestMetricBufferCallsDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// unbuffered queue to make sure things are processed in a predictable order
+	mq, bufReq, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 0, &gostatsd.TimerSubtypes{})
+
+	mm := &gostatsd.MetricMap{
+		Gauges: gostatsd.Gauges{
+			"metric": map[string]gostatsd.Gauge{
+				"key.value.s.hostname": {
+					Value:     1,
+					Timestamp: 0,
+					Hostname:  "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+	}
+
+	called := int64(0)
+	bm := &batchMessage{
+		metrics:   mm,
+		flushTime: time.Now(),
+		done: func(err []error) {
+			atomic.AddInt64(&called, 1)
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout sending batch")
+	case mq <- bm:
+	}
+
+	// perform a sync request, to ensure the batch is processed
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout requesting response")
+	case bufReq <- plz:
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout getting response")
+	case <-bufReady:
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt64(&called), "done was not called")
+}
+
+func TestMetricBufferPercentiles(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// unbuffered queue to make sure things are processed in a predictable order
+	mq, bufReq, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 0, &gostatsd.TimerSubtypes{})
+	mm := &gostatsd.MetricMap{
+		Timers: gostatsd.Timers{
+			"t": map[string]gostatsd.Timer{ // Does not test percentiles
+				"key.value.s.hostname": {
+					Count:      5,
+					PerSecond:  0.5,
+					Mean:       4,
+					Median:     4,
+					Min:        2,
+					Max:        6,
+					StdDev:     1.4,
+					Sum:        20,
+					SumSquares: 90,
+					Hostname:   "hostname",
+					Percentiles: gostatsd.Percentiles{
+						gostatsd.Percentile{
+							Float: 1.0,
+							Str:   "upper_90",
+						},
+					},
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+	}
+
+	timeStamp := 20.0
+	bm := &batchMessage{
+		metrics:   mm,
+		flushTime: time.Unix(int64(timeStamp), 0),
+		done:      func(err []error) {},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout sending batch")
+	case mq <- bm:
+	}
+
+	// perform a sync request, to ensure the batch is processed
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout requesting response")
+	case bufReq <- plz:
+	}
+
+	expected := ddMetricMap{
+		"t.count":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.count", "hostname", timeStamp, 5, "key:value")},
+		"t.count_ps":    map[string]*ddMetric{"key.value.s.hostname": newRate("t.count_ps", "hostname", timeStamp, 0.5, "key:value")},
+		"t.lower":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.lower", "hostname", timeStamp, 2, "key:value")},
+		"t.mean":        map[string]*ddMetric{"key.value.s.hostname": newGauge("t.mean", "hostname", timeStamp, 4, "key:value")},
+		"t.median":      map[string]*ddMetric{"key.value.s.hostname": newGauge("t.median", "hostname", timeStamp, 4, "key:value")},
+		"t.std":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.std", "hostname", timeStamp, 1.4, "key:value")},
+		"t.sum":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum", "hostname", timeStamp, 20, "key:value")},
+		"t.sum_squares": map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum_squares", "hostname", timeStamp, 90, "key:value")},
+		"t.upper":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.upper", "hostname", timeStamp, 6, "key:value")},
+		"t.upper_90":    map[string]*ddMetric{"key.value.s.hostname": newGauge("t.upper_90", "hostname", timeStamp, 1, "key:value")},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout getting response")
+	case result := <-bufReady:
+		require.Equal(t, expected, result, "result mismatch")
+	}
+}
+
+func TestMetricBufferHandlesAllMetricTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// unbuffered queue to make sure things are processed in a predictable order
+	mq, bufReq, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 0, &gostatsd.TimerSubtypes{})
+
+	mm := &gostatsd.MetricMap{
+		Counters: gostatsd.Counters{
+			"c": map[string]gostatsd.Counter{
+				"key.value.s.hostname": {
+					Value:     1,
+					PerSecond: 0.1,
+					Hostname:  "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+		Timers: gostatsd.Timers{
+			"t": map[string]gostatsd.Timer{ // Does not test percentiles
+				"key.value.s.hostname": {
+					Count:      5,
+					PerSecond:  0.5,
+					Mean:       4,
+					Median:     4,
+					Min:        2,
+					Max:        6,
+					StdDev:     1.4,
+					Sum:        20,
+					SumSquares: 90,
+					Hostname:   "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+		Gauges: gostatsd.Gauges{
+			"g": map[string]gostatsd.Gauge{
+				"key.value.s.hostname": {
+					Value:    7,
+					Hostname: "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+		Sets: gostatsd.Sets{
+			"s": map[string]gostatsd.Set{
+				"key.value.s.hostname": {
+					Values: map[string]struct{}{
+						"alice":   {},
+						"bob":     {},
+						"carol":   {},
+						"carlos":  {},
+						"charlie": {},
+						"chuck":   {},
+						"craig":   {},
+						"dan":     {},
+					},
+					Hostname: "hostname",
+					Tags: gostatsd.Tags{
+						"key:value",
+					},
+				},
+			},
+		},
+	}
+
+	timeStamp := 20.0
+	bm := &batchMessage{
+		metrics:   mm,
+		flushTime: time.Unix(int64(timeStamp), 0),
+		done:      func(err []error) {},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout sending batch")
+	case mq <- bm:
+	}
+
+	// perform a sync request, to ensure the batch is processed
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout requesting response")
+	case bufReq <- plz:
+	}
+
+	expected := ddMetricMap{
+		"c":             map[string]*ddMetric{"key.value.s.hostname": newRate("c", "hostname", timeStamp, 0.1, "key:value")},
+		"c.count":       map[string]*ddMetric{"key.value.s.hostname": newGauge("c.count", "hostname", timeStamp, 1, "key:value")},
+		"t.count":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.count", "hostname", timeStamp, 5, "key:value")},
+		"t.count_ps":    map[string]*ddMetric{"key.value.s.hostname": newRate("t.count_ps", "hostname", timeStamp, 0.5, "key:value")},
+		"t.lower":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.lower", "hostname", timeStamp, 2, "key:value")},
+		"t.mean":        map[string]*ddMetric{"key.value.s.hostname": newGauge("t.mean", "hostname", timeStamp, 4, "key:value")},
+		"t.median":      map[string]*ddMetric{"key.value.s.hostname": newGauge("t.median", "hostname", timeStamp, 4, "key:value")},
+		"t.std":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.std", "hostname", timeStamp, 1.4, "key:value")},
+		"t.sum":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum", "hostname", timeStamp, 20, "key:value")},
+		"t.sum_squares": map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum_squares", "hostname", timeStamp, 90, "key:value")},
+		"t.upper":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.upper", "hostname", timeStamp, 6, "key:value")},
+		"g":             map[string]*ddMetric{"key.value.s.hostname": newGauge("g", "hostname", timeStamp, 7, "key:value")},
+		"s":             map[string]*ddMetric{"key.value.s.hostname": newGauge("s", "hostname", timeStamp, 8, "key:value")},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout getting response")
+	case result := <-bufReady:
+		require.Equal(t, expected, result, "result mismatch")
+	}
+}
+
+func TestMetricBufferHandlesMultipleTags(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// unbuffered queue to make sure things are processed in a predictable order
+	mq, bufReq, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 0, &gostatsd.TimerSubtypes{})
+
+	mm := &gostatsd.MetricMap{
+		Gauges: gostatsd.Gauges{
+			"g1": map[string]gostatsd.Gauge{
+				"key.value1.s.hostname1": {
+					Value:    111,
+					Hostname: "hostname1",
+					Tags: gostatsd.Tags{
+						"key:value1",
+					},
+				},
+				"key.value1.s.hostname2": {
+					Value:    112,
+					Hostname: "hostname2",
+					Tags: gostatsd.Tags{
+						"key:value1",
+					},
+				},
+				"key.value2.s.hostname1": {
+					Value:    121,
+					Hostname: "hostname1",
+					Tags: gostatsd.Tags{
+						"key:value2",
+					},
+				},
+				"key.value2.s.hostname2": {
+					Value:    122,
+					Hostname: "hostname2",
+					Tags: gostatsd.Tags{
+						"key:value2",
+					},
+				},
+			},
+			"g2": map[string]gostatsd.Gauge{
+				"key.value1.s.hostname1": {
+					Value:    211,
+					Hostname: "hostname1",
+					Tags: gostatsd.Tags{
+						"key:value1",
+					},
+				},
+				"key.value1.s.hostname2": {
+					Value:    212,
+					Hostname: "hostname2",
+					Tags: gostatsd.Tags{
+						"key:value1",
+					},
+				},
+				"key.value2.s.hostname1": {
+					Value:    221,
+					Hostname: "hostname1",
+					Tags: gostatsd.Tags{
+						"key:value2",
+					},
+				},
+				"key.value2.s.hostname2": {
+					Value:    222,
+					Hostname: "hostname2",
+					Tags: gostatsd.Tags{
+						"key:value2",
+					},
+				},
+			},
+		},
+	}
+
+	timeStamp := 20.0
+	bm := &batchMessage{
+		metrics:   mm,
+		flushTime: time.Unix(int64(timeStamp), 0),
+		done:      func(err []error) {},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout sending batch")
+	case mq <- bm:
+	}
+
+	// perform a sync request, to ensure the batch is processed
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout requesting response")
+	case bufReq <- plz:
+	}
+
+	expected := ddMetricMap{
+		"g1": map[string]*ddMetric{
+			"key.value1.s.hostname1": newGauge("g1", "hostname1", timeStamp, 111, "key:value1"),
+			"key.value1.s.hostname2": newGauge("g1", "hostname2", timeStamp, 112, "key:value1"),
+			"key.value2.s.hostname1": newGauge("g1", "hostname1", timeStamp, 121, "key:value2"),
+			"key.value2.s.hostname2": newGauge("g1", "hostname2", timeStamp, 122, "key:value2"),
+		},
+		"g2": map[string]*ddMetric{
+			"key.value1.s.hostname1": newGauge("g2", "hostname1", timeStamp, 211, "key:value1"),
+			"key.value1.s.hostname2": newGauge("g2", "hostname2", timeStamp, 212, "key:value1"),
+			"key.value2.s.hostname1": newGauge("g2", "hostname1", timeStamp, 221, "key:value2"),
+			"key.value2.s.hostname2": newGauge("g2", "hostname2", timeStamp, 222, "key:value2"),
+		},
+	}
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timeout getting response")
+	case result := <-bufReady:
+		require.Equal(t, expected, result, "result mismatch")
+	}
+}
+
+func TestMetricBufferObeysDisabledMetrics(t *testing.T) {
+	tests := []struct {
+		subType  string
+		disabled gostatsd.TimerSubtypes
+	}{
+		{"lower", gostatsd.TimerSubtypes{Lower: true}},
+		{"upper", gostatsd.TimerSubtypes{Upper: true}},
+		{"count", gostatsd.TimerSubtypes{Count: true}},
+		{"count_ps", gostatsd.TimerSubtypes{CountPerSecond: true}},
+		{"mean", gostatsd.TimerSubtypes{Mean: true}},
+		{"median", gostatsd.TimerSubtypes{Median: true}},
+		{"std", gostatsd.TimerSubtypes{StdDev: true}},
+		{"sum", gostatsd.TimerSubtypes{Sum: true}},
+		{"sum_squares", gostatsd.TimerSubtypes{SumSquares: true}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.subType, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			// unbuffered queue to make sure things are processed in a predictable order
+			mq, bufReq, bufReady := makeTestMetricBuffer(ctx, 10*time.Second, 0, &test.disabled)
+
+			mm := &gostatsd.MetricMap{
+				Timers: gostatsd.Timers{
+					"t": map[string]gostatsd.Timer{
+						"key.value.s.hostname": {
+							Count:      5,
+							PerSecond:  0.5,
+							Mean:       4,
+							Median:     4,
+							Min:        2,
+							Max:        6,
+							StdDev:     1.4,
+							Sum:        20,
+							SumSquares: 90,
+							Hostname:   "hostname",
+							Tags: gostatsd.Tags{
+								"key:value",
+							},
+						},
+					},
+				},
+			}
+			timeStamp := 20.0
+			bm := &batchMessage{
+				metrics:   mm,
+				flushTime: time.Unix(int64(timeStamp), 0),
+				done:      func(err []error) {},
+			}
+
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "timeout sending batch")
+			case mq <- bm:
+			}
+
+			// perform a sync request, to ensure the batch is processed
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "timeout requesting response")
+			case bufReq <- plz:
+			}
+
+			expected := ddMetricMap{
+				"t.count":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.count", "hostname", timeStamp, 5, "key:value")},
+				"t.count_ps":    map[string]*ddMetric{"key.value.s.hostname": newRate("t.count_ps", "hostname", timeStamp, 0.5, "key:value")},
+				"t.lower":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.lower", "hostname", timeStamp, 2, "key:value")},
+				"t.mean":        map[string]*ddMetric{"key.value.s.hostname": newGauge("t.mean", "hostname", timeStamp, 4, "key:value")},
+				"t.median":      map[string]*ddMetric{"key.value.s.hostname": newGauge("t.median", "hostname", timeStamp, 4, "key:value")},
+				"t.std":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.std", "hostname", timeStamp, 1.4, "key:value")},
+				"t.sum":         map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum", "hostname", timeStamp, 20, "key:value")},
+				"t.sum_squares": map[string]*ddMetric{"key.value.s.hostname": newGauge("t.sum_squares", "hostname", timeStamp, 90, "key:value")},
+				"t.upper":       map[string]*ddMetric{"key.value.s.hostname": newGauge("t.upper", "hostname", timeStamp, 6, "key:value")},
+			}
+
+			// Remove the thing we expect missing
+			delete(expected, "t."+test.subType)
+
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "timeout getting response")
+			case result := <-bufReady:
+				require.Equal(t, expected, result, "result mismatch")
+			}
+
+		})
+	}
+}
+
+func newRate(name, hostname string, timeStamp, value float64, tags ...string) *ddMetric {
+	return &ddMetric{
+		Metric:   name,
+		Host:     hostname,
+		Interval: 10.0,
+		Points:   []ddPoint{{timeStamp, value}},
+		Tags:     tags,
+		Type:     rate,
+	}
+}
+
+func newGauge(name, hostname string, timeStamp, value float64, tags ...string) *ddMetric {
+	return &ddMetric{
+		Metric:   name,
+		Host:     hostname,
+		Interval: 10.0,
+		Points:   []ddPoint{{timeStamp, value}},
+		Tags:     tags,
+		Type:     gauge,
+	}
+}

--- a/pkg/backends/datadogexp/types.go
+++ b/pkg/backends/datadogexp/types.go
@@ -1,0 +1,57 @@
+package datadogexp
+
+import (
+	"time"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// ddMetric represents a metric timeseries for Datadog.
+type ddMetric struct {
+	Host     string     `json:"host,omitempty"`
+	Interval float64    `json:"interval,omitempty"`
+	Metric   string     `json:"metric"`
+	Points   []ddPoint  `json:"points"`
+	Tags     []string   `json:"tags,omitempty"`
+	Type     metricType `json:"type,omitempty"`
+}
+
+// ddPoint is a tuple consisting of a timestamp and a value
+type ddPoint [2]float64
+
+// ddTimeSeries represents a time series data structure.
+type ddTimeSeries struct {
+	Series []*ddMetric `json:"series"`
+}
+
+// ddMetricMap is a map[metricName][tagKey] which holds a string
+// indexable list of ddMetrics that are pending flush to Datadog
+type ddMetricMap map[string]map[string]*ddMetric
+
+type metricType string
+
+const (
+	// gauge is datadog gauge type.
+	gauge metricType = "gauge"
+	// rate is datadog rate type.
+	rate metricType = "rate"
+)
+
+type batchMessage struct {
+	metrics   *gostatsd.MetricMap
+	flushTime time.Time
+	done      gostatsd.SendCallback
+}
+
+// ddEvent represents an event data structure for Datadog.
+type ddEvent struct {
+	Title          string   `json:"title"`
+	Text           string   `json:"text"`
+	DateHappened   int64    `json:"date_happened,omitempty"`
+	Hostname       string   `json:"host,omitempty"`
+	AggregationKey string   `json:"aggregation_key,omitempty"`
+	SourceTypeName string   `json:"source_type_name,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	Priority       string   `json:"priority,omitempty"`
+	AlertType      string   `json:"alert_type,omitempty"`
+}

--- a/pkg/backends/graphite/graphite.go
+++ b/pkg/backends/graphite/graphite.go
@@ -84,7 +84,7 @@ func (client *Client) Run(ctx context.Context) {
 }
 
 // SendMetricsAsync flushes the metrics to the Graphite server, preparing payload synchronously but doing the send asynchronously.
-func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
 	buf := client.preparePayload(metrics, time.Now())
 	sink := make(chan *bytes.Buffer, 1)
 	sink <- buf

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -146,7 +146,7 @@ func TestSendMetricsAsync(t *testing.T) {
 	wg.StartWithContext(ctx, c.Run)
 	var swg sync.WaitGroup
 	swg.Add(1)
-	c.SendMetricsAsync(ctx, metrics(), func(errs []error) {
+	c.SendMetricsAsync(ctx, metrics(), time.Now(), func(errs []error) {
 		defer swg.Done()
 		for i, e := range errs {
 			assert.NoError(t, e, i)

--- a/pkg/backends/null/null.go
+++ b/pkg/backends/null/null.go
@@ -2,6 +2,7 @@ package null
 
 import (
 	"context"
+	"time"
 
 	"github.com/atlassian/gostatsd"
 
@@ -25,7 +26,7 @@ func NewClient() (*Client, error) {
 }
 
 // SendMetricsAsync discards the metrics in a MetricsMap.
-func (Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+func (Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
 	cb(nil)
 }
 

--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -52,7 +52,7 @@ func (client *Client) Run(ctx context.Context) {
 }
 
 // SendMetricsAsync flushes the metrics to the statsd server, preparing payload synchronously but doing the send asynchronously.
-func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+func (client *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
 	sink := make(chan *bytes.Buffer, sendChannelSize)
 	select {
 	case <-ctx.Done():

--- a/pkg/backends/stdout/stdout.go
+++ b/pkg/backends/stdout/stdout.go
@@ -52,7 +52,7 @@ func tagToMetricName(tag string) string {
 }
 
 // SendMetricsAsync prints the metrics in a MetricsMap to the stdout, preparing payload synchronously but doing the send asynchronously.
-func (client Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+func (client Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, flushTime time.Time, cb gostatsd.SendCallback) {
 	buf := preparePayload(metrics, &client.disabledSubtypes)
 	go func() {
 		cb([]error{writePayload(buf)})

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -3,14 +3,15 @@ package statsd
 import (
 	"context"
 	"net"
+	"strings"
 	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/atlassian/gostatsd/pkg/pool"
 	stats "github.com/atlassian/gostatsd/pkg/statser"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // ip packet size is stored in two bytes and that is how big in theory the packet can be.
@@ -85,7 +86,7 @@ func (dr *DatagramReceiver) Receive(ctx context.Context, c net.PacketConn) {
 				return
 			default:
 			}
-			if err != fakesocket.ErrClosedConnection {
+			if err != fakesocket.ErrClosedConnection && !strings.Contains(err.Error(), "use of closed network connection") {
 				log.Warnf("Error reading from socket: %v", err)
 			}
 			continue

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -11,6 +11,8 @@ import (
 	"github.com/atlassian/gostatsd"
 	stats "github.com/atlassian/gostatsd/pkg/statser"
 
+	"strings"
+
 	"github.com/ash2k/stager"
 	"github.com/jbenet/go-reuseport"
 	log "github.com/sirupsen/logrus"
@@ -207,7 +209,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 		}
 		defer func(c net.PacketConn) {
 			// This makes receivers error out and stop
-			if e := c.Close(); e != nil {
+			if e := c.Close(); e != nil && !strings.Contains(e.Error(), "use of closed network connection") {
 				log.Warnf("Error closing socket: %v", e)
 			}
 		}(c)

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -84,7 +84,7 @@ func (cb *countingBackend) Name() string {
 	return "countingBackend"
 }
 
-func (cb *countingBackend) SendMetricsAsync(ctx context.Context, m *gostatsd.MetricMap, callback gostatsd.SendCallback) {
+func (cb *countingBackend) SendMetricsAsync(ctx context.Context, m *gostatsd.MetricMap, flushTime time.Time, callback gostatsd.SendCallback) {
 	count := 0
 	m.Counters.Each(func(name, tagset string, c gostatsd.Counter) {
 		count++

--- a/sets.go
+++ b/sets.go
@@ -44,3 +44,24 @@ func (s Sets) Each(f func(string, string, Set)) {
 		}
 	}
 }
+
+// copy returns a deep-ish copy of this Sets object
+func (s Sets) copy() Sets {
+	sNew := Sets{}
+	for name, value := range s {
+		s := map[string]Set{}
+		for tagsKey, set := range value {
+			s[tagsKey] = Set{
+				Values: make(map[string]struct{}),
+				// Timestamp: counter.Timestamp, // Timestamp is not required
+				Hostname: set.Hostname,
+				Tags:     set.Tags, // shallow copy is acceptable
+			}
+			for key := range set.Values {
+				s[tagsKey].Values[key] = struct{}{}
+			}
+		}
+		sNew[name] = s
+	}
+	return sNew
+}

--- a/sets.go
+++ b/sets.go
@@ -47,21 +47,21 @@ func (s Sets) Each(f func(string, string, Set)) {
 
 // copy returns a deep-ish copy of this Sets object
 func (s Sets) copy() Sets {
-	sNew := Sets{}
+	sNew := make(Sets, len(s))
 	for name, value := range s {
-		s := map[string]Set{}
+		m := make(map[string]Set, len(value))
 		for tagsKey, set := range value {
-			s[tagsKey] = Set{
+			m[tagsKey] = Set{
 				Values: make(map[string]struct{}),
 				// Timestamp: counter.Timestamp, // Timestamp is not required
 				Hostname: set.Hostname,
 				Tags:     set.Tags, // shallow copy is acceptable
 			}
 			for key := range set.Values {
-				s[tagsKey].Values[key] = struct{}{}
+				m[tagsKey].Values[key] = struct{}{}
 			}
 		}
-		sNew[name] = s
+		sNew[name] = m
 	}
 	return sNew
 }

--- a/timers.go
+++ b/timers.go
@@ -59,9 +59,9 @@ func (t Timers) Each(f func(string, string, Timer)) {
 
 // copy returns a deep-ish copy of this Timers object
 func (t Timers) copy() Timers {
-	tNew := Timers{}
+	tNew := make(Timers, len(t))
 	for name, value := range t {
-		m := map[string]Timer{}
+		m := make(map[string]Timer, len(value))
 		for tagsKey, timer := range value {
 			m[tagsKey] = Timer{
 				Count:      timer.Count,

--- a/timers.go
+++ b/timers.go
@@ -57,6 +57,35 @@ func (t Timers) Each(f func(string, string, Timer)) {
 	}
 }
 
+// copy returns a deep-ish copy of this Timers object
+func (t Timers) copy() Timers {
+	tNew := Timers{}
+	for name, value := range t {
+		m := map[string]Timer{}
+		for tagsKey, timer := range value {
+			m[tagsKey] = Timer{
+				Count:      timer.Count,
+				PerSecond:  timer.PerSecond,
+				Mean:       timer.Mean,
+				Median:     timer.Median,
+				Min:        timer.Min,
+				Max:        timer.Max,
+				StdDev:     timer.StdDev,
+				Sum:        timer.Sum,
+				SumSquares: timer.SumSquares,
+				// Values: nil, // Values is not required
+				Percentiles: make([]Percentile, len(timer.Percentiles)),
+				// Timestamp: timer.Timestamp, // Timestamp is not required
+				Hostname: timer.Hostname,
+				Tags:     timer.Tags, // shallow copy is acceptable
+			}
+			copy(m[tagsKey].Percentiles, timer.Percentiles)
+		}
+		tNew[name] = m
+	}
+	return tNew
+}
+
 func DisabledSubMetrics(viper *viper.Viper) TimerSubtypes {
 	subViper := viper.Sub("disabled-sub-metrics")
 	if subViper == nil {


### PR DESCRIPTION
Replacement backend for DD I've been working on.  It's pretty close to ready, but wanted to get some feedback on current state of it before I pepper it with metrics.  PR will not be merged, just after feedback.

Currently missing:
- Benchmarks everywhere
- End to end testing (+bench)
- Internal metrics
- Events

The primary goal is to unblock the flusher, and accumulate more than a single datapoint (metricBuffer).  The single big map is periodically sliced up in to batches (metricBatcher), and sent off to a serializer+compressor (batchSerializer) / sender (bodyWriter).  These some stuff in bodyWriter for tracing, I was trying to track the pool idle count, looks like it's not possible though as there's no event for an idle timeout (unless I'm missing something).

Overall, this should enable the flush interval to always be met (although back pressure is still present, there is an upper bound on how much we will accumulate), and decouples CPU bound/network bound goroutines.

It should also reduce network traffic where flush interval isn't met, as we're only sending an additional pair of floats, instead of an entire metric + tags.  Which actually means if we don't write fast enough, that's a good thing - I might make the metricBatcher configurable to do that deliberately.