### PR TITLE
Dedupe tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ check:
 	go install ./cmd/tester
 	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=600s ./... --vendor \
 		--linter='errcheck:errcheck:-ignore=net:Close' --cyclo-over=20 \
-		--disable=interfacer --disable=golint --dupl-threshold=200
+		--disable=interfacer --disable=golint --disable=gosec --dupl-threshold=200
 
 check-all:
 	go install ./cmd/gostatsd

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -56,14 +56,14 @@ func uniqueTags(t1 gostatsd.Tags, t2 gostatsd.Tags) gostatsd.Tags {
 	seen := map[string]bool{}
 
 	for _, v := range t1 {
-		if seen[v] != true {
+		if !seen[v] {
 			tags = append(tags, v)
 			seen[v] = true
 		}
 	}
 
 	for _, v := range t2 {
-		if seen[v] != true {
+		if !seen[v] {
 			tags = append(tags, v)
 			seen[v] = true
 		}

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -13,7 +13,7 @@ type TagHandler struct {
 	estimatedTags int
 }
 
-// NewTagHandler initialises a new handler which adds tags and sends metrics/events to the next handler
+// NewTagHandler initialises a new handler which adds unqiue tags and sends metrics/events to the next handler
 func NewTagHandler(metrics MetricHandler, events EventHandler, tags gostatsd.Tags) *TagHandler {
 	return &TagHandler{
 		metrics:       metrics,
@@ -28,7 +28,7 @@ func (th *TagHandler) EstimatedTags() int {
 	return th.estimatedTags
 }
 
-// DispatchMetric adds the tags from the TagHandler to the metric and passes it to the next stage in the pipeline
+// DispatchMetric adds the unqiue tags from the TagHandler to the metric and passes it to the next stage in the pipeline
 func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	if m.Hostname == "" {
 		m.Hostname = string(m.SourceIP)
@@ -37,7 +37,7 @@ func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) er
 	return th.metrics.DispatchMetric(ctx, m)
 }
 
-// DispatchEvent adds the tags from the TagHandler to the event and passes it to the next stage in the pipeline
+// DispatchEvent adds the unqiue tags from the TagHandler to the event and passes it to the next stage in the pipeline
 func (th *TagHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
 	if e.Hostname == "" {
 		e.Hostname = string(e.SourceIP)

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -13,7 +13,7 @@ type TagHandler struct {
 	estimatedTags int
 }
 
-// NewTagHandler initialises a new handler which adds unqiue tags and sends metrics/events to the next handler
+// NewTagHandler initialises a new handler which adds unique tags and sends metrics/events to the next handler
 func NewTagHandler(metrics MetricHandler, events EventHandler, tags gostatsd.Tags) *TagHandler {
 	return &TagHandler{
 		metrics:       metrics,
@@ -28,7 +28,7 @@ func (th *TagHandler) EstimatedTags() int {
 	return th.estimatedTags
 }
 
-// DispatchMetric adds the unqiue tags from the TagHandler to the metric and passes it to the next stage in the pipeline
+// DispatchMetric adds the unique tags from the TagHandler to the metric and passes it to the next stage in the pipeline
 func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
 	if m.Hostname == "" {
 		m.Hostname = string(m.SourceIP)
@@ -37,7 +37,7 @@ func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) er
 	return th.metrics.DispatchMetric(ctx, m)
 }
 
-// DispatchEvent adds the unqiue tags from the TagHandler to the event and passes it to the next stage in the pipeline
+// DispatchEvent adds the unique tags from the TagHandler to the event and passes it to the next stage in the pipeline
 func (th *TagHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
 	if e.Hostname == "" {
 		e.Hostname = string(e.SourceIP)

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -33,7 +33,7 @@ func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) er
 	if m.Hostname == "" {
 		m.Hostname = string(m.SourceIP)
 	}
-	m.Tags = append(m.Tags, th.tags...)
+	m.Tags = uniqueTags(m.Tags, th.tags)
 	return th.metrics.DispatchMetric(ctx, m)
 }
 
@@ -42,11 +42,32 @@ func (th *TagHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) erro
 	if e.Hostname == "" {
 		e.Hostname = string(e.SourceIP)
 	}
-	e.Tags = append(e.Tags, th.tags...)
+	e.Tags = uniqueTags(e.Tags, th.tags)
 	return th.events.DispatchEvent(ctx, e)
 }
 
 // WaitForEvents waits for all event-dispatching goroutines to finish.
 func (th *TagHandler) WaitForEvents() {
 	th.events.WaitForEvents()
+}
+
+func uniqueTags(t1 gostatsd.Tags, t2 gostatsd.Tags) gostatsd.Tags {
+	tags := gostatsd.Tags{}
+	seen := map[string]bool{}
+
+	for _, v := range t1 {
+		if seen[v] != true {
+			tags = append(tags, v)
+			seen[v] = true
+		}
+	}
+
+	for _, v := range t2 {
+		if seen[v] != true {
+			tags = append(tags, v)
+			seen[v] = true
+		}
+	}
+
+	return tags
 }

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -148,15 +148,16 @@ func TestTagEventHandlerAddsDuplicateTags(t *testing.T) {
 
 func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
 	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		th := NewTagHandler(tch, tch, gostatsd.Tags{
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-		})
 		m := &gostatsd.Metric{}
 		th.DispatchMetric(context.Background(), m)
 	}
@@ -164,22 +165,23 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
 
 func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
+		"dddddddddddddddddddddddddddddddd:dddddddddddddddddddddddddddddddd",
+		"dddddddddddddddddddddddddddddddd:dddddddddddddddddddddddddddddddd",
+		"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	})
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		th := NewTagHandler(tch, tch, gostatsd.Tags{
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"cccccccccccccccc:cccccccccccccccc",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"cccccccccccccccc:cccccccccccccccc",
-			"dddddddddddddddd:dddddddddddddddd",
-			"dddddddddddddddd:dddddddddddddddd",
-			"eeeeeeeeeeeeeeee:eeeeeeeeeeeeeeee",
-		})
 		m := &gostatsd.Metric{}
 		th.DispatchMetric(context.Background(), m)
 	}
@@ -187,15 +189,16 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 
 func BenchmarkTagEventHandlerAddsDuplicateTagsSmall(b *testing.B) {
 	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		th := NewTagHandler(tch, tch, gostatsd.Tags{
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-		})
 		e := &gostatsd.Event{}
 		th.DispatchEvent(context.Background(), e)
 	}
@@ -203,22 +206,23 @@ func BenchmarkTagEventHandlerAddsDuplicateTagsSmall(b *testing.B) {
 
 func BenchmarkTagEventHandlerAddsDuplicateTagsLarge(b *testing.B) {
 	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
+		"dddddddddddddddddddddddddddddddd:dddddddddddddddddddddddddddddddd",
+		"dddddddddddddddddddddddddddddddd:dddddddddddddddddddddddddddddddd",
+		"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	})
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		th := NewTagHandler(tch, tch, gostatsd.Tags{
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"cccccccccccccccc:cccccccccccccccc",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
-			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
-			"cccccccccccccccc:cccccccccccccccc",
-			"dddddddddddddddd:dddddddddddddddd",
-			"dddddddddddddddd:dddddddddddddddd",
-			"eeeeeeeeeeeeeeee:eeeeeeeeeeeeeeee",
-		})
 		e := &gostatsd.Event{}
 		th.DispatchEvent(context.Background(), e)
 	}

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -75,6 +75,19 @@ func TestTagMetricHandlerAddsHostname(t *testing.T) {
 	assert.Equal(t, "1.2.3.4", tch.m[0].Hostname) // Hostname injected
 }
 
+func TestTagMetricHandlerAddsDuplicateTags(t *testing.T) {
+	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"})
+	m := &gostatsd.Metric{}
+	th.DispatchMetric(context.Background(), m)
+	assert.Equal(t, 1, len(tch.m))            // Metric tracked
+	assert.Equal(t, 3, len(tch.m[0].Tags))    // 3 tags added
+	assert.Equal(t, "tag1", tch.m[0].Tags[0]) //  "tag1" added
+	assert.Equal(t, "tag2", tch.m[0].Tags[1]) //  "tag2" added
+	assert.Equal(t, "tag3", tch.m[0].Tags[2]) //  "tag3" added
+	assert.Equal(t, "", tch.m[0].Hostname)    // No hostname added
+}
+
 func TestTagEventHandlerAddsNoTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
 	th := NewTagHandler(tch, tch, gostatsd.Tags{})
@@ -118,4 +131,95 @@ func TestTagEventHandlerAddsHostname(t *testing.T) {
 	assert.Equal(t, 1, len(tch.e))                // Metric tracked
 	assert.Equal(t, 0, len(tch.e[0].Tags))        // No tags added
 	assert.Equal(t, "1.2.3.4", tch.e[0].Hostname) // Hostname injected
+}
+
+func TestTagEventHandlerAddsDuplicateTags(t *testing.T) {
+	tch := &TagCapturingHandler{}
+	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"})
+	e := &gostatsd.Event{}
+	th.DispatchEvent(context.Background(), e)
+	assert.Equal(t, 1, len(tch.e))            // Metric tracked
+	assert.Equal(t, 3, len(tch.e[0].Tags))    // 3 tags added
+	assert.Equal(t, "tag1", tch.e[0].Tags[0]) //  "tag1" added
+	assert.Equal(t, "tag2", tch.e[0].Tags[1]) //  "tag2" added
+	assert.Equal(t, "tag3", tch.e[0].Tags[2]) //  "tag3" added
+	assert.Equal(t, "", tch.e[0].Hostname)    // No hostname added
+}
+
+func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
+	tch := &TagCapturingHandler{}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		th := NewTagHandler(tch, tch, gostatsd.Tags{
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+		})
+		m := &gostatsd.Metric{}
+		th.DispatchMetric(context.Background(), m)
+	}
+}
+
+func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
+	tch := &TagCapturingHandler{}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		th := NewTagHandler(tch, tch, gostatsd.Tags{
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"cccccccccccccccc:cccccccccccccccc",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"cccccccccccccccc:cccccccccccccccc",
+			"dddddddddddddddd:dddddddddddddddd",
+			"dddddddddddddddd:dddddddddddddddd",
+			"eeeeeeeeeeeeeeee:eeeeeeeeeeeeeeee",
+		})
+		m := &gostatsd.Metric{}
+		th.DispatchMetric(context.Background(), m)
+	}
+}
+
+func BenchmarkTagEventHandlerAddsDuplicateTagsSmall(b *testing.B) {
+	tch := &TagCapturingHandler{}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		th := NewTagHandler(tch, tch, gostatsd.Tags{
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+		})
+		e := &gostatsd.Event{}
+		th.DispatchEvent(context.Background(), e)
+	}
+}
+
+func BenchmarkTagEventHandlerAddsDuplicateTagsLarge(b *testing.B) {
+	tch := &TagCapturingHandler{}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		th := NewTagHandler(tch, tch, gostatsd.Tags{
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"cccccccccccccccc:cccccccccccccccc",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+			"bbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbb",
+			"aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaa",
+			"cccccccccccccccc:cccccccccccccccc",
+			"dddddddddddddddd:dddddddddddddddd",
+			"dddddddddddddddd:dddddddddddddddd",
+			"eeeeeeeeeeeeeeee:eeeeeeeeeeeeeeee",
+		})
+		e := &gostatsd.Event{}
+		th.DispatchEvent(context.Background(), e)
+	}
 }


### PR DESCRIPTION
We sometimes receive duplicate tags for a metric. This PR will only add unique tags to the metric or event.

The other approach would be to consolidate the dupe tags into one tag. e.g. from `my_tag:my_value,my_tag:my_value,my_tag:my_value` to `my_tag:my_value__my_value__my_value`. Thoughts on this?