### PR TITLE
Remove errors from *Handler pipeline

### DIFF
--- a/pkg/stats/statser_internal.go
+++ b/pkg/stats/statser_internal.go
@@ -11,13 +11,13 @@ import (
 // InternalMetricHandler is an interface to dispatch metrics to.  Exists
 // to break circular dependencies.
 type InternalMetricHandler interface {
-	DispatchMetric(ctx context.Context, m *gostatsd.Metric) error
+	DispatchMetric(ctx context.Context, m *gostatsd.Metric)
 }
 
 // InternalEventHandler is an interface to dispatch metrics to.  Exists
 // to break circular dependencies.
 type InternalEventHandler interface {
-	DispatchEvent(context.Context, *gostatsd.Event) error
+	DispatchEvent(context.Context, *gostatsd.Event)
 }
 
 // InternalStatser is a Statser which sends metrics to a handler on a best
@@ -146,5 +146,5 @@ func (is *InternalStatser) dispatchMetric(ctx context.Context, metric *gostatsd.
 		metric.Name = is.namespace + "." + metric.Name
 	}
 	metric.Tags = metric.Tags.Concat(is.tags)
-	_ = is.metrics.DispatchMetric(ctx, metric)
+	is.metrics.DispatchMetric(ctx, metric)
 }

--- a/pkg/statsd/handler_backend_test.go
+++ b/pkg/statsd/handler_backend_test.go
@@ -128,7 +128,7 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 		}
 		go func() {
 			defer wg.Done()
-			assert.NoError(t, h.DispatchMetric(ctx, m))
+			h.DispatchMetric(ctx, m)
 		}()
 	}
 	wg.Wait()       // Wait for all metrics to be dispatched
@@ -172,9 +172,7 @@ func BenchmarkBackendHandler(b *testing.B) {
 				Tags:  nil,
 				Value: rand.Float64(),
 			}
-			if err := h.DispatchMetric(ctx, m); err != nil {
-				b.Errorf("unexpected error: %v", err)
-			}
+			h.DispatchMetric(ctx, m)
 		}
 	})
 	cancelFunc()    // After all metrics have been dispatched, we signal dispatcher to shut down

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -16,14 +16,12 @@ func (tch *TagCapturingHandler) EstimatedTags() int {
 	return 0
 }
 
-func (tch *TagCapturingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+func (tch *TagCapturingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) {
 	tch.m = append(tch.m, m)
-	return nil
 }
 
-func (tch *TagCapturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
+func (tch *TagCapturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	tch.e = append(tch.e, e)
-	return nil
 }
 
 func (tch *TagCapturingHandler) WaitForEvents() {
@@ -35,12 +33,10 @@ func (nh *nopHandler) EstimatedTags() int {
 	return 0
 }
 
-func (nh *nopHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
-	return nil
+func (nh *nopHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) {
 }
 
-func (nh *nopHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
-	return nil
+func (nh *nopHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 }
 
 func (nh *nopHandler) WaitForEvents() {
@@ -56,19 +52,17 @@ func (ch *countingHandler) EstimatedTags() int {
 	return 0
 }
 
-func (ch *countingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+func (ch *countingHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) {
 	m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data which interferes with the tests
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	ch.metrics = append(ch.metrics, *m)
-	return nil
 }
 
-func (ch *countingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
+func (ch *countingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	ch.events = append(ch.events, *e)
-	return nil
 }
 
 func (ch *countingHandler) WaitForEvents() {

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -53,14 +53,13 @@ func (th *TagHandler) EstimatedTags() int {
 }
 
 // DispatchMetric adds the unique tags from the TagHandler to the metric and passes it to the next stage in the pipeline
-func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) error {
+func (th *TagHandler) DispatchMetric(ctx context.Context, m *gostatsd.Metric) {
 	if m.Hostname == "" {
 		m.Hostname = string(m.SourceIP)
 	}
 	if th.uniqueFilterMetricAndAddTags(m) {
-		return th.metrics.DispatchMetric(ctx, m)
+		th.metrics.DispatchMetric(ctx, m)
 	}
-	return nil
 }
 
 // uniqueFilterMetricAndAddTags will perform 3 tasks:
@@ -119,12 +118,12 @@ func (th *TagHandler) uniqueFilterMetricAndAddTags(m *gostatsd.Metric) bool {
 }
 
 // DispatchEvent adds the unique tags from the TagHandler to the event and passes it to the next stage in the pipeline
-func (th *TagHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) error {
+func (th *TagHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	if e.Hostname == "" {
 		e.Hostname = string(e.SourceIP)
 	}
 	e.Tags = uniqueTags(e.Tags, th.tags)
-	return th.events.DispatchEvent(ctx, e)
+	th.events.DispatchEvent(ctx, e)
 }
 
 // WaitForEvents waits for all event-dispatching goroutines to finish.

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -294,7 +294,6 @@ drop-tags='host:*'
 		{MatchMetrics: toStringMatch([]string{"global.*"}), ExcludeMetrics: empty, MatchTags: empty, DropTags: toStringMatch([]string{"host:*"}), DropMetric: false, DropHost: true},
 	}
 	assert.Equal(t, expected, th.filters)
-
 }
 
 func assertHasAllTags(t *testing.T, actual gostatsd.Tags, expected... string) {

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/stats"
+
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
 
@@ -36,8 +36,7 @@ func TestParseEmptyDatagram(t *testing.T) {
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
 			mr, ch := newTestParser(false)
-			_, _, _, err := mr.handleDatagram(context.Background(), gostatsd.UnknownIP, inp)
-			require.NoError(t, err)
+			_, _, _ = mr.handleDatagram(context.Background(), gostatsd.UnknownIP, inp)
 			assert.Zero(t, len(ch.events), ch.events)
 			assert.Zero(t, len(ch.metrics), ch.metrics)
 		})
@@ -94,8 +93,7 @@ func TestParseDatagram(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			mr, ch := newTestParser(false)
-			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
-			assert.NoError(t, err)
+			_, _, _ = mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			for i, e := range ch.events {
 				if e.DateHappened <= 0 {
 					t.Errorf("%q: DateHappened should be positive", e)
@@ -163,8 +161,7 @@ func TestParseDatagramIgnoreHost(t *testing.T) {
 		t.Run(datagram, func(t *testing.T) {
 			t.Parallel()
 			mr, ch := newTestParser(true)
-			_, _, _, err := mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
-			assert.NoError(t, err)
+			_, _, _ = mr.handleDatagram(context.Background(), fakeIP, []byte(datagram))
 			for i, e := range ch.events {
 				if e.DateHappened <= 0 {
 					t.Errorf("%q: DateHappened should be positive", e)

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -233,7 +233,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 }
 
 func sendStartEvent(ctx context.Context, events EventHandler, selfIP gostatsd.IP, hostname string) {
-	err := events.DispatchEvent(ctx, &gostatsd.Event{
+	events.DispatchEvent(ctx, &gostatsd.Event{
 		Title:        "Gostatsd started",
 		Text:         "Gostatsd started",
 		DateHappened: time.Now().Unix(),
@@ -241,15 +241,12 @@ func sendStartEvent(ctx context.Context, events EventHandler, selfIP gostatsd.IP
 		SourceIP:     selfIP,
 		Priority:     gostatsd.PriLow,
 	})
-	if unexpectedErr(err) {
-		log.Warnf("Failed to send start event: %v", err)
-	}
 }
 
 func sendStopEvent(events EventHandler, selfIP gostatsd.IP, hostname string) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancelFunc()
-	err := events.DispatchEvent(ctx, &gostatsd.Event{
+	events.DispatchEvent(ctx, &gostatsd.Event{
 		Title:        "Gostatsd stopped",
 		Text:         "Gostatsd stopped",
 		DateHappened: time.Now().Unix(),
@@ -257,9 +254,6 @@ func sendStopEvent(events EventHandler, selfIP gostatsd.IP, hostname string) {
 		SourceIP:     selfIP,
 		Priority:     gostatsd.PriLow,
 	})
-	if unexpectedErr(err) {
-		log.Warnf("Failed to send stop event: %v", err)
-	}
 	events.WaitForEvents()
 }
 
@@ -288,8 +282,4 @@ func toStringSlice(fs []float64) []string {
 		s[i] = strconv.FormatFloat(f, 'f', -1, 64)
 	}
 	return s
-}
-
-func unexpectedErr(err error) bool {
-	return err != nil && err != context.Canceled && err != context.DeadlineExceeded
 }

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -13,13 +13,13 @@ type MetricHandler interface {
 	// EstimatedTags returns a guess for how many tags to pre-allocate
 	EstimatedTags() int
 	// DispatchMetric dispatches a metric to the next step in a pipeline.
-	DispatchMetric(ctx context.Context, m *gostatsd.Metric) error
+	DispatchMetric(ctx context.Context, m *gostatsd.Metric)
 }
 
 // EventHandler can be used to handle events
 type EventHandler interface {
 	// DispatchEvent dispatches event to the next step in a pipeline.
-	DispatchEvent(ctx context.Context, e *gostatsd.Event) error
+	DispatchEvent(ctx context.Context, e *gostatsd.Event)
 	// WaitForEvents waits for all event-dispatching goroutines to finish.
 	WaitForEvents()
 }


### PR DESCRIPTION
This is basically accepting that we don't actually have errors.  There is nothing in the pipeline where we have a failure that's not a context cancellation.