### PR TITLE
[cloudwatch] Batch requests to Cloudwatch to reduce cost

### DIFF
--- a/pkg/backends/cloudwatch/cloudwatch_test.go
+++ b/pkg/backends/cloudwatch/cloudwatch_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"time"
 	"context"
 	"testing"
 
@@ -26,7 +27,8 @@ func (m *mockedCloudwatch) PutMetricData(input *cloudwatch.PutMetricDataInput) (
 func TestSendMetrics(t *testing.T) {
 	t.Parallel()
 
-	cli, err := NewClient("ns", gostatsd.TimerSubtypes{})
+	duration, _ := time.ParseDuration("50ms")
+	cli, err := NewClient("ns", duration, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 
 	expected := []struct {
@@ -82,7 +84,8 @@ func TestSendMetrics(t *testing.T) {
 func TestSendMetricDimensions(t *testing.T) {
 	t.Parallel()
 
-	cli, err := NewClient("ns", gostatsd.TimerSubtypes{})
+	duration, _ := time.ParseDuration("50ms")
+	cli, err := NewClient("ns", duration, gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 
 	metricMap := &gostatsd.MetricMap{


### PR DESCRIPTION
Cloudwatch is billed per request and by batching requests to Cloudwatch we can significantly reduce the cost of running statsd with Cloudwatch as configured backend.

![screenshot 2018-12-02 21 53 49](https://user-images.githubusercontent.com/223318/49344878-22cceb80-f67d-11e8-9cdd-43ef578f1c6a.png)
