### PR TITLE
Add support for sampling timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.3.0
+-----
+- Added support for sampling timers to be compatible with original statsd.
+
 7.2.0
 -----
 - New Cloudwatch backend contirubted by JorgenEvens

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ respectively.
 
 A single packet can contain multiple metrics, each ending with a newline.
 
-Optionally, `gostatsd` supports sample rates and tags (unused):
+Optionally, `gostatsd` supports sample rates (for simple counters, and for timer counters) and tags (unused):
 
 * `<bucket name>:<value>|c|@<sample rate>\n` where `sample rate` is a float between 0 and 1
 * `<bucket name>:<value>|c|@<sample rate>|#<tags>\n` where `tags` is a comma separated list of tags

--- a/metrics.go
+++ b/metrics.go
@@ -39,6 +39,7 @@ func (m MetricType) String() string {
 type Metric struct {
 	Name        string     // The name of the metric
 	Value       float64    // The numeric value of the metric
+	Rate        float64    // The sampling rate of the metric
 	Tags        Tags       // The tags for the metric
 	TagsKey     string     // The tags rendered as a string to uniquely identify the tagset in a map
 	StringValue string     // The string value for some metrics e.g. Set
@@ -52,6 +53,7 @@ type Metric struct {
 func (m *Metric) Reset() {
 	m.Name = ""
 	m.Value = 0
+	m.Rate = 1
 	m.Tags = m.Tags[:0]
 	m.TagsKey = ""
 	m.StringValue = ""

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -26,7 +26,7 @@ func TestPreparePayload(t *testing.T) {
 	input := []testData{
 		{
 			config: &Config{
-				// Use defaults
+			// Use defaults
 			},
 			result: []byte("stats_counts.stat1 5 1234\n" +
 				"stats.stat1 1.100000 1234\n" +

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -85,14 +85,14 @@ func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 			sort.Float64s(timer.Values)
 			timer.Min = timer.Values[0]
 			timer.Max = timer.Values[count-1]
-			timer.Count = len(timer.Values)
-			count := float64(timer.Count)
+			n := len(timer.Values)
+			count := float64(n)
 
-			cumulativeValues := make([]float64, timer.Count)
-			cumulSumSquaresValues := make([]float64, timer.Count)
+			cumulativeValues := make([]float64, n)
+			cumulSumSquaresValues := make([]float64, n)
 			cumulativeValues[0] = timer.Min
 			cumulSumSquaresValues[0] = timer.Min * timer.Min
-			for i := 1; i < timer.Count; i++ {
+			for i := 1; i < n; i++ {
 				cumulativeValues[i] = timer.Values[i] + cumulativeValues[i-1]
 				cumulSumSquaresValues[i] = timer.Values[i]*timer.Values[i] + cumulSumSquaresValues[i-1]
 			}
@@ -103,8 +103,8 @@ func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 			var thresholdBoundary = timer.Max
 
 			for pct, pctStruct := range a.percentThresholds {
-				numInThreshold := timer.Count
-				if timer.Count > 1 {
+				numInThreshold := n
+				if n > 1 {
 					numInThreshold = int(round(math.Abs(pct) / 100 * count))
 					if numInThreshold == 0 {
 						continue
@@ -114,9 +114,9 @@ func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 						sum = cumulativeValues[numInThreshold-1]
 						sumSquares = cumulSumSquaresValues[numInThreshold-1]
 					} else {
-						thresholdBoundary = timer.Values[timer.Count-numInThreshold]
-						sum = cumulativeValues[timer.Count-1] - cumulativeValues[timer.Count-numInThreshold-1]
-						sumSquares = cumulSumSquaresValues[timer.Count-1] - cumulSumSquaresValues[timer.Count-numInThreshold-1]
+						thresholdBoundary = timer.Values[n-numInThreshold]
+						sum = cumulativeValues[n-1] - cumulativeValues[n-numInThreshold-1]
+						sumSquares = cumulSumSquaresValues[n-1] - cumulSumSquaresValues[n-numInThreshold-1]
 					}
 					mean = sum / float64(numInThreshold)
 				}
@@ -144,12 +144,12 @@ func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 				}
 			}
 
-			sum = cumulativeValues[timer.Count-1]
-			sumSquares = cumulSumSquaresValues[timer.Count-1]
+			sum = cumulativeValues[n-1]
+			sumSquares = cumulSumSquaresValues[n-1]
 			mean = sum / count
 
 			var sumOfDiffs float64
-			for i := 0; i < timer.Count; i++ {
+			for i := 0; i < n; i++ {
 				sumOfDiffs += (timer.Values[i] - mean) * (timer.Values[i] - mean)
 			}
 
@@ -164,11 +164,14 @@ func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 			timer.StdDev = math.Sqrt(sumOfDiffs / count)
 			timer.Sum = sum
 			timer.SumSquares = sumSquares
-			timer.PerSecond = count / flushInSeconds
+
+			timer.Count = int(round(timer.SampledCount))
+			timer.PerSecond = timer.SampledCount / flushInSeconds
 
 			a.Timers[key][tagsKey] = timer
 		} else {
 			timer.Count = 0
+			timer.SampledCount = 0
 			timer.PerSecond = 0
 		}
 	})
@@ -245,7 +248,7 @@ func (a *MetricAggregator) Reset() {
 }
 
 func (a *MetricAggregator) receiveCounter(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
-	value := int64(m.Value)
+	value := int64(m.Value / m.Rate)
 	v, ok := a.Counters[m.Name]
 	if ok {
 		c, ok := v[tagsKey]
@@ -284,20 +287,23 @@ func (a *MetricAggregator) receiveGauge(m *gostatsd.Metric, tagsKey string, now 
 
 func (a *MetricAggregator) receiveTimer(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {
 	v, ok := a.Timers[m.Name]
-	if ok {
-		t, ok := v[tagsKey]
-		if ok {
-			t.Values = append(t.Values, m.Value)
-			t.Timestamp = now
-		} else {
-			t = gostatsd.NewTimer(now, []float64{m.Value}, m.Hostname, m.Tags)
+	if !ok {
+		v = map[string]gostatsd.Timer{
+			tagsKey: gostatsd.NewTimer(now, []float64{}, m.Hostname, m.Tags),
 		}
-		v[tagsKey] = t
-	} else {
-		a.Timers[m.Name] = map[string]gostatsd.Timer{
-			tagsKey: gostatsd.NewTimer(now, []float64{m.Value}, m.Hostname, m.Tags),
-		}
+		a.Timers[m.Name] = v
 	}
+
+	t, ok := v[tagsKey]
+	if ok {
+		t.Values = append(t.Values, m.Value)
+		t.Timestamp = now
+		t.SampledCount += 1.0 / m.Rate
+	} else {
+		t = gostatsd.NewTimer(now, []float64{m.Value}, m.Hostname, m.Tags)
+		t.SampledCount = 1.0 / m.Rate
+	}
+	v[tagsKey] = t
 }
 
 func (a *MetricAggregator) receiveSet(m *gostatsd.Metric, tagsKey string, now gostatsd.Nanotime) {

--- a/pkg/statsd/lexer.go
+++ b/pkg/statsd/lexer.go
@@ -76,6 +76,7 @@ func (l *lexer) run(input []byte, namespace string) (*gostatsd.Metric, *gostatsd
 		return nil, nil, l.err
 	}
 	if l.m != nil {
+		l.m.Rate = l.sampling
 		if l.m.Type != gostatsd.SET {
 			v, err := strconv.ParseFloat(l.m.StringValue, 64)
 			if err != nil {
@@ -86,9 +87,6 @@ func (l *lexer) run(input []byte, namespace string) (*gostatsd.Metric, *gostatsd
 			}
 			l.m.Value = v
 			l.m.StringValue = ""
-		}
-		if l.m.Type == gostatsd.COUNTER {
-			l.m.Value = l.m.Value / l.sampling
 		}
 		l.m.Tags = l.tags
 	} else {

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -13,32 +13,32 @@ import (
 func TestMetricsLexer(t *testing.T) {
 	t.Parallel()
 	tests := map[string]gostatsd.Metric{
-		"foo.bar.baz:2|c":               {Name: "foo.bar.baz", Value: 2, Type: gostatsd.COUNTER},
-		"abc.def.g:3|g":                 {Name: "abc.def.g", Value: 3, Type: gostatsd.GAUGE},
-		"def.g:10|ms":                   {Name: "def.g", Value: 10, Type: gostatsd.TIMER},
-		"def.h:10|h":                    {Name: "def.h", Value: 10, Type: gostatsd.TIMER},
-		"def.i:10|h|#foo":               {Name: "def.i", Value: 10, Type: gostatsd.TIMER, Tags: gostatsd.Tags{"foo"}},
-		"smp.rte:5|c|@0.1":              {Name: "smp.rte", Value: 50, Type: gostatsd.COUNTER},
-		"smp.rte:5|c|@0.1|#foo:bar,baz": {Name: "smp.rte", Value: 50, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"foo:bar", "baz"}},
-		"smp.rte:5|c|#foo:bar,baz":      {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"foo:bar", "baz"}},
-		"uniq.usr:joe|s":                {Name: "uniq.usr", StringValue: "joe", Type: gostatsd.SET},
-		"fooBarBaz:2|c":                 {Name: "fooBarBaz", Value: 2, Type: gostatsd.COUNTER},
-		"smp.rte:5|c|#Foo:Bar,baz":      {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"Foo:Bar", "baz"}},
-		"smp.gge:1|g|#Foo:Bar":          {Name: "smp.gge", Value: 1, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"Foo:Bar"}},
-		"smp.gge:1|g|#fo_o:ba-r":        {Name: "smp.gge", Value: 1, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"fo_o:ba-r"}},
-		"smp gge:1|g":                   {Name: "smp_gge", Value: 1, Type: gostatsd.GAUGE},
-		"smp/gge:1|g":                   {Name: "smp-gge", Value: 1, Type: gostatsd.GAUGE},
-		"smp,gge$:1|g":                  {Name: "smpgge", Value: 1, Type: gostatsd.GAUGE},
-		"un1qu3:john|s":                 {Name: "un1qu3", StringValue: "john", Type: gostatsd.SET},
-		"un1qu3:john|s|#some:42":        {Name: "un1qu3", StringValue: "john", Type: gostatsd.SET, Tags: gostatsd.Tags{"some:42"}},
-		"da-sh:1|s":                     {Name: "da-sh", StringValue: "1", Type: gostatsd.SET},
-		"under_score:1|s":               {Name: "under_score", StringValue: "1", Type: gostatsd.SET},
-		"a:1|g|#f,,":                    {Name: "a", Value: 1, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"f"}},
-		"a:1|g|#,,f":                    {Name: "a", Value: 1, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"f"}},
-		"a:1|g|#f,,z":                   {Name: "a", Value: 1, Type: gostatsd.GAUGE, Tags: gostatsd.Tags{"f", "z"}},
-		"a:1|g|#":                       {Name: "a", Value: 1, Type: gostatsd.GAUGE},
-		"a:1|g|#,":                      {Name: "a", Value: 1, Type: gostatsd.GAUGE},
-		"a:1|g|#,,":                     {Name: "a", Value: 1, Type: gostatsd.GAUGE},
+		"foo.bar.baz:2|c":               {Name: "foo.bar.baz", Value: 2, Type: gostatsd.COUNTER, Rate: 1.0},
+		"abc.def.g:3|g":                 {Name: "abc.def.g", Value: 3, Type: gostatsd.GAUGE, Rate: 1.0},
+		"def.g:10|ms":                   {Name: "def.g", Value: 10, Type: gostatsd.TIMER, Rate: 1.0},
+		"def.h:10|h":                    {Name: "def.h", Value: 10, Type: gostatsd.TIMER, Rate: 1.0},
+		"def.i:10|h|#foo":               {Name: "def.i", Value: 10, Type: gostatsd.TIMER, Rate: 1.0, Tags: gostatsd.Tags{"foo"}},
+		"smp.rte:5|c|@0.1":              {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Rate: 0.1},
+		"smp.rte:5|c|@0.1|#foo:bar,baz": {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Rate: 0.1, Tags: gostatsd.Tags{"foo:bar", "baz"}},
+		"smp.rte:5|c|#foo:bar,baz":      {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Rate: 1.0, Tags: gostatsd.Tags{"foo:bar", "baz"}},
+		"uniq.usr:joe|s":                {Name: "uniq.usr", StringValue: "joe", Type: gostatsd.SET, Rate: 1.0},
+		"fooBarBaz:2|c":                 {Name: "fooBarBaz", Value: 2, Type: gostatsd.COUNTER, Rate: 1.0},
+		"smp.rte:5|c|#Foo:Bar,baz":      {Name: "smp.rte", Value: 5, Type: gostatsd.COUNTER, Rate: 1.0, Tags: gostatsd.Tags{"Foo:Bar", "baz"}},
+		"smp.gge:1|g|#Foo:Bar":          {Name: "smp.gge", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0, Tags: gostatsd.Tags{"Foo:Bar"}},
+		"smp.gge:1|g|#fo_o:ba-r":        {Name: "smp.gge", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0, Tags: gostatsd.Tags{"fo_o:ba-r"}},
+		"smp gge:1|g":                   {Name: "smp_gge", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
+		"smp/gge:1|g":                   {Name: "smp-gge", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
+		"smp,gge$:1|g":                  {Name: "smpgge", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
+		"un1qu3:john|s":                 {Name: "un1qu3", StringValue: "john", Type: gostatsd.SET, Rate: 1.0},
+		"un1qu3:john|s|#some:42":        {Name: "un1qu3", StringValue: "john", Type: gostatsd.SET, Rate: 1.0, Tags: gostatsd.Tags{"some:42"}},
+		"da-sh:1|s":                     {Name: "da-sh", StringValue: "1", Type: gostatsd.SET, Rate: 1.0},
+		"under_score:1|s":               {Name: "under_score", StringValue: "1", Type: gostatsd.SET, Rate: 1.0},
+		"a:1|g|#f,,":                    {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0, Tags: gostatsd.Tags{"f"}},
+		"a:1|g|#,,f":                    {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0, Tags: gostatsd.Tags{"f"}},
+		"a:1|g|#f,,z":                   {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0, Tags: gostatsd.Tags{"f", "z"}},
+		"a:1|g|#":                       {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
+		"a:1|g|#,":                      {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
+		"a:1|g|#,,":                     {Name: "a", Value: 1, Type: gostatsd.GAUGE, Rate: 1.0},
 	}
 
 	compareMetric(t, tests, "")
@@ -57,10 +57,10 @@ func TestInvalidMetricsLexer(t *testing.T) {
 	}
 
 	tests := map[string]gostatsd.Metric{
-		"foo.bar.baz:2|c": {Name: "stats.foo.bar.baz", Value: 2, Type: gostatsd.COUNTER},
-		"abc.def.g:3|g":   {Name: "stats.abc.def.g", Value: 3, Type: gostatsd.GAUGE},
-		"def.g:10|ms":     {Name: "stats.def.g", Value: 10, Type: gostatsd.TIMER},
-		"uniq.usr:joe|s":  {Name: "stats.uniq.usr", StringValue: "joe", Type: gostatsd.SET},
+		"foo.bar.baz:2|c": {Name: "stats.foo.bar.baz", Value: 2, Type: gostatsd.COUNTER, Rate: 1.0},
+		"abc.def.g:3|g":   {Name: "stats.abc.def.g", Value: 3, Type: gostatsd.GAUGE, Rate: 1.0},
+		"def.g:10|ms":     {Name: "stats.def.g", Value: 10, Type: gostatsd.TIMER, Rate: 1.0},
+		"uniq.usr:joe|s":  {Name: "stats.uniq.usr", StringValue: "joe", Type: gostatsd.SET, Rate: 1.0},
 	}
 
 	compareMetric(t, tests, "stats")

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -49,39 +49,39 @@ func TestParseDatagram(t *testing.T) {
 	input := map[string]metricAndEvent{
 		"f:2|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\n": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#t": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h"}},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"host:h"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
-				{Name: "x", Value: 3, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
+				{Name: "x", Value: 3, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\nx:3|c\n": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
-				{Name: "x", Value: 3, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
+				{Name: "x", Value: 3, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"_e{1,1}:a|b\nf:6|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 6, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 6, SourceIP: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 			events: gostatsd.Events{
 				gostatsd.Event{Title: "a", Text: "b", SourceIP: "127.0.0.1"},
@@ -113,44 +113,44 @@ func TestParseDatagramIgnoreHost(t *testing.T) {
 	input := map[string]metricAndEvent{
 		"f:2|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\n": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#t": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"t"}},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Hostname: "h", Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Hostname: "h", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#host:h1,host:h2": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Hostname: "h1", Type: gostatsd.COUNTER, Tags: gostatsd.Tags{"host:h2"}},
+				{Name: "f", Value: 2, Hostname: "h1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"host:h2"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
-				{Name: "x", Value: 3, Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
+				{Name: "x", Value: 3, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\nx:3|c\n": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 2, Type: gostatsd.COUNTER},
-				{Name: "x", Value: 3, Type: gostatsd.COUNTER},
+				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
+				{Name: "x", Value: 3, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"_e{1,1}:a|b\nf:6|c": {
 			metrics: []gostatsd.Metric{
-				{Name: "f", Value: 6, Type: gostatsd.COUNTER},
+				{Name: "f", Value: 6, Type: gostatsd.COUNTER, Rate: 1},
 			},
 			events: gostatsd.Events{
 				gostatsd.Event{Title: "a", Text: "b", SourceIP: "127.0.0.1"},

--- a/timers.go
+++ b/timers.go
@@ -4,25 +4,31 @@ import "github.com/spf13/viper"
 
 // Timer is used for storing aggregated values for timers.
 type Timer struct {
-	Count       int         // The number of timers in the series
-	PerSecond   float64     // The calculated per second rate
-	Mean        float64     // The mean time of the series
-	Median      float64     // The median time of the series
-	Min         float64     // The minimum time of the series
-	Max         float64     // The maximum time of the series
-	StdDev      float64     // The standard deviation for the series
-	Sum         float64     // The sum for the series
-	SumSquares  float64     // The sum squares for the series
-	Values      []float64   // The numeric value of the metric
-	Percentiles Percentiles // The percentile aggregations of the metric
-	Timestamp   Nanotime    // Last time value was updated
-	Hostname    string      // Hostname of the source of the metric
-	Tags        Tags        // The tags for the timer
+	Count        int         // The number of timers in the series
+	SampledCount float64     // Number of timings received, divided by sampling rate
+	PerSecond    float64     // The calculated per second rate
+	Mean         float64     // The mean time of the series
+	Median       float64     // The median time of the series
+	Min          float64     // The minimum time of the series
+	Max          float64     // The maximum time of the series
+	StdDev       float64     // The standard deviation for the series
+	Sum          float64     // The sum for the series
+	SumSquares   float64     // The sum squares for the series
+	Values       []float64   // The numeric value of the metric
+	Percentiles  Percentiles // The percentile aggregations of the metric
+	Timestamp    Nanotime    // Last time value was updated
+	Hostname     string      // Hostname of the source of the metric
+	Tags         Tags        // The tags for the timer
 }
 
 // NewTimer initialises a new timer.
 func NewTimer(timestamp Nanotime, values []float64, hostname string, tags Tags) Timer {
-	return Timer{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy()}
+	return Timer{Values: values, Timestamp: timestamp, Hostname: hostname, Tags: tags.Copy(), SampledCount: float64(len(values))}
+}
+
+// NewTimerValues initialises a new timer only from Values array
+func NewTimerValues(values []float64) Timer {
+	return NewTimer(Nanotime(0), values, "", nil)
 }
 
 // Timers stores a map of timers by tags.


### PR DESCRIPTION
**Problem**:

`gostatsd` does not support sample rate for timer metrics, only for counters.
Original Etsy's `statsd` implementation supports sample rate for timers since 2013: https://github.com/etsy/statsd/pull/243/commits/cc12534e3b3bf5137a263e4e065876329e1a719c

**Situation**:

Consider a generic API service which does performance tracking by sending a single `timer` metric for each request to its endpoint. Common statsd-carbon-graphite pipeline (or any equivalent one) produces both mean / percentile response time data and requests-per-second data from `timer` metrics, which is sufficient for most monitoring situations.

Now, suppose this service handles quite a lot of requests per second. In this situation is reasonable to use metric sampling and submit only, say, 50% of timer metrics:

    megaservice.supernode-14.get_customers:110|ms|@0.5
    
This works well with Etsy's `statsd`: values of `count` and `count_ps` generated from a timer metric are divided by the sample rate, producing a (reasonable estimate of a) correct requests-per-second data. `mean`, `median`, `upper_95`, `sum`, and other aggregated values which are measured in seconds are not affected by sampling.

With `gostatsd`, however, sampling works only for counters and not for timers. So if I use `gostatsd` and submit timer metrics with 50% sample rate, I get `count_ps` values which are 2 times lower than the actual number of requests per second.

**Note**:

Etsy's `statsd` implementation assumes that, within a single flush interval, a single timer metric is submitted with the same sample rate:

    megaservice.supernode-14.get_customers:54|ms|@0.5
    megaservice.supernode-14.get_customers:22|ms|@0.5
    megaservice.supernode-14.get_customers:5553|ms|@0.5

If this assumption holds, then only the counters (`count`, `count_ps`) need to be adjusted for samping, and mean / percentile / etc time values can be calculated as normal.

If this assumption breaks, and we recieve metrics with different sample rates within a single flush interval...

    megaservice.supernode-14.get_customers:54|ms|@0.1
    megaservice.supernode-14.get_customers:22|ms|@0.5
    megaservice.supernode-14.get_customers:5553|ms|@0.25

...then all aggregations (mean / percentile / etc) should be somehow computed with regard to the sample rate of each individual metric: mean becomes weighted average, etc; or else they would not make sense statistically.

In practice, it is hard to imagine why would one need to change the sample rate continuously, and how would that be implemented on the client side. Most likely the sample rate is chosen by a developer and stays the same for long periods of time. When it does eventually change, only a single flush interval would be affected.

So I've chosen to keep the assumption of a single, rarely-changing sample rate per metric --- same assumption that is used in Etsy's `statsd`.

**Summary**:

This pull request implements support for sample rate for timer counters in `gostatsd`, in original-Etsy's-`statsd`-compatible way.