### PR TITLE
fix the legacy counter namespace

### DIFF
--- a/pkg/backends/graphite/graphite.go
+++ b/pkg/backends/graphite/graphite.go
@@ -218,7 +218,7 @@ func NewClient(config *Config, disabled gostatsd.TimerSubtypes) (*Client, error)
 		legacyNamespace = DefaultLegacyNamespace
 	}
 	if legacyNamespace {
-		counterNamespace = DefaultGlobalPrefix + `.`
+		counterNamespace = DefaultGlobalPrefix + ".counters."
 		timerNamespace = DefaultGlobalPrefix + ".timers."
 		gaugesNamespace = DefaultGlobalPrefix + ".gauges."
 		setsNamespace = DefaultGlobalPrefix + ".sets."


### PR DESCRIPTION
The prefix for counters in statsd was "counters" which is not reflected in the legacy namespaces for graphite in gostatsd. The reference to this in statsd can be found [here](https://github.com/etsy/statsd/blob/8d5363cb109cc6363661a1d5813e0b96787c4411/docs/namespacing.md)