### PR TITLE
Add support for New Relic backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ are interested in. Configuration file might look like this:
 	max_retries = 4
 
 [newrelic] # Enable the http server on a host running New Relic Infrastructure
-	address = "localhost:8001"
+	address = "http://localhost:8001/v1/data"
 	event_type = "GoStatsD"
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,42 @@ are interested in. Configuration file might look like this:
 [aws]
 	max_retries = 4
 
-[newrelic] # Enable the http server on a host running New Relic Infrastructure
+[newrelic] 
 	address = "http://localhost:8001/v1/data"
 	event_type = "GoStatsD"
+	#see full configuration options further below
+```
+
+New Relic Backend
+-----------------------------
+This backend sends a HTTP Payload to the [New Relic Infrastructure Agent](https://newrelic.com/products/infrastructure)
+ via it's inbuilt HTTP Server. Sending via the inbuilt HTTP server provides additional features, such as automatically applying additional metadata to the event the host may have such as AWS tags, instance type, host information, labels etc. 
+
+The payload structure required to be accepted by the agent can be viewed [here.](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample)
+
+To enable the HTTP server, modify /etc/newrelic.yml to include the below, and restart the agent ([Step 1.2](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration#install)).
+```
+http_server_enabled: true		
+http_server_host: 127.0.0.1 #(default host)
+http_server_port: 8001 #(default port)
+```
+
+Additional options are available to rename attributes if required.
+```
+[newrelic]
+	tag-prefix = ""
+	metric-name = "name"
+	metric-type = "type"
+	per-second = "per_second"
+	value = "value"
+	timer-min = "min"
+	timer-max = "max"
+	timer-count = "samples_count"
+	timer-mean = "samples_mean"
+	timer-median = "samples_median"
+	timer-stddev = "samples_std_dev"
+	timer-sum = "samples_sum"
+	timer-sumsquare = "samples_sum_squares"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ are interested in. Configuration file might look like this:
 
 [aws]
 	max_retries = 4
+
+[newrelic] # Enable the http server on a host running New Relic Infrastructure
+	address = "localhost:8001"
+	event_type = "GoStatsD"
 ```
 
 
@@ -133,6 +137,7 @@ Currently supported backends are:
 * statsdaemon
 * stdout
 * cloudwatch
+* newrelic
 
 The format of each metric is:
 

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -7,6 +7,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/backends/cloudwatch"
 	"github.com/atlassian/gostatsd/pkg/backends/datadog"
 	"github.com/atlassian/gostatsd/pkg/backends/graphite"
+	"github.com/atlassian/gostatsd/pkg/backends/newrelic"
 	"github.com/atlassian/gostatsd/pkg/backends/null"
 	"github.com/atlassian/gostatsd/pkg/backends/statsdaemon"
 	"github.com/atlassian/gostatsd/pkg/backends/stdout"
@@ -23,6 +24,7 @@ var backends = map[string]gostatsd.BackendFactory{
 	statsdaemon.BackendName: statsdaemon.NewClientFromViper,
 	stdout.BackendName:      stdout.NewClientFromViper,
 	cloudwatch.BackendName:  cloudwatch.NewClientFromViper,
+	newrelic.BackendName:    newrelic.NewClientFromViper,
 }
 
 // GetBackend creates an instance of the named backend, or nil if

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -59,7 +59,7 @@ type Metric struct {
 func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string, timestamp gostatsd.Nanotime) {
 	standardMetric := setDefaultMetricSet(n, f, name, metricType, value, tags, timestamp)
 	if metricType == "counter" {
-		standardMetric["per_second"] = persecond
+		standardMetric[n.metricPerSecond] = persecond
 	}
 
 	f.ts.Metrics = append(f.ts.Metrics, standardMetric)

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -21,46 +21,12 @@ type timeSeries struct {
 	Metrics []interface{} `json:"metrics"`
 }
 
-// Tag struct
-type Tag struct {
-	Key string
-	Val string
-}
-
-// Percentile struct
-type Percentile struct {
-	Key string
-	Val float64
-}
-
-// Metric represents a metric data structure for New Relic
-type Metric struct {
-	Interval    float64      `json:"interval,omitempty"`
-	EventType   string       `json:"event_type"`
-	Timestamp   float64      `json:"timestamp"`
-	Name        string       `json:"metric_name"`
-	Type        string       `json:"metric_type"`
-	Value       float64      `json:"metric_value"`
-	PerSecond   float64      `json:"metric_per_second"`
-	Count       float64      `json:"metric_count"`
-	Min         float64      `json:"samples_min,omitempty"`
-	Max         float64      `json:"samples_max,omitempty"`
-	Mean        float64      `json:"samples_mean,omitempty"`
-	Median      float64      `json:"samples_median,omitempty"`
-	StdDev      float64      `json:"samples_std_dev,omitempty"`
-	Sum         float64      `json:"samples_sum,omitempty"`
-	SumSquares  float64      `json:"samples_sum_squares,omitempty"`
-	Percentiles []Percentile `json:",omitempty"`
-	Tags        []Tag        `json:",omitempty"`
-}
-
 // addMetric adds a metric to the series.
 func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string, timestamp gostatsd.Nanotime) {
 	standardMetric := setDefaultMetricSet(n, f, name, metricType, value, tags, timestamp)
 	if metricType == "counter" {
-		standardMetric[n.metricPerSecond] = persecond
+		standardMetric[n.metricPrefix+n.metricPerSecond] = persecond
 	}
-
 	f.ts.Metrics = append(f.ts.Metrics, standardMetric)
 }
 
@@ -69,34 +35,34 @@ func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Time
 	timerMetric := setDefaultMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags, timer.Timestamp)
 
 	if !n.disabledSubtypes.Lower {
-		timerMetric[n.timerMin] = timer.Min
+		timerMetric[n.metricPrefix+n.timerMin] = timer.Min
 	}
 	if !n.disabledSubtypes.Upper {
-		timerMetric[n.timerMax] = timer.Max
+		timerMetric[n.metricPrefix+n.timerMax] = timer.Max
 	}
 	if !n.disabledSubtypes.Count {
-		timerMetric[n.timerCount] = float64(timer.Count)
+		timerMetric[n.metricPrefix+n.timerCount] = float64(timer.Count)
 	}
 	if !n.disabledSubtypes.CountPerSecond {
-		timerMetric[n.metricPerSecond] = timer.PerSecond
+		timerMetric[n.metricPrefix+n.metricPerSecond] = timer.PerSecond
 	}
 	if !n.disabledSubtypes.Mean {
-		timerMetric[n.timerMean] = timer.Mean
+		timerMetric[n.metricPrefix+n.timerMean] = timer.Mean
 	}
 	if !n.disabledSubtypes.Median {
-		timerMetric[n.timerMedian] = timer.Median
+		timerMetric[n.metricPrefix+n.timerMedian] = timer.Median
 	}
 	if !n.disabledSubtypes.StdDev {
-		timerMetric[n.timerStdDev] = timer.StdDev
+		timerMetric[n.metricPrefix+n.timerStdDev] = timer.StdDev
 	}
 	if !n.disabledSubtypes.Sum {
-		timerMetric[n.timerSum] = timer.Sum
+		timerMetric[n.metricPrefix+n.timerSum] = timer.Sum
 	}
 	if !n.disabledSubtypes.SumSquares {
-		timerMetric[n.timerSumSquares] = timer.SumSquares
+		timerMetric[n.metricPrefix+n.timerSumSquares] = timer.SumSquares
 	}
 	for _, pct := range timer.Percentiles {
-		timerMetric[pct.Str] = pct.Float
+		timerMetric[n.metricPrefix+pct.Str] = pct.Float
 	}
 	f.ts.Metrics = append(f.ts.Metrics, timerMetric)
 }
@@ -120,13 +86,13 @@ func setDefaultMetricSet(n *Client, f *flush, metricName, Type string, Value flo
 	defaultMetricSet := map[string]interface{}{}
 	defaultMetricSet["interval"] = f.flushIntervalSec
 	defaultMetricSet["timestamp"] = timestamp
-	defaultMetricSet[n.metricType] = Type
-	defaultMetricSet[n.metricName] = metricName
-	defaultMetricSet[n.metricValue] = Value
 	defaultMetricSet["event_type"] = n.eventType
-
 	defaultMetricSet["integration_version"] = integrationVersion
 	defaultMetricSet["protocol_version"] = protocolVersion
+
+	defaultMetricSet[n.metricPrefix+n.metricType] = Type
+	defaultMetricSet[n.metricPrefix+n.metricName] = metricName
+	defaultMetricSet[n.metricPrefix+n.metricValue] = Value
 
 	for _, tag := range tags {
 		if tag != "" && strings.Contains(tag, ":") {

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -135,9 +135,9 @@ func setDefaultMetricSet(n *Client, f *flush, metricName, Type string, Value flo
 				keyvalpair := strings.Split(tag, ":")
 				parsed, err := strconv.ParseFloat(keyvalpair[1], 64)
 				if err != nil || strings.EqualFold(keyvalpair[1], "infinity") {
-					defaultMetricSet[keyvalpair[0]] = keyvalpair[1]
+					defaultMetricSet[n.tagPrefix+keyvalpair[0]] = keyvalpair[1]
 				} else {
-					defaultMetricSet[keyvalpair[0]] = parsed
+					defaultMetricSet[n.tagPrefix+keyvalpair[0]] = parsed
 				}
 			}
 		}

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -128,16 +128,14 @@ func setDefaultMetricSet(n *Client, f *flush, metricName, Type string, Value flo
 	defaultMetricSet["integration_version"] = integrationVersion
 	defaultMetricSet["protocol_version"] = protocolVersion
 
-	if len(tags) > 0 {
-		for _, tag := range tags {
-			if tag != "" && strings.Contains(tag, ":") {
-				keyvalpair := strings.Split(tag, ":")
-				parsed, err := strconv.ParseFloat(keyvalpair[1], 64)
-				if err != nil || strings.EqualFold(keyvalpair[1], "infinity") {
-					defaultMetricSet[n.tagPrefix+keyvalpair[0]] = keyvalpair[1]
-				} else {
-					defaultMetricSet[n.tagPrefix+keyvalpair[0]] = parsed
-				}
+	for _, tag := range tags {
+		if tag != "" && strings.Contains(tag, ":") {
+			keyvalpair := strings.Split(tag, ":")
+			parsed, err := strconv.ParseFloat(keyvalpair[1], 64)
+			if err != nil || strings.EqualFold(keyvalpair[1], "infinity") {
+				defaultMetricSet[n.tagPrefix+keyvalpair[0]] = keyvalpair[1]
+			} else {
+				defaultMetricSet[n.tagPrefix+keyvalpair[0]] = parsed
 			}
 		}
 	}

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -19,7 +19,6 @@ type flush struct {
 // timeSeries represents a time series data structure.
 type timeSeries struct {
 	Metrics []interface{} `json:"metrics"`
-	// Metrics []NewRelicPayload `json:"metrics"`
 }
 
 // Tag struct

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -1,0 +1,147 @@
+package newrelic
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/atlassian/gostatsd"
+)
+
+// flush represents a send operation.
+type flush struct {
+	ts               *timeSeries
+	timestamp        float64
+	flushIntervalSec float64
+	metricsPerBatch  uint
+	cb               func(*timeSeries)
+}
+
+// timeSeries represents a time series data structure.
+type timeSeries struct {
+	Metrics []interface{} `json:"metrics"`
+	// Metrics []NewRelicPayload `json:"metrics"`
+}
+
+// Tag struct
+type Tag struct {
+	Key string
+	Val string
+}
+
+// Percentile struct
+type Percentile struct {
+	Key string
+	Val float64
+}
+
+// Metric represents a metric data structure for New Relic
+type Metric struct {
+	Interval    float64      `json:"interval,omitempty"`
+	EventType   string       `json:"event_type"`
+	Timestamp   float64      `json:"timestamp"`
+	Name        string       `json:"metric_name"`
+	Type        string       `json:"metric_type"`
+	Value       float64      `json:"metric_value"`
+	PerSecond   float64      `json:"metric_per_second"`
+	Count       float64      `json:"metric_count"`
+	Min         float64      `json:"samples_min,omitempty"`
+	Max         float64      `json:"samples_max,omitempty"`
+	Mean        float64      `json:"samples_mean,omitempty"`
+	Median      float64      `json:"samples_median,omitempty"`
+	StdDev      float64      `json:"samples_std_dev,omitempty"`
+	Sum         float64      `json:"samples_sum,omitempty"`
+	SumSquares  float64      `json:"samples_sum_squares,omitempty"`
+	Percentiles []Percentile `json:",omitempty"`
+	Tags        []Tag        `json:",omitempty"`
+}
+
+// addMetric adds a metric to the series.
+func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string, timestamp gostatsd.Nanotime) {
+	standardMetric := setDefaultMetricSet(n, f, name, metricType, value, tags, timestamp)
+	if metricType == "counter" {
+		standardMetric["per_second"] = persecond
+	}
+
+	f.ts.Metrics = append(f.ts.Metrics, standardMetric)
+}
+
+// addMetric adds a timer metric to the series.
+func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Timer, tagsKey, name string) {
+	timerMetric := setDefaultMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags, timer.Timestamp)
+
+	if !n.disabledSubtypes.Lower {
+		timerMetric[n.timerMin] = timer.Min
+	}
+	if !n.disabledSubtypes.Upper {
+		timerMetric[n.timerMax] = timer.Max
+	}
+	if !n.disabledSubtypes.Count {
+		timerMetric[n.timerCount] = float64(timer.Count)
+	}
+	if !n.disabledSubtypes.CountPerSecond {
+		timerMetric[n.metricPerSecond] = timer.PerSecond
+	}
+	if !n.disabledSubtypes.Mean {
+		timerMetric[n.timerMean] = timer.Mean
+	}
+	if !n.disabledSubtypes.Median {
+		timerMetric[n.timerMedian] = timer.Median
+	}
+	if !n.disabledSubtypes.StdDev {
+		timerMetric[n.timerStdDev] = timer.StdDev
+	}
+	if !n.disabledSubtypes.Sum {
+		timerMetric[n.timerSum] = timer.Sum
+	}
+	if !n.disabledSubtypes.SumSquares {
+		timerMetric[n.timerSumSquares] = timer.SumSquares
+	}
+	for _, pct := range timer.Percentiles {
+		timerMetric[pct.Str] = pct.Float
+	}
+	f.ts.Metrics = append(f.ts.Metrics, timerMetric)
+}
+
+func (f *flush) maybeFlush() {
+	if uint(len(f.ts.Metrics))+20 >= f.metricsPerBatch { // flush before it reaches max size and grows the slice
+		f.cb(f.ts)
+		f.ts = &timeSeries{
+			Metrics: make([]interface{}, 0, f.metricsPerBatch),
+		}
+	}
+}
+
+func (f *flush) finish() {
+	if len(f.ts.Metrics) > 0 {
+		f.cb(f.ts)
+	}
+}
+
+func setDefaultMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags, timestamp gostatsd.Nanotime) map[string]interface{} {
+	defaultMetricSet := map[string]interface{}{}
+	defaultMetricSet["interval"] = f.flushIntervalSec
+	defaultMetricSet["timestamp"] = timestamp
+	defaultMetricSet[n.metricType] = Type
+	defaultMetricSet[n.metricName] = metricName
+	defaultMetricSet[n.metricValue] = Value
+	defaultMetricSet["event_type"] = n.eventType
+
+	defaultMetricSet["integration_version"] = integrationVersion
+	defaultMetricSet["protocol_version"] = protocolVersion
+
+	if len(tags) > 0 {
+		for _, tag := range tags {
+			if tag != "" && strings.Contains(tag, ":") {
+				keyvalpair := strings.Split(tag, ":")
+				parsed, err := strconv.ParseFloat(keyvalpair[1], 64)
+				if err != nil || strings.EqualFold(keyvalpair[1], "infinity") {
+					defaultMetricSet[keyvalpair[0]] = keyvalpair[1]
+				} else {
+					defaultMetricSet[keyvalpair[0]] = parsed
+				}
+			}
+		}
+	}
+
+	return defaultMetricSet
+}

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -48,10 +48,11 @@ var (
 
 // Client represents a New Relic client.
 type Client struct {
-	address   string
-	eventType string
-	flushType string
-	tagPrefix string
+	address      string
+	eventType    string
+	flushType    string
+	metricPrefix string
+	tagPrefix    string
 	//Options to define your own field names to support other StatsD implementations
 	metricName      string
 	metricType      string
@@ -167,7 +168,7 @@ func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 	}
 
 	metrics.Gauges.Each(func(key, tagsKey string, g gostatsd.Gauge) {
-		fl.addMetric(n, "gauge", g.Value, Metric{}.PerSecond, g.Hostname, g.Tags, key, g.Timestamp)
+		fl.addMetric(n, "gauge", g.Value, 0, g.Hostname, g.Tags, key, g.Timestamp)
 		fl.maybeFlush()
 	})
 
@@ -177,7 +178,7 @@ func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 	})
 
 	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
-		fl.addMetric(n, "set", float64(len(set.Values)), Metric{}.PerSecond, set.Hostname, set.Tags, key, set.Timestamp)
+		fl.addMetric(n, "set", float64(len(set.Values)), 0, set.Hostname, set.Tags, key, set.Timestamp)
 		fl.maybeFlush()
 	})
 
@@ -284,6 +285,7 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 	nr.SetDefault("address", "http://localhost:8001/v1/data")
 	nr.SetDefault("event_type", "StatsD")
 	nr.SetDefault("flush_type", "http")
+	nr.SetDefault("metric_prefix", "")
 	nr.SetDefault("tag_prefix", "")
 	nr.SetDefault("metric_name", "metric_name")
 	nr.SetDefault("metric_type", "metric_type")
@@ -310,6 +312,7 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 		nr.GetString("address"),
 		nr.GetString("event_type"),
 		nr.GetString("flush_type"),
+		nr.GetString("metric_prefix"),
 		nr.GetString("tag_prefix"),
 		nr.GetString("metric_name"),
 		nr.GetString("metric_type"),
@@ -336,7 +339,7 @@ func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
 }
 
 // NewClient returns a new New Relic client.
-func NewClient(address, eventType, flushType, tagPrefix,
+func NewClient(address, eventType, flushType, metricPrefix, tagPrefix,
 	metricName, metricType, metricPerSecond, metricValue,
 	timerMin, timerMax, timerCount, timerMean, timerMedian, timerStdDev, timerSum, timerSumSquares,
 	userAgent, network string, metricsPerBatch, maxRequests uint, enableHttp2 bool,
@@ -392,6 +395,7 @@ func NewClient(address, eventType, flushType, tagPrefix,
 		address:               address,
 		eventType:             eventType,
 		flushType:             flushType,
+		metricPrefix:          metricPrefix,
 		tagPrefix:             tagPrefix,
 		metricName:            metricName,
 		metricType:            metricType,

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -34,8 +34,7 @@ const (
 	// defaultMetricsPerBatch is the default number of metrics to send in a single batch.
 	defaultMetricsPerBatch = 1000
 	// maxResponseSize is the maximum response size we are willing to read.
-	maxResponseSize     = 10 * 1024
-	maxConcurrentEvents = 20
+	maxResponseSize = 10 * 1024
 
 	defaultEnableHttp2 = false
 )

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -1,0 +1,345 @@
+package newrelic
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/cenkalti/backoff"
+	"github.com/json-iterator/go"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Metric struct
+type Metric struct {
+	EventType   string       `json:"event_type"`
+	Timestamp   int64        `json:"timestamp"`
+	Name        string       `json:"metric_name"`
+	Type        string       `json:"metric_type"`
+	Value       float64      `json:"metric_value"`
+	PerSecond   float64      `json:"metric_per_second"`
+	Count       float64      `json:"metric_count"`
+	Min         float64      `json:"samples_min,omitempty"`
+	Max         float64      `json:"samples_max,omitempty"`
+	Mean        float64      `json:"samples_mean,omitempty"`
+	Median      float64      `json:"samples_median,omitempty"`
+	StdDev      float64      `json:"samples_std_dev,omitempty"`
+	Sum         float64      `json:"samples_sum,omitempty"`
+	SumSquares  float64      `json:"samples_sum_squares,omitempty"`
+	Percentiles []Percentile `json:",omitempty"`
+	Tags        []Tag        `json:",omitempty"`
+}
+
+// Tag struct
+type Tag struct {
+	Key string
+	Val string
+}
+
+// Percentile struct
+type Percentile struct {
+	Key string
+	Val float64
+}
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+// BackendName is the name of this backend.
+const BackendName = "newrelic"
+
+// Client is an object that is used to send messages to newrelic
+type Client struct {
+	address   string
+	eventType string
+	tagPrefix string
+	//Options to define your own field names to support other StatsD implementations
+	metricName       string
+	metricType       string
+	metricPerSecond  string
+	metricValue      string
+	timerValue       string
+	timerMin         string
+	timerMax         string
+	timerMean        string
+	timerMedian      string
+	timerStdDev      string
+	timerSum         string
+	timerSumSquares  string
+	now              func() time.Time // Returns current time. Useful for testing.
+	disabledSubtypes gostatsd.TimerSubtypes
+}
+
+func getSubViper(v *viper.Viper, key string) *viper.Viper {
+	n := v.Sub(key)
+	if n == nil {
+		n = viper.New()
+	}
+	return n
+}
+
+// NewClientFromViper constructs a newrelic backend
+func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
+	nr := getSubViper(v, "newrelic")
+	nr.SetDefault("address", "localhost:8001")
+	nr.SetDefault("event_type", "StatsD")
+	nr.SetDefault("tag_prefix", "")
+	nr.SetDefault("metric_name", "metric_name")
+	nr.SetDefault("metric_type", "metric_type")
+	nr.SetDefault("metric_per_second", "metric_per_second")
+	nr.SetDefault("metric_value", "metric_value")
+	nr.SetDefault("timer_value", "samples_count")
+	nr.SetDefault("timer_min", "samples_min")
+	nr.SetDefault("timer_max", "samples_max")
+	nr.SetDefault("timer_mean", "samples_mean")
+	nr.SetDefault("timer_median", "samples_median")
+	nr.SetDefault("timer_std_dev", "samples_std_dev")
+	nr.SetDefault("timer_sum", "samples_sum")
+	nr.SetDefault("timer_sum_square", "samples_sum_squares")
+
+	return NewClient(
+		nr.GetString("address"),
+		nr.GetString("event_type"),
+		nr.GetString("tag_prefix"),
+		nr.GetString("metric_name"),
+		nr.GetString("metric_type"),
+		nr.GetString("metric_per_second"),
+		nr.GetString("metric_value"),
+		nr.GetString("timer_value"),
+		nr.GetString("timer_min"),
+		nr.GetString("timer_max"),
+		nr.GetString("timer_mean"),
+		nr.GetString("timer_median"),
+		nr.GetString("timer_std_dev"),
+		nr.GetString("timer_sum"),
+		nr.GetString("timer_sum_square"),
+		gostatsd.DisabledSubMetrics(v),
+	)
+}
+
+// NewClient constructs a newrelic backend.
+func NewClient(address, eventType, tagPrefix,
+	metricName, metricType, metricPerSecond, metricValue,
+	timerValue, timerMin, timerMax, timerMean, timerMedian, timerStdDev, timerSum, timerSumSquares string,
+	disabled gostatsd.TimerSubtypes) (*Client, error) {
+
+	return &Client{
+		address:          address,
+		eventType:        eventType,
+		tagPrefix:        tagPrefix,
+		metricName:       metricName,
+		metricType:       metricType,
+		metricPerSecond:  metricPerSecond,
+		metricValue:      metricValue,
+		timerValue:       timerValue,
+		timerMin:         timerMin,
+		timerMax:         timerMax,
+		timerMean:        timerMean,
+		timerMedian:      timerMedian,
+		timerStdDev:      timerStdDev,
+		timerSum:         timerSum,
+		timerSumSquares:  timerSumSquares,
+		disabledSubtypes: disabled,
+	}, nil
+}
+
+// SendMetricsAsync prints the metrics in a MetricsMap for newrelic, preparing payload synchronously but doing the send asynchronously.
+func (client Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+	statsdMetrics := client.preparePayload(metrics, &client.disabledSubtypes)
+	go func() {
+		cb([]error{client.sendPayload(statsdMetrics, &client.disabledSubtypes)})
+	}()
+}
+
+func (client Client) sendPayload(metricSets []Metric, disabled *gostatsd.TimerSubtypes) (retErr error) {
+	for ms := range metricSets {
+
+		go func(ms int) {
+			metrics := map[string]interface{}{}
+			metrics["event_type"] = metricSets[ms].EventType
+			metrics["timestamp"] = metricSets[ms].Timestamp
+			metrics[client.metricName] = metricSets[ms].Name
+			metrics[client.metricType] = metricSets[ms].Type
+			metrics[client.metricValue] = metricSets[ms].Value
+
+			if metricSets[ms].Type == "counter" || metricSets[ms].Type == "timer" {
+				metrics[client.metricPerSecond] = metricSets[ms].PerSecond
+			}
+
+			for _, tag := range metricSets[ms].Tags {
+				metrics[client.tagPrefix+tag.Key] = tag.Val
+			}
+
+			if metricSets[ms].Type == "timer" {
+				if !disabled.Count {
+					metrics[client.timerValue] = metricSets[ms].Count
+				}
+				if !disabled.Lower {
+					metrics[client.timerMin] = metricSets[ms].Min
+				}
+				if !disabled.Upper {
+					metrics[client.timerMax] = metricSets[ms].Max
+				}
+				if !disabled.Mean {
+					metrics[client.timerMean] = metricSets[ms].Mean
+				}
+				if !disabled.Median {
+					metrics[client.timerMedian] = metricSets[ms].Median
+				}
+				if !disabled.StdDev {
+					metrics[client.timerStdDev] = metricSets[ms].StdDev
+				}
+				if !disabled.Sum {
+					metrics[client.timerSum] = metricSets[ms].Sum
+				}
+				if !disabled.SumSquares {
+					metrics[client.timerSumSquares] = metricSets[ms].SumSquares
+				}
+				for _, percentile := range metricSets[ms].Percentiles {
+					metrics[percentile.Key] = percentile.Val
+				}
+			}
+
+			v2Payload := map[string]interface{}{
+				"name":                "com.nr.gostatsd-server",
+				"protocol_version":    "2",
+				"integration_version": "1.2.0",
+				"data": []interface{}{
+					map[string]interface{}{
+						"metrics": []interface{}{metrics},
+					},
+				},
+			}
+
+			mJSON, _ := json.Marshal(v2Payload)
+
+			b := backoff.NewExponentialBackOff()
+			b.MaxElapsedTime = time.Duration(15 * time.Second)
+			ticker := backoff.NewTicker(b)
+
+			for range ticker.C {
+				req, err := http.NewRequest("POST", "http://"+client.address+"/v1/data", bytes.NewBuffer(mJSON))
+				req.Header.Set("Content-Type", "application/json")
+				hclient := &http.Client{}
+				_, err = hclient.Do(req)
+
+				if err != nil {
+					log.Debug("Failed to send payload:", err)
+					log.Debug("Retrying...")
+					continue
+				}
+				ticker.Stop()
+				break
+			}
+
+		}(ms)
+	}
+
+	return nil
+}
+
+// createTags split key:val pairs
+func createTags(tagsKey string) (metricTags []Tag) {
+	metricTags = Metric{}.Tags
+	tags := strings.Split(tagsKey, ",")
+
+	if len(tags) > 0 {
+		for _, tag := range tags {
+			if tag != "" && strings.Contains(tag, ":") {
+				keyvalpair := strings.Split(tag, ":")
+				metricTags = append(metricTags, Tag{Key: keyvalpair[0], Val: keyvalpair[1]})
+			}
+		}
+	}
+
+	return metricTags
+}
+
+func (client Client) preparePayload(metrics *gostatsd.MetricMap, disabled *gostatsd.TimerSubtypes) []Metric {
+	now := time.Now().Unix()
+	var metricSets []Metric
+
+	metrics.Gauges.Each(func(key, tagsKey string, gauge gostatsd.Gauge) {
+		metricTags := createTags(tagsKey)
+		metricSet := createDefaultMetricSet(client, "gauge", now, metricTags, key, gauge.Value)
+		metricSets = append(metricSets, metricSet)
+	})
+
+	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
+		metricTags := createTags(tagsKey)
+		metricSet := createDefaultMetricSet(client, "set", now, metricTags, key, float64(len(set.Values)))
+		metricSets = append(metricSets, metricSet)
+	})
+
+	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
+		metricTags := createTags(tagsKey)
+		metricSet := createDefaultMetricSet(client, "counter", now, metricTags, key, float64(counter.Value))
+		metricSet.PerSecond = counter.PerSecond
+		metricSets = append(metricSets, metricSet)
+	})
+
+	metrics.Timers.Each(func(key, tagsKey string, timer gostatsd.Timer) {
+		metricTags := createTags(tagsKey)
+		metricSet := createDefaultMetricSet(client, "timer", now, metricTags, key, 0)
+
+		if !disabled.Count {
+			metricSet.Count = float64(timer.Count)
+		}
+		if !disabled.Lower {
+			metricSet.Min = timer.Min
+		}
+		if !disabled.Upper {
+			metricSet.Max = timer.Max
+		}
+		if !disabled.CountPerSecond {
+			metricSet.PerSecond = timer.PerSecond
+		}
+		if !disabled.Mean {
+			metricSet.Mean = timer.Mean
+		}
+		if !disabled.Median {
+			metricSet.Median = timer.Median
+		}
+		if !disabled.StdDev {
+			metricSet.StdDev = timer.StdDev
+		}
+		if !disabled.Sum {
+			metricSet.Sum = timer.Sum
+		}
+		if !disabled.SumSquares {
+			metricSet.SumSquares = timer.SumSquares
+		}
+
+		for _, pct := range timer.Percentiles {
+			metricSet.Percentiles = append(metricSet.Percentiles, Percentile{Key: pct.Str, Val: pct.Float})
+		}
+
+		metricSets = append(metricSets, metricSet)
+	})
+
+	return metricSets
+}
+
+func createDefaultMetricSet(client Client, Type string, Now int64, metricTags []Tag, metricName string, Value float64) Metric {
+	defaultMetricSet := Metric{}
+	defaultMetricSet.Type = Type
+	defaultMetricSet.Timestamp = Now
+	defaultMetricSet.Tags = metricTags
+	defaultMetricSet.Name = metricName
+	defaultMetricSet.Value = Value
+	defaultMetricSet.EventType = client.eventType
+	return defaultMetricSet
+}
+
+// SendEvent prints events
+func (client Client) SendEvent(ctx context.Context, e *gostatsd.Event) (retErr error) {
+	return nil
+}
+
+// Name returns the name of the backend.
+func (Client) Name() string {
+	return BackendName
+}

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -3,73 +3,422 @@ package newrelic
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
 	"net/http"
-	"strings"
+	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/atlassian/gostatsd"
+	stats "github.com/atlassian/gostatsd/pkg/statser"
+
 	"github.com/cenkalti/backoff"
-	"github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
-// Metric struct
-type Metric struct {
-	EventType   string       `json:"event_type"`
-	Timestamp   int64        `json:"timestamp"`
-	Name        string       `json:"metric_name"`
-	Type        string       `json:"metric_type"`
-	Value       float64      `json:"metric_value"`
-	PerSecond   float64      `json:"metric_per_second"`
-	Count       float64      `json:"metric_count"`
-	Min         float64      `json:"samples_min,omitempty"`
-	Max         float64      `json:"samples_max,omitempty"`
-	Mean        float64      `json:"samples_mean,omitempty"`
-	Median      float64      `json:"samples_median,omitempty"`
-	StdDev      float64      `json:"samples_std_dev,omitempty"`
-	Sum         float64      `json:"samples_sum,omitempty"`
-	SumSquares  float64      `json:"samples_sum_squares,omitempty"`
-	Percentiles []Percentile `json:",omitempty"`
-	Tags        []Tag        `json:",omitempty"`
-}
+const (
+	// BackendName is the name of this backend.
+	BackendName                  = "newrelic"
+	integrationName              = "com.newrelic.gostatsd"
+	integrationVersion           = "2.0.0"
+	protocolVersion              = "2"
+	defaultUserAgent             = "gostatsd"
+	defaultMaxRequestElapsedTime = 15 * time.Second
+	defaultClientTimeout         = 9 * time.Second
+	// defaultMetricsPerBatch is the default number of metrics to send in a single batch.
+	defaultMetricsPerBatch = 1000
+	// maxResponseSize is the maximum response size we are willing to read.
+	maxResponseSize     = 10 * 1024
+	maxConcurrentEvents = 20
 
-// Tag struct
-type Tag struct {
-	Key string
-	Val string
-}
+	defaultEnableHttp2 = false
+)
 
-// Percentile struct
-type Percentile struct {
-	Key string
-	Val float64
-}
+var (
+	// defaultMaxRequests is the number of parallel outgoing requests to New Relic.  As this mixes both
+	// CPU (JSON encoding, TLS) and network bound operations, balancing may require some experimentation.
+	defaultMaxRequests = uint(2 * runtime.NumCPU())
+)
 
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
-
-// BackendName is the name of this backend.
-const BackendName = "newrelic"
-
-// Client is an object that is used to send messages to newrelic
+// Client represents a New Relic client.
 type Client struct {
 	address   string
 	eventType string
+	flushType string
 	tagPrefix string
 	//Options to define your own field names to support other StatsD implementations
-	metricName       string
-	metricType       string
-	metricPerSecond  string
-	metricValue      string
-	timerValue       string
-	timerMin         string
-	timerMax         string
-	timerMean        string
-	timerMedian      string
-	timerStdDev      string
-	timerSum         string
-	timerSumSquares  string
+	metricName      string
+	metricType      string
+	metricPerSecond string
+	metricValue     string
+	timerMin        string
+	timerMax        string
+	timerCount      string
+	timerMean       string
+	timerMedian     string
+	timerStdDev     string
+	timerSum        string
+	timerSumSquares string
+
+	batchesCreated uint64 // Accumulated number of batches created
+	batchesRetried uint64 // Accumulated number of batches retried (first send is not a retry)
+	batchesDropped uint64 // Accumulated number of batches aborted (data loss)
+	batchesSent    uint64 // Accumulated number of batches successfully sent
+
+	userAgent             string
+	maxRequestElapsedTime time.Duration
+	client                http.Client
+	metricsPerBatch       uint
+	metricsBufferSem      chan *bytes.Buffer // Two in one - a semaphore and a buffer pool
+	eventsBufferSem       chan *bytes.Buffer // Two in one - a semaphore and a buffer pool
+	now                   func() time.Time   // Returns current time. Useful for testing.
+
 	disabledSubtypes gostatsd.TimerSubtypes
+	flushInterval    time.Duration
+}
+
+// NewRelicPayload struct
+type NewRelicPayload struct {
+	Name               string        `json:"name"`
+	ProtocolVersion    string        `json:"protocol_version"`
+	IntegrationVersion string        `json:"integration_version"`
+	Data               []interface{} `json:"data"`
+}
+
+// SendMetricsAsync flushes the metrics to New Relic, preparing payload synchronously but doing the send asynchronously.
+func (n *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
+	counter := 0
+	results := make(chan error)
+	n.processMetrics(metrics, func(ts *timeSeries) {
+		// This section would be likely be better if it pushed all ts's in to a single channel
+		// which n goroutines then read from.  Current behavior still spins up many goroutines
+		// and has them all hit the same channel.
+		atomic.AddUint64(&n.batchesCreated, 1)
+		go func() {
+			select {
+			case <-ctx.Done():
+				return
+			case buffer := <-n.metricsBufferSem:
+				defer func() {
+					buffer.Reset()
+					n.metricsBufferSem <- buffer
+				}()
+				err := n.postMetrics(ctx, buffer, ts)
+
+				select {
+				case <-ctx.Done():
+				case results <- err:
+				}
+			}
+		}()
+		counter++
+	})
+	go func() {
+		errs := make([]error, 0, counter)
+	loop:
+		for c := 0; c < counter; c++ {
+			select {
+			case <-ctx.Done():
+				errs = append(errs, ctx.Err())
+				break loop
+			case err := <-results:
+				errs = append(errs, err)
+			}
+		}
+		cb(errs)
+	}()
+}
+
+// RunMetrics x
+func (n *Client) RunMetrics(ctx context.Context, statser stats.Statser) {
+	statser = statser.WithTags(gostatsd.Tags{"backend:newrelic"})
+
+	flushed, unregister := statser.RegisterFlush()
+	defer unregister()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-flushed:
+			statser.Gauge("backend.created", float64(atomic.LoadUint64(&n.batchesCreated)), nil)
+			statser.Gauge("backend.retried", float64(atomic.LoadUint64(&n.batchesRetried)), nil)
+			statser.Gauge("backend.dropped", float64(atomic.LoadUint64(&n.batchesDropped)), nil)
+			statser.Gauge("backend.sent", float64(atomic.LoadUint64(&n.batchesSent)), nil)
+		}
+	}
+}
+
+func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries)) {
+	fl := flush{
+		ts: &timeSeries{
+			Metrics: make([]interface{}, 0, n.metricsPerBatch),
+			// Metrics: make([]NewRelicPayload, 0, n.metricsPerBatch),
+		},
+		timestamp:        float64(n.now().Unix()),
+		flushIntervalSec: n.flushInterval.Seconds(),
+		metricsPerBatch:  n.metricsPerBatch,
+		cb:               cb,
+	}
+
+	metrics.Gauges.Each(func(key, tagsKey string, g gostatsd.Gauge) {
+		fl.addMetric(n, "gauge", g.Value, Metric{}.PerSecond, g.Hostname, g.Tags, key, g.Timestamp)
+		fl.maybeFlush()
+	})
+
+	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
+		fl.addMetric(n, "counter", float64(counter.Value), counter.PerSecond, counter.Hostname, counter.Tags, key, counter.Timestamp)
+		fl.maybeFlush()
+	})
+
+	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
+		fl.addMetric(n, "set", float64(len(set.Values)), Metric{}.PerSecond, set.Hostname, set.Tags, key, set.Timestamp)
+		fl.maybeFlush()
+	})
+
+	metrics.Timers.Each(func(key, tagsKey string, timer gostatsd.Timer) {
+		fl.addTimerMetric(n, "timer", timer, tagsKey, key)
+		fl.maybeFlush()
+	})
+
+	fl.finish()
+}
+
+func (n *Client) postMetrics(ctx context.Context, buffer *bytes.Buffer, ts *timeSeries) error {
+	return n.post(ctx, buffer, "metrics", ts)
+}
+
+// SendEvent sends an event to New Relic.
+func (n *Client) SendEvent(ctx context.Context, e *gostatsd.Event) error {
+	return nil
+}
+
+// Name returns the name of the backend.
+func (n *Client) Name() string {
+	return BackendName
+}
+
+func (n *Client) post(ctx context.Context, buffer *bytes.Buffer, typeOfPost string, data interface{}) error {
+	post, err := n.constructPost(ctx, buffer, typeOfPost, data)
+	if err != nil {
+		atomic.AddUint64(&n.batchesDropped, 1)
+		return err
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = n.maxRequestElapsedTime
+	for {
+		if err = post(); err == nil {
+			atomic.AddUint64(&n.batchesSent, 1)
+			return nil
+		}
+
+		next := b.NextBackOff()
+		if next == backoff.Stop {
+			atomic.AddUint64(&n.batchesDropped, 1)
+			return fmt.Errorf("[%s] %v", BackendName, err)
+		}
+
+		log.Warnf("[%s] failed to send %s, sleeping for %s: %v", BackendName, typeOfPost, next, err)
+
+		timer := time.NewTimer(next)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		atomic.AddUint64(&n.batchesRetried, 1)
+	}
+}
+
+func (n *Client) constructPost(ctx context.Context, buffer *bytes.Buffer, typeOfPost string, data interface{}) (func() error /*doPost*/, error) {
+
+	NRPayload := setDefaultPayload()
+	NRPayload.Data = append(NRPayload.Data, data)
+	mJSON, err := json.Marshal(NRPayload)
+
+	if err != nil {
+		return nil, fmt.Errorf("[%s] unable to marshal %s: %v", BackendName, typeOfPost, err)
+	}
+
+	return func() error {
+		headers := map[string]string{
+			"Content-Type": "application/json",
+			"User-Agent":   n.userAgent,
+		}
+		req, err := http.NewRequest("POST", n.address, bytes.NewBuffer(mJSON))
+		if err != nil {
+			return fmt.Errorf("unable to create http.Request: %v", err)
+		}
+		req = req.WithContext(ctx)
+		for header, v := range headers {
+			req.Header.Set(header, v)
+		}
+		resp, err := n.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("error POSTing: %s", err.Error())
+		}
+		defer resp.Body.Close()
+		body := io.LimitReader(resp.Body, maxResponseSize)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusNoContent {
+			b, _ := ioutil.ReadAll(body)
+			log.Infof("[%s] failed request status: %d\n%s", BackendName, resp.StatusCode, b)
+			return fmt.Errorf("received bad status code %d", resp.StatusCode)
+		}
+		_, _ = io.Copy(ioutil.Discard, body)
+		return nil
+	}, nil
+
+}
+
+// NewClientFromViper returns a new New Relic client.
+func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
+	nr := getSubViper(v, "datadog")
+	nr.SetDefault("address", "http://localhost:8001/v1/data")
+	nr.SetDefault("event_type", "StatsD")
+	nr.SetDefault("flush_type", "http")
+	nr.SetDefault("tag_prefix", "")
+	nr.SetDefault("metric_name", "metric_name")
+	nr.SetDefault("metric_type", "metric_type")
+	nr.SetDefault("metric_per_second", "metric_per_second")
+	nr.SetDefault("metric_value", "metric_value")
+	nr.SetDefault("timer_min", "samples_min")
+	nr.SetDefault("timer_max", "samples_max")
+	nr.SetDefault("timer_count", "samples_count")
+	nr.SetDefault("timer_mean", "samples_mean")
+	nr.SetDefault("timer_median", "samples_median")
+	nr.SetDefault("timer_std_dev", "samples_std_dev")
+	nr.SetDefault("timer_sum", "samples_sum")
+	nr.SetDefault("timer_sum_square", "samples_sum_squares")
+
+	nr.SetDefault("metrics_per_batch", defaultMetricsPerBatch)
+	nr.SetDefault("network", "tcp")
+	nr.SetDefault("client_timeout", defaultClientTimeout)
+	nr.SetDefault("max_request_elapsed_time", defaultMaxRequestElapsedTime)
+	nr.SetDefault("max_requests", defaultMaxRequests)
+	nr.SetDefault("enable-http2", defaultEnableHttp2)
+	nr.SetDefault("user-agent", defaultUserAgent)
+
+	return NewClient(
+		nr.GetString("address"),
+		nr.GetString("event_type"),
+		nr.GetString("flush_type"),
+		nr.GetString("tag_prefix"),
+		nr.GetString("metric_name"),
+		nr.GetString("metric_type"),
+		nr.GetString("metric_per_second"),
+		nr.GetString("metric_value"),
+		nr.GetString("timer_min"),
+		nr.GetString("timer_max"),
+		nr.GetString("timer_count"),
+		nr.GetString("timer_mean"),
+		nr.GetString("timer_median"),
+		nr.GetString("timer_std_dev"),
+		nr.GetString("timer_sum"),
+		nr.GetString("timer_sum_square"),
+		nr.GetString("user-agent"),
+		nr.GetString("network"),
+		uint(nr.GetInt("metrics_per_batch")),
+		uint(nr.GetInt("max_requests")),
+		nr.GetBool("enable-http2"),
+		nr.GetDuration("client_timeout"),
+		nr.GetDuration("max_request_elapsed_time"),
+		v.GetDuration("flush-interval"), // Main viper, not sub-viper
+		gostatsd.DisabledSubMetrics(v),
+	)
+}
+
+// NewClient returns a new New Relic client.
+func NewClient(address, eventType, flushType, tagPrefix,
+	metricName, metricType, metricPerSecond, metricValue,
+	timerMin, timerMax, timerCount, timerMean, timerMedian, timerStdDev, timerSum, timerSumSquares,
+	userAgent, network string, metricsPerBatch, maxRequests uint, enableHttp2 bool,
+	clientTimeout, maxRequestElapsedTime, flushInterval time.Duration, disabled gostatsd.TimerSubtypes) (*Client, error) {
+
+	if metricsPerBatch <= 0 {
+		return nil, fmt.Errorf("[%s] metricsPerBatch must be positive", BackendName)
+	}
+	if clientTimeout <= 0 {
+		return nil, fmt.Errorf("[%s] clientTimeout must be positive", BackendName)
+	}
+	if maxRequestElapsedTime <= 0 {
+		return nil, fmt.Errorf("[%s] maxRequestElapsedTime must be positive", BackendName)
+	}
+
+	log.Infof("[%s] maxRequestElapsedTime=%s maxRequests=%d clientTimeout=%s metricsPerBatch=%d", BackendName, maxRequestElapsedTime, maxRequests, clientTimeout, metricsPerBatch)
+
+	dialer := &net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 3 * time.Second,
+		TLSClientConfig: &tls.Config{
+			// Can't use SSLv3 because of POODLE and BEAST
+			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+			// Can't use TLSv1.1 because of RC4 cipher usage
+			MinVersion: tls.VersionTLS12,
+		},
+		DialContext: func(ctx context.Context, _, address string) (net.Conn, error) {
+			// replace the network with our own
+			return dialer.DialContext(ctx, network, address)
+		},
+		MaxIdleConns:    50,
+		IdleConnTimeout: 1 * time.Minute,
+	}
+	if !enableHttp2 {
+		// A non-nil empty map used in TLSNextProto to disable HTTP/2 support in client.
+		// https://golang.org/doc/go1.6#http2
+		transport.TLSNextProto = map[string](func(string, *tls.Conn) http.RoundTripper){}
+	}
+
+	metricsBufferSem := make(chan *bytes.Buffer, maxRequests)
+	for i := uint(0); i < maxRequests; i++ {
+		metricsBufferSem <- &bytes.Buffer{}
+	}
+	eventsBufferSem := make(chan *bytes.Buffer, maxConcurrentEvents)
+	for i := uint(0); i < maxConcurrentEvents; i++ {
+		eventsBufferSem <- &bytes.Buffer{}
+	}
+	return &Client{
+		address:               address,
+		eventType:             eventType,
+		flushType:             flushType,
+		tagPrefix:             tagPrefix,
+		metricName:            metricName,
+		metricType:            metricType,
+		metricPerSecond:       metricPerSecond,
+		metricValue:           metricValue,
+		timerMin:              timerMin,
+		timerMax:              timerMax,
+		timerCount:            timerCount,
+		timerMean:             timerMean,
+		timerMedian:           timerMedian,
+		timerStdDev:           timerStdDev,
+		timerSum:              timerSum,
+		timerSumSquares:       timerSumSquares,
+		userAgent:             userAgent,
+		maxRequestElapsedTime: maxRequestElapsedTime,
+		client: http.Client{
+			Transport: transport,
+			Timeout:   clientTimeout,
+		},
+		metricsPerBatch:  metricsPerBatch,
+		metricsBufferSem: metricsBufferSem,
+		eventsBufferSem:  eventsBufferSem,
+		now:              time.Now,
+		flushInterval:    flushInterval,
+		disabledSubtypes: disabled,
+	}, nil
 }
 
 func getSubViper(v *viper.Viper, key string) *viper.Viper {
@@ -80,265 +429,10 @@ func getSubViper(v *viper.Viper, key string) *viper.Viper {
 	return n
 }
 
-// NewClientFromViper constructs a newrelic backend
-func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
-	nr := getSubViper(v, "newrelic")
-	nr.SetDefault("address", "localhost:8001")
-	nr.SetDefault("event_type", "StatsD")
-	nr.SetDefault("tag_prefix", "")
-	nr.SetDefault("metric_name", "metric_name")
-	nr.SetDefault("metric_type", "metric_type")
-	nr.SetDefault("metric_per_second", "metric_per_second")
-	nr.SetDefault("metric_value", "metric_value")
-	nr.SetDefault("timer_value", "samples_count")
-	nr.SetDefault("timer_min", "samples_min")
-	nr.SetDefault("timer_max", "samples_max")
-	nr.SetDefault("timer_mean", "samples_mean")
-	nr.SetDefault("timer_median", "samples_median")
-	nr.SetDefault("timer_std_dev", "samples_std_dev")
-	nr.SetDefault("timer_sum", "samples_sum")
-	nr.SetDefault("timer_sum_square", "samples_sum_squares")
-
-	return NewClient(
-		nr.GetString("address"),
-		nr.GetString("event_type"),
-		nr.GetString("tag_prefix"),
-		nr.GetString("metric_name"),
-		nr.GetString("metric_type"),
-		nr.GetString("metric_per_second"),
-		nr.GetString("metric_value"),
-		nr.GetString("timer_value"),
-		nr.GetString("timer_min"),
-		nr.GetString("timer_max"),
-		nr.GetString("timer_mean"),
-		nr.GetString("timer_median"),
-		nr.GetString("timer_std_dev"),
-		nr.GetString("timer_sum"),
-		nr.GetString("timer_sum_square"),
-		gostatsd.DisabledSubMetrics(v),
-	)
-}
-
-// NewClient constructs a newrelic backend.
-func NewClient(address, eventType, tagPrefix,
-	metricName, metricType, metricPerSecond, metricValue,
-	timerValue, timerMin, timerMax, timerMean, timerMedian, timerStdDev, timerSum, timerSumSquares string,
-	disabled gostatsd.TimerSubtypes) (*Client, error) {
-
-	return &Client{
-		address:          address,
-		eventType:        eventType,
-		tagPrefix:        tagPrefix,
-		metricName:       metricName,
-		metricType:       metricType,
-		metricPerSecond:  metricPerSecond,
-		metricValue:      metricValue,
-		timerValue:       timerValue,
-		timerMin:         timerMin,
-		timerMax:         timerMax,
-		timerMean:        timerMean,
-		timerMedian:      timerMedian,
-		timerStdDev:      timerStdDev,
-		timerSum:         timerSum,
-		timerSumSquares:  timerSumSquares,
-		disabledSubtypes: disabled,
-	}, nil
-}
-
-// SendMetricsAsync prints the metrics in a MetricsMap for newrelic, preparing payload synchronously but doing the send asynchronously.
-func (client Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	statsdMetrics := client.preparePayload(metrics, &client.disabledSubtypes)
-	go func() {
-		cb([]error{client.sendPayload(statsdMetrics, &client.disabledSubtypes)})
-	}()
-}
-
-func (client Client) sendPayload(metricSets []Metric, disabled *gostatsd.TimerSubtypes) (retErr error) {
-	for ms := range metricSets {
-
-		go func(ms int) {
-			metrics := map[string]interface{}{}
-			metrics["event_type"] = metricSets[ms].EventType
-			metrics["timestamp"] = metricSets[ms].Timestamp
-			metrics[client.metricName] = metricSets[ms].Name
-			metrics[client.metricType] = metricSets[ms].Type
-			metrics[client.metricValue] = metricSets[ms].Value
-
-			if metricSets[ms].Type == "counter" || metricSets[ms].Type == "timer" {
-				metrics[client.metricPerSecond] = metricSets[ms].PerSecond
-			}
-
-			for _, tag := range metricSets[ms].Tags {
-				metrics[client.tagPrefix+tag.Key] = tag.Val
-			}
-
-			if metricSets[ms].Type == "timer" {
-				if !disabled.Count {
-					metrics[client.timerValue] = metricSets[ms].Count
-				}
-				if !disabled.Lower {
-					metrics[client.timerMin] = metricSets[ms].Min
-				}
-				if !disabled.Upper {
-					metrics[client.timerMax] = metricSets[ms].Max
-				}
-				if !disabled.Mean {
-					metrics[client.timerMean] = metricSets[ms].Mean
-				}
-				if !disabled.Median {
-					metrics[client.timerMedian] = metricSets[ms].Median
-				}
-				if !disabled.StdDev {
-					metrics[client.timerStdDev] = metricSets[ms].StdDev
-				}
-				if !disabled.Sum {
-					metrics[client.timerSum] = metricSets[ms].Sum
-				}
-				if !disabled.SumSquares {
-					metrics[client.timerSumSquares] = metricSets[ms].SumSquares
-				}
-				for _, percentile := range metricSets[ms].Percentiles {
-					metrics[percentile.Key] = percentile.Val
-				}
-			}
-
-			v2Payload := map[string]interface{}{
-				"name":                "com.nr.gostatsd-server",
-				"protocol_version":    "2",
-				"integration_version": "2.0.0",
-				"data": []interface{}{
-					map[string]interface{}{
-						"metrics": []interface{}{metrics},
-					},
-				},
-			}
-
-			mJSON, _ := json.Marshal(v2Payload)
-
-			b := backoff.NewExponentialBackOff()
-			b.MaxElapsedTime = 15 * time.Second
-			ticker := backoff.NewTicker(b)
-
-			for range ticker.C {
-				req, _ := http.NewRequest("POST", "http://"+client.address+"/v1/data", bytes.NewBuffer(mJSON))
-				req.Header.Set("Content-Type", "application/json")
-				hclient := &http.Client{}
-				_, err := hclient.Do(req)
-
-				if err != nil {
-					log.Debug("Failed to send payload:", err)
-					log.Debug("Retrying...")
-					continue
-				}
-				ticker.Stop()
-				break
-			}
-
-		}(ms)
+func setDefaultPayload() NewRelicPayload {
+	return NewRelicPayload{
+		Name:               integrationName,
+		ProtocolVersion:    protocolVersion,
+		IntegrationVersion: integrationVersion,
 	}
-
-	return nil
-}
-
-// createTags split key:val pairs
-func createTags(tagsKey string) (metricTags []Tag) {
-	metricTags = Metric{}.Tags
-	tags := strings.Split(tagsKey, ",")
-
-	if len(tags) > 0 {
-		for _, tag := range tags {
-			if tag != "" && strings.Contains(tag, ":") {
-				keyvalpair := strings.Split(tag, ":")
-				metricTags = append(metricTags, Tag{Key: keyvalpair[0], Val: keyvalpair[1]})
-			}
-		}
-	}
-
-	return metricTags
-}
-
-func (client Client) preparePayload(metrics *gostatsd.MetricMap, disabled *gostatsd.TimerSubtypes) []Metric {
-	now := time.Now().Unix()
-	var metricSets []Metric
-
-	metrics.Gauges.Each(func(key, tagsKey string, gauge gostatsd.Gauge) {
-		metricTags := createTags(tagsKey)
-		metricSet := createDefaultMetricSet(client, "gauge", now, metricTags, key, gauge.Value)
-		metricSets = append(metricSets, metricSet)
-	})
-
-	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
-		metricTags := createTags(tagsKey)
-		metricSet := createDefaultMetricSet(client, "set", now, metricTags, key, float64(len(set.Values)))
-		metricSets = append(metricSets, metricSet)
-	})
-
-	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
-		metricTags := createTags(tagsKey)
-		metricSet := createDefaultMetricSet(client, "counter", now, metricTags, key, float64(counter.Value))
-		metricSet.PerSecond = counter.PerSecond
-		metricSets = append(metricSets, metricSet)
-	})
-
-	metrics.Timers.Each(func(key, tagsKey string, timer gostatsd.Timer) {
-		metricTags := createTags(tagsKey)
-		metricSet := createDefaultMetricSet(client, "timer", now, metricTags, key, 0)
-
-		if !disabled.Count {
-			metricSet.Count = float64(timer.Count)
-		}
-		if !disabled.Lower {
-			metricSet.Min = timer.Min
-		}
-		if !disabled.Upper {
-			metricSet.Max = timer.Max
-		}
-		if !disabled.CountPerSecond {
-			metricSet.PerSecond = timer.PerSecond
-		}
-		if !disabled.Mean {
-			metricSet.Mean = timer.Mean
-		}
-		if !disabled.Median {
-			metricSet.Median = timer.Median
-		}
-		if !disabled.StdDev {
-			metricSet.StdDev = timer.StdDev
-		}
-		if !disabled.Sum {
-			metricSet.Sum = timer.Sum
-		}
-		if !disabled.SumSquares {
-			metricSet.SumSquares = timer.SumSquares
-		}
-
-		for _, pct := range timer.Percentiles {
-			metricSet.Percentiles = append(metricSet.Percentiles, Percentile{Key: pct.Str, Val: pct.Float})
-		}
-
-		metricSets = append(metricSets, metricSet)
-	})
-
-	return metricSets
-}
-
-func createDefaultMetricSet(client Client, Type string, Now int64, metricTags []Tag, metricName string, Value float64) Metric {
-	defaultMetricSet := Metric{}
-	defaultMetricSet.Type = Type
-	defaultMetricSet.Timestamp = Now
-	defaultMetricSet.Tags = metricTags
-	defaultMetricSet.Name = metricName
-	defaultMetricSet.Value = Value
-	defaultMetricSet.EventType = client.eventType
-	return defaultMetricSet
-}
-
-// SendEvent prints events
-func (client Client) SendEvent(ctx context.Context, e *gostatsd.Event) (retErr error) {
-	return nil
-}
-
-// Name returns the name of the backend.
-func (Client) Name() string {
-	return BackendName
 }

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -69,7 +69,6 @@ type Client struct {
 	timerStdDev      string
 	timerSum         string
 	timerSumSquares  string
-	now              func() time.Time // Returns current time. Useful for testing.
 	disabledSubtypes gostatsd.TimerSubtypes
 }
 
@@ -206,7 +205,7 @@ func (client Client) sendPayload(metricSets []Metric, disabled *gostatsd.TimerSu
 			v2Payload := map[string]interface{}{
 				"name":                "com.nr.gostatsd-server",
 				"protocol_version":    "2",
-				"integration_version": "1.2.0",
+				"integration_version": "2.0.0",
 				"data": []interface{}{
 					map[string]interface{}{
 						"metrics": []interface{}{metrics},
@@ -217,14 +216,14 @@ func (client Client) sendPayload(metricSets []Metric, disabled *gostatsd.TimerSu
 			mJSON, _ := json.Marshal(v2Payload)
 
 			b := backoff.NewExponentialBackOff()
-			b.MaxElapsedTime = time.Duration(15 * time.Second)
+			b.MaxElapsedTime = 15 * time.Second
 			ticker := backoff.NewTicker(b)
 
 			for range ticker.C {
-				req, err := http.NewRequest("POST", "http://"+client.address+"/v1/data", bytes.NewBuffer(mJSON))
+				req, _ := http.NewRequest("POST", "http://"+client.address+"/v1/data", bytes.NewBuffer(mJSON))
 				req.Header.Set("Content-Type", "application/json")
 				hclient := &http.Client{}
-				_, err = hclient.Do(req)
+				_, err := hclient.Do(req)
 
 				if err != nil {
 					log.Debug("Failed to send payload:", err)

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -159,7 +159,6 @@ func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 	fl := flush{
 		ts: &timeSeries{
 			Metrics: make([]interface{}, 0, n.metricsPerBatch),
-			// Metrics: make([]NewRelicPayload, 0, n.metricsPerBatch),
 		},
 		timestamp:        float64(n.now().Unix()),
 		flushIntervalSec: n.flushInterval.Seconds(),
@@ -281,7 +280,7 @@ func (n *Client) constructPost(ctx context.Context, buffer *bytes.Buffer, typeOf
 
 // NewClientFromViper returns a new New Relic client.
 func NewClientFromViper(v *viper.Viper) (gostatsd.Backend, error) {
-	nr := getSubViper(v, "datadog")
+	nr := getSubViper(v, "newrelic")
 	nr.SetDefault("address", "http://localhost:8001/v1/data")
 	nr.SetDefault("event_type", "StatsD")
 	nr.SetDefault("flush_type", "http")

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -218,7 +218,7 @@ func (n *Client) post(ctx context.Context, buffer *bytes.Buffer, data interface{
 			return fmt.Errorf("[%s] %v", BackendName, err)
 		}
 
-		log.Warnf("[%s] failed to send %s, sleeping for %s: %v", BackendName, next, err)
+		log.Warnf("[%s] failed to send, sleeping for %s: %v", BackendName, next, err)
 
 		timer := time.NewTimer(next)
 		select {

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -35,7 +35,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "GoStatsD", "http", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
@@ -68,7 +68,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "GoStatsD", "http", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		1, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
@@ -92,17 +92,18 @@ func TestSendMetrics(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.0","data":[{"metrics":[` +
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"protocol_version":"2","timestamp":0},` +
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"protocol_version":"2","timestamp":0},` +
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"protocol_version":"2","timestamp":0},` +
-			`{"count_90":0.1,"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,"protocol_version":"2","samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"timestamp":0}]}]}`
+		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.1","data":[{"metrics":` +
+			`[{"event_type":"GoStatsD","integration_version":"2.0.1","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.0.1","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.0.1","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
+			`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.0.1","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
+			`"samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":0}]}]}`
 		assert.Equal(t, expected, string(data))
 	})
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "GoStatsD", "http", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -35,7 +35,7 @@ func TestRetries(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
@@ -68,7 +68,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		1, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
@@ -102,7 +102,7 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
 		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -1,98 +1,147 @@
 package newrelic
 
 import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/atlassian/gostatsd"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPreparePayload(t *testing.T) {
+func TestRetries(t *testing.T) {
 	t.Parallel()
+	var requestNum uint32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/data", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		n := atomic.AddUint32(&requestNum, 1)
+		data, err := ioutil.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotEmpty(t, data)
+		if n == 1 {
+			// Return error on first request to trigger a retry
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 
-	cli, err := NewClient("localhost:8001", "StatsD", "", "metric_name", "metric_type",
-		"metric_per_second", "metric_value", "samples_count", "samples_min", "samples_max",
-		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", gostatsd.TimerSubtypes{})
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
+		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+
 	require.NoError(t, err)
+	res := make(chan []error, 1)
+	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
+		res <- errs
+	})
+	errs := <-res
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+	assert.EqualValues(t, 2, requestNum)
+}
 
-	expectedMetricSets := []Metric{
-		{
-			EventType: "StatsD",
-			Type:      "gauge",
-			Timestamp: time.Now().Unix(),
-			Value:     3,
-		},
-		{
-			EventType: "StatsD",
-			Type:      "set",
-			Timestamp: time.Now().Unix(),
-			Value:     3,
-		},
-		{
-			EventType: "StatsD",
-			Type:      "counter",
-			Timestamp: time.Now().Unix(),
-			PerSecond: 1.1,
-			Value:     5,
-		},
-		{
-			EventType:  "StatsD",
-			Type:       "timer",
-			Timestamp:  time.Now().Unix(),
-			Value:      0,
-			Count:      1,
-			PerSecond:  1.1,
-			Mean:       0.5,
-			Median:     0.5,
-			Min:        0,
-			Max:        1,
-			StdDev:     0.1,
-			Sum:        1,
-			SumSquares: 1,
+func TestSendMetricsInMultipleBatches(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/data", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		data, err := ioutil.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.0","data":[{"metrics":[`+
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat1","metric_type":"counter","metric_value":5,"per_second":0,"protocol_version":"2","timestamp":0},`+
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat2","metric_type":"counter","metric_value":50,"per_second":0,"protocol_version":"2","timestamp":0}]}]}`,
+			string(data))
+		assert.NotEmpty(t, data)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
+		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+	res := make(chan []error, 1)
+	client.SendMetricsAsync(context.Background(), twoCounters(), func(errs []error) {
+		res <- errs
+	})
+	errs := <-res
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+func TestSendMetrics(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/data", func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.0","data":[{"metrics":[` +
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"protocol_version":"2","timestamp":0},` +
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"c1","metric_type":"counter","metric_value":5,"per_second":1.1,"protocol_version":"2","timestamp":0},` +
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"protocol_version":"2","timestamp":0},` +
+			`{"count_90":0.1,"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,"protocol_version":"2","samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"timestamp":0}]}]}`
+		assert.Equal(t, expected, string(data))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL+"/v1/data", "StatsD", "http", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
+		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+
+	require.NoError(t, err)
+	client.now = func() time.Time {
+		return time.Unix(100, 0)
+	}
+	res := make(chan []error, 1)
+	client.SendMetricsAsync(context.Background(), metricsOneOfEach(), func(errs []error) {
+		res <- errs
+	})
+	errs := <-res
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+// twoCounters returns two counters.
+func twoCounters() *gostatsd.MetricMap {
+	return &gostatsd.MetricMap{
+		Counters: gostatsd.Counters{
+			"stat1": map[string]gostatsd.Counter{
+				"tag1": gostatsd.NewCounter(0, 5, "", nil),
+			},
+			"stat2": map[string]gostatsd.Counter{
+				"tag2": gostatsd.NewCounter(0, 50, "", nil),
+			},
 		},
 	}
-
-	statsdMetrics := cli.preparePayload(metricsOneOfEach(), &cli.disabledSubtypes)
-	assert.Equal(t, len(expectedMetricSets), len(statsdMetrics), "Should generate 4 metric sets")
-
-	for no, metric := range expectedMetricSets {
-		assert.Equal(t, metric.EventType, statsdMetrics[no].EventType)
-		assert.Equal(t, metric.Type, statsdMetrics[no].Type)
-		assert.Equal(t, metric.Value, statsdMetrics[no].Value)
-		assert.Equal(t, metric.Count, statsdMetrics[no].Count)
-		assert.Equal(t, metric.PerSecond, statsdMetrics[no].PerSecond)
-		assert.Equal(t, metric.Mean, statsdMetrics[no].Mean)
-		assert.Equal(t, metric.Median, statsdMetrics[no].Median)
-		assert.Equal(t, metric.Min, statsdMetrics[no].Min)
-		assert.Equal(t, metric.Max, statsdMetrics[no].Max)
-		assert.Equal(t, metric.StdDev, statsdMetrics[no].StdDev)
-		assert.Equal(t, metric.Sum, statsdMetrics[no].Sum)
-		assert.Equal(t, metric.SumSquares, statsdMetrics[no].SumSquares)
-	}
-
 }
 
 func metricsOneOfEach() *gostatsd.MetricMap {
 	return &gostatsd.MetricMap{
-		Gauges: gostatsd.Gauges{
-			"g1": map[string]gostatsd.Gauge{
-				"tag3": {Value: 3, Timestamp: gostatsd.Nanotime(300), Hostname: "h3", Tags: gostatsd.Tags{"tag3"}},
-			},
-		},
-		Sets: gostatsd.Sets{
-			"users": map[string]gostatsd.Set{
-				"tag4": {
-					Values: map[string]struct{}{
-						"joe":  {},
-						"bob":  {},
-						"john": {},
-					},
-					Timestamp: gostatsd.Nanotime(400),
-					Hostname:  "h4",
-					Tags:      gostatsd.Tags{"tag4"},
-				},
+		Counters: gostatsd.Counters{
+			"c1": map[string]gostatsd.Counter{
+				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: 0, Hostname: "h1", Tags: gostatsd.Tags{"tag1"}},
 			},
 		},
 		Timers: gostatsd.Timers{
@@ -111,15 +160,29 @@ func metricsOneOfEach() *gostatsd.MetricMap {
 					Percentiles: gostatsd.Percentiles{
 						gostatsd.Percentile{Float: 0.1, Str: "count_90"},
 					},
-					Timestamp: gostatsd.Nanotime(200),
+					Timestamp: 0,
 					Hostname:  "h2",
 					Tags:      gostatsd.Tags{"tag2"},
 				},
 			},
 		},
-		Counters: gostatsd.Counters{
-			"c1": map[string]gostatsd.Counter{
-				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: gostatsd.Nanotime(100), Hostname: "h1", Tags: gostatsd.Tags{"tag1"}},
+		Gauges: gostatsd.Gauges{
+			"g1": map[string]gostatsd.Gauge{
+				"tag3": {Value: 3, Timestamp: 0, Hostname: "h3", Tags: gostatsd.Tags{"tag3"}},
+			},
+		},
+		Sets: gostatsd.Sets{
+			"users": map[string]gostatsd.Set{
+				"tag4": {
+					Values: map[string]struct{}{
+						"joe":  {},
+						"bob":  {},
+						"john": {},
+					},
+					Timestamp: 0,
+					Hostname:  "h4",
+					Tags:      gostatsd.Tags{"tag4"},
+				},
 			},
 		},
 	}

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -63,8 +63,8 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 		}
 
 		assert.Equal(t, `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.0","data":[{"metrics":[`+
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat1","metric_type":"counter","metric_value":5,"per_second":0,"protocol_version":"2","timestamp":0},`+
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat2","metric_type":"counter","metric_value":50,"per_second":0,"protocol_version":"2","timestamp":0}]}]}`,
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat1","metric_per_second":0,"metric_type":"counter","metric_value":5,"protocol_version":"2","timestamp":0},`+
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"stat2","metric_per_second":0,"metric_type":"counter","metric_value":50,"protocol_version":"2","timestamp":0}]}]}`,
 			string(data))
 		assert.NotEmpty(t, data)
 	})
@@ -96,7 +96,7 @@ func TestSendMetrics(t *testing.T) {
 		}
 		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.0.0","data":[{"metrics":[` +
 			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"protocol_version":"2","timestamp":0},` +
-			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"c1","metric_type":"counter","metric_value":5,"per_second":1.1,"protocol_version":"2","timestamp":0},` +
+			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"protocol_version":"2","timestamp":0},` +
 			`{"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"protocol_version":"2","timestamp":0},` +
 			`{"count_90":0.1,"event_type":"StatsD","integration_version":"2.0.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,"protocol_version":"2","samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"timestamp":0}]}]}`
 		assert.Equal(t, expected, string(data))

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -1,0 +1,126 @@
+package newrelic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreparePayload(t *testing.T) {
+	t.Parallel()
+
+	cli, err := NewClient("localhost:8001", "StatsD", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_count", "samples_min", "samples_max",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+
+	expectedMetricSets := []Metric{
+		{
+			EventType: "StatsD",
+			Type:      "gauge",
+			Timestamp: time.Now().Unix(),
+			Value:     3,
+		},
+		{
+			EventType: "StatsD",
+			Type:      "set",
+			Timestamp: time.Now().Unix(),
+			Value:     3,
+		},
+		{
+			EventType: "StatsD",
+			Type:      "counter",
+			Timestamp: time.Now().Unix(),
+			PerSecond: 1.1,
+			Value:     5,
+		},
+		{
+			EventType:  "StatsD",
+			Type:       "timer",
+			Timestamp:  time.Now().Unix(),
+			Value:      0,
+			Count:      1,
+			PerSecond:  1.1,
+			Mean:       0.5,
+			Median:     0.5,
+			Min:        0,
+			Max:        1,
+			StdDev:     0.1,
+			Sum:        1,
+			SumSquares: 1,
+		},
+	}
+
+	statsdMetrics := cli.preparePayload(metricsOneOfEach(), &cli.disabledSubtypes)
+	assert.Equal(t, len(expectedMetricSets), len(statsdMetrics), "Should generate 4 metric sets")
+
+	for no, metric := range expectedMetricSets {
+		assert.Equal(t, metric.EventType, statsdMetrics[no].EventType)
+		assert.Equal(t, metric.Type, statsdMetrics[no].Type)
+		assert.Equal(t, metric.Value, statsdMetrics[no].Value)
+		assert.Equal(t, metric.Count, statsdMetrics[no].Count)
+		assert.Equal(t, metric.PerSecond, statsdMetrics[no].PerSecond)
+		assert.Equal(t, metric.Mean, statsdMetrics[no].Mean)
+		assert.Equal(t, metric.Median, statsdMetrics[no].Median)
+		assert.Equal(t, metric.Min, statsdMetrics[no].Min)
+		assert.Equal(t, metric.Max, statsdMetrics[no].Max)
+		assert.Equal(t, metric.StdDev, statsdMetrics[no].StdDev)
+		assert.Equal(t, metric.Sum, statsdMetrics[no].Sum)
+		assert.Equal(t, metric.SumSquares, statsdMetrics[no].SumSquares)
+	}
+
+}
+
+func metricsOneOfEach() *gostatsd.MetricMap {
+	return &gostatsd.MetricMap{
+		Gauges: gostatsd.Gauges{
+			"g1": map[string]gostatsd.Gauge{
+				"tag3": {Value: 3, Timestamp: gostatsd.Nanotime(300), Hostname: "h3", Tags: gostatsd.Tags{"tag3"}},
+			},
+		},
+		Sets: gostatsd.Sets{
+			"users": map[string]gostatsd.Set{
+				"tag4": {
+					Values: map[string]struct{}{
+						"joe":  {},
+						"bob":  {},
+						"john": {},
+					},
+					Timestamp: gostatsd.Nanotime(400),
+					Hostname:  "h4",
+					Tags:      gostatsd.Tags{"tag4"},
+				},
+			},
+		},
+		Timers: gostatsd.Timers{
+			"t1": map[string]gostatsd.Timer{
+				"tag2": {
+					Count:      1,
+					PerSecond:  1.1,
+					Mean:       0.5,
+					Median:     0.5,
+					Min:        0,
+					Max:        1,
+					StdDev:     0.1,
+					Sum:        1,
+					SumSquares: 1,
+					Values:     []float64{0, 1},
+					Percentiles: gostatsd.Percentiles{
+						gostatsd.Percentile{Float: 0.1, Str: "count_90"},
+					},
+					Timestamp: gostatsd.Nanotime(200),
+					Hostname:  "h2",
+					Tags:      gostatsd.Tags{"tag2"},
+				},
+			},
+		},
+		Counters: gostatsd.Counters{
+			"c1": map[string]gostatsd.Counter{
+				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: gostatsd.Nanotime(100), Hostname: "h1", Tags: gostatsd.Tags{"tag1"}},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds support to flush to New Relic via the New Relic Infrastructure Agent http server.

eg. modify the New Relic Infrastructure Agent Config > /etc/newrelic.yml to include the below:
```
http_server_enabled: true		
http_server_host: 127.0.0.1 #(default host)
http_server_port: 8001 #(default port)
```