### PR TITLE
Refactor the startup of the pipeline.  Also a lot of fmt changes.

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -24,10 +24,3 @@ type Backend interface {
 	// SendEvent sends event to the backend.
 	SendEvent(context.Context, *Event) error
 }
-
-// RunnableBackend represents a backend that needs a Run method to be executed to work.
-type RunnableBackend interface {
-	Backend
-	// Run executes backend send operations. Should be started in a goroutine.
-	Run(context.Context)
-}

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -133,8 +133,8 @@ func (d *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricM
 	}()
 }
 
-func (d *Client) RunMetrics(ctx context.Context, statser stats.Statser) {
-	statser = statser.WithTags(gostatsd.Tags{"backend:datadog"})
+func (d *Client) Run(ctx context.Context) {
+	statser := stats.FromContext(ctx).WithTags(gostatsd.Tags{"backend:datadog"})
 
 	flushed, unregister := statser.RegisterFlush()
 	defer unregister()

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -25,9 +25,7 @@ func TestPreparePayload(t *testing.T) {
 	metrics := metrics()
 	input := []testData{
 		{
-			config: &Config{
-			// Use defaults
-			},
+			config: &Config{}, // Use defaults
 			result: []byte("stats_counts.stat1 5 1234\n" +
 				"stats.stat1 1.100000 1234\n" +
 				"stats.timers.t1.lower 0.000000 1234\n" +

--- a/pkg/stats/context.go
+++ b/pkg/stats/context.go
@@ -1,0 +1,25 @@
+package stats
+
+import (
+	"context"
+)
+
+type statserKey int
+
+const statserContextKey = statserKey(0)
+
+var nullStatser = &NullStatser{}
+
+// NewContext attaches a Statser to a Context
+func NewContext(ctx context.Context, statser Statser) context.Context {
+	return context.WithValue(ctx, statserContextKey, statser)
+}
+
+// FromContext returns a Statser from a Context.  Always succeeds, will return a NullStatser if there is no
+// statser present.
+func FromContext(ctx context.Context) Statser {
+	if statser, ok := ctx.Value(statserContextKey).(Statser); ok {
+		return statser
+	}
+	return nullStatser
+}

--- a/pkg/stats/context_test.go
+++ b/pkg/stats/context_test.go
@@ -1,0 +1,24 @@
+package stats
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextValid(t *testing.T) {
+	t.Parallel()
+
+	originalStatser := NewLoggingStatser(nil, nil)
+	ctxWithStatser := NewContext(context.Background(), originalStatser)
+	returnedStatser := FromContext(ctxWithStatser)
+	require.Equal(t, originalStatser, returnedStatser)
+}
+
+func TestContextInvalid(t *testing.T) {
+	t.Parallel()
+
+	returnedStatser := FromContext(context.Background())
+	require.NotNil(t, returnedStatser)
+}

--- a/pkg/stats/heartbeat.go
+++ b/pkg/stats/heartbeat.go
@@ -8,21 +8,22 @@ import (
 
 // HeartBeater periodically sends a gauge for heartbeat purposes
 type HeartBeater struct {
-	statser    Statser
 	metricName string
+	tags       gostatsd.Tags
 }
 
 // NewHeartBeater creates a new HeartBeater
-func NewHeartBeater(statser Statser, metricName string, tags gostatsd.Tags) *HeartBeater {
+func NewHeartBeater(metricName string, tags gostatsd.Tags) *HeartBeater {
 	return &HeartBeater{
-		statser:    statser.WithTags(tags),
 		metricName: metricName,
+		tags:       tags,
 	}
 }
 
 // Run will run a HeartBeater in the background until the supplied context is closed.
 func (hb *HeartBeater) Run(ctx context.Context) {
-	flushed, unregister := hb.statser.RegisterFlush()
+	statser := FromContext(ctx).WithTags(hb.tags)
+	flushed, unregister := statser.RegisterFlush()
 	defer unregister()
 
 	for {
@@ -30,11 +31,11 @@ func (hb *HeartBeater) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-flushed:
-			hb.emit()
+			hb.emit(statser)
 		}
 	}
 }
 
-func (hb *HeartBeater) emit() {
-	hb.statser.Gauge(hb.metricName, 1, nil)
+func (hb *HeartBeater) emit(statser Statser) {
+	statser.Gauge(hb.metricName, 1, nil)
 }

--- a/pkg/stats/statser_internal.go
+++ b/pkg/stats/statser_internal.go
@@ -41,9 +41,11 @@ type InternalStatser struct {
 	dropped   uint64
 }
 
+const bufferSize = 1000 // estimating this is difficult and tends to cause problems if too small
+
 // NewInternalStatser creates a new Statser which sends metrics to the
 // supplied InternalHandler.
-func NewInternalStatser(bufferSize int, tags gostatsd.Tags, namespace, hostname string, metrics InternalMetricHandler, events InternalEventHandler) *InternalStatser {
+func NewInternalStatser(tags gostatsd.Tags, namespace, hostname string, metrics InternalMetricHandler, events InternalEventHandler) *InternalStatser {
 	return &InternalStatser{
 		buffer:    make(chan *gostatsd.Metric, bufferSize),
 		tags:      tags,

--- a/pkg/statsd/aggregator_test.go
+++ b/pkg/statsd/aggregator_test.go
@@ -452,7 +452,7 @@ func TestReceive(t *testing.T) {
 			"baz,foo:bar": {Values: []float64{1}, Timestamp: nowNano, SampledCount: 1, Tags: gostatsd.Tags{"baz", "foo:bar"}},
 		},
 		"timer_sampling": map[string]gostatsd.Timer{
-			"": {Values: []float64{10,30,50}, Timestamp: nowNano, SampledCount: 30},
+			"": {Values: []float64{10, 30, 50}, Timestamp: nowNano, SampledCount: 30},
 		},
 	}
 	assrt.Equal(expectedTimers, ma.Timers)

--- a/pkg/statsd/flusher.go
+++ b/pkg/statsd/flusher.go
@@ -24,23 +24,21 @@ type MetricFlusher struct {
 	flushInterval      time.Duration // How often to flush metrics to the sender
 	aggregateProcesser AggregateProcesser
 	backends           []gostatsd.Backend
-	hostname           string
-	statser            stats.Statser
 }
 
 // NewMetricFlusher creates a new MetricFlusher with provided configuration.
-func NewMetricFlusher(flushInterval time.Duration, aggregateProcesser AggregateProcesser, backends []gostatsd.Backend, hostname string, statser stats.Statser) *MetricFlusher {
+func NewMetricFlusher(flushInterval time.Duration, aggregateProcesser AggregateProcesser, backends []gostatsd.Backend) *MetricFlusher {
 	return &MetricFlusher{
 		flushInterval:      flushInterval,
 		aggregateProcesser: aggregateProcesser,
 		backends:           backends,
-		hostname:           hostname,
-		statser:            statser,
 	}
 }
 
 // Run runs the MetricFlusher.
 func (f *MetricFlusher) Run(ctx context.Context) {
+	statser := stats.FromContext(ctx)
+
 	flushTicker := time.NewTicker(f.flushInterval)
 	defer flushTicker.Stop()
 
@@ -51,31 +49,31 @@ func (f *MetricFlusher) Run(ctx context.Context) {
 			return
 		case thisFlush := <-flushTicker.C: // Time to flush to the backends
 			flushDelta := thisFlush.Sub(lastFlush)
-			f.flushData(ctx, flushDelta)
-			f.statser.NotifyFlush(flushDelta)
+			f.flushData(ctx, flushDelta, statser)
+			statser.NotifyFlush(flushDelta)
 			lastFlush = thisFlush
 		}
 	}
 }
 
-func (f *MetricFlusher) flushData(ctx context.Context, flushInterval time.Duration) {
+func (f *MetricFlusher) flushData(ctx context.Context, flushInterval time.Duration, statser stats.Statser) {
 	var sendWg sync.WaitGroup
-	timerTotal := f.statser.NewTimer("flusher.total_time", nil)
+	timerTotal := statser.NewTimer("flusher.total_time", nil)
 	processWait := f.aggregateProcesser.Process(ctx, func(workerId int, aggr Aggregator) {
 		// This is in the flusher, but it's an aggregator action, so put it in that space.
 		tags := gostatsd.Tags{fmt.Sprintf("aggregator_id:%d", workerId)}
 
-		timerFlush := f.statser.NewTimer("aggregator.aggregation_time", tags)
+		timerFlush := statser.NewTimer("aggregator.aggregation_time", tags)
 		aggr.Flush(flushInterval)
 		timerFlush.SendGauge()
 
-		timerProcess := f.statser.NewTimer("aggregator.process_time", tags)
+		timerProcess := statser.NewTimer("aggregator.process_time", tags)
 		aggr.Process(func(m *gostatsd.MetricMap) {
 			f.sendMetricsAsync(ctx, &sendWg, m)
 		})
 		timerProcess.SendGauge()
 
-		timerReset := f.statser.NewTimer("aggregator.reset_time", tags)
+		timerReset := statser.NewTimer("aggregator.reset_time", tags)
 		aggr.Reset()
 		timerReset.SendGauge()
 	})

--- a/pkg/statsd/flusher_test.go
+++ b/pkg/statsd/flusher_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"strconv"
 	"testing"
-
-	"github.com/atlassian/gostatsd/pkg/stats"
 )
 
 func TestFlusherHandleSendResultNoErrors(t *testing.T) {
@@ -19,7 +17,7 @@ func TestFlusherHandleSendResultNoErrors(t *testing.T) {
 		errs := errs
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
-			fl := NewMetricFlusher(0, nil, nil, "host", stats.NewNullStatser())
+			fl := NewMetricFlusher(0, nil, nil)
 			fl.handleSendResult(errs)
 
 			if fl.lastFlush == 0 || fl.lastFlushError != 0 {
@@ -41,7 +39,7 @@ func TestFlusherHandleSendResultError(t *testing.T) {
 		errs := errs
 		t.Run(strconv.Itoa(pos), func(t *testing.T) {
 			t.Parallel()
-			fl := NewMetricFlusher(0, nil, nil, "host", stats.NewNullStatser())
+			fl := NewMetricFlusher(0, nil, nil)
 			fl.handleSendResult(errs)
 
 			if fl.lastFlushError == 0 || fl.lastFlush != 0 {

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -139,7 +139,7 @@ func uniqueTags(t1 gostatsd.Tags, t2 gostatsd.Tags) gostatsd.Tags {
 // uniqueTags returns the set of (t1 | t2) - seen.  It may modify the contents of t1, t2, and seen.
 func uniqueTagsWithSeen(seen map[string]struct{}, t1 gostatsd.Tags, t2 gostatsd.Tags) gostatsd.Tags {
 	last := len(t1)
-	for idx := 0 ; idx < last ; {
+	for idx := 0; idx < last; {
 		tag := t1[idx]
 		if _, ok := seen[tag]; ok {
 			last--

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -3,13 +3,13 @@ package statsd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/atlassian/gostatsd"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"strings"
 )
 
 func TestFilterPassesNoFilters(t *testing.T) {
@@ -296,7 +296,7 @@ drop-tags='host:*'
 	assert.Equal(t, expected, th.filters)
 }
 
-func assertHasAllTags(t *testing.T, actual gostatsd.Tags, expected... string) {
+func assertHasAllTags(t *testing.T, actual gostatsd.Tags, expected ...string) {
 	assert.Equal(t, len(expected), len(actual))
 	seenActual := map[string]struct{}{}
 	for _, actualTag := range actual {
@@ -340,7 +340,7 @@ func TestTagMetricHandlerAddsNoTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
-	assert.Equal(t, 1, len(tch.m))         // Metric tracked
+	assert.Equal(t, 1, len(tch.m)) // Metric tracked
 	assertHasAllTags(t, tch.m[0].Tags)
 	assert.Equal(t, "", tch.m[0].Hostname) // No hostname added
 }
@@ -350,9 +350,9 @@ func TestTagMetricHandlerAddsSingleTag(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
-	assert.Equal(t, 1, len(tch.m))            // Metric tracked
+	assert.Equal(t, 1, len(tch.m)) // Metric tracked
 	assertHasAllTags(t, tch.m[0].Tags, "tag1")
-	assert.Equal(t, "", tch.m[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.m[0].Hostname) // No hostname added
 }
 
 func TestTagMetricHandlerAddsMultipleTags(t *testing.T) {
@@ -360,9 +360,9 @@ func TestTagMetricHandlerAddsMultipleTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
-	assert.Equal(t, 1, len(tch.m))            // Metric tracked
+	assert.Equal(t, 1, len(tch.m)) // Metric tracked
 	assertHasAllTags(t, tch.m[0].Tags, "tag1", "tag2")
-	assert.Equal(t, "", tch.m[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.m[0].Hostname) // No hostname added
 }
 
 func TestTagMetricHandlerAddsHostname(t *testing.T) {
@@ -382,9 +382,9 @@ func TestTagMetricHandlerAddsDuplicateTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
-	assert.Equal(t, 1, len(tch.m))            // Metric tracked
+	assert.Equal(t, 1, len(tch.m)) // Metric tracked
 	assertHasAllTags(t, tch.m[0].Tags, "tag1", "tag2", "tag3")
-	assert.Equal(t, "", tch.m[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.m[0].Hostname) // No hostname added
 }
 
 func TestTagEventHandlerAddsNoTags(t *testing.T) {
@@ -392,7 +392,7 @@ func TestTagEventHandlerAddsNoTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
-	assert.Equal(t, 1, len(tch.e))         // Metric tracked
+	assert.Equal(t, 1, len(tch.e)) // Metric tracked
 	assertHasAllTags(t, tch.e[0].Tags)
 	assert.Equal(t, "", tch.e[0].Hostname) // No hostname added
 }
@@ -402,9 +402,9 @@ func TestTagEventHandlerAddsSingleTag(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
-	assert.Equal(t, 1, len(tch.e))            // Metric tracked
+	assert.Equal(t, 1, len(tch.e)) // Metric tracked
 	assertHasAllTags(t, tch.e[0].Tags, "tag1")
-	assert.Equal(t, "", tch.e[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.e[0].Hostname) // No hostname added
 }
 
 func TestTagEventHandlerAddsMultipleTags(t *testing.T) {
@@ -412,9 +412,9 @@ func TestTagEventHandlerAddsMultipleTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
-	assert.Equal(t, 1, len(tch.e))            // Metric tracked
+	assert.Equal(t, 1, len(tch.e)) // Metric tracked
 	assertHasAllTags(t, tch.e[0].Tags, "tag1", "tag2")
-	assert.Equal(t, "", tch.e[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.e[0].Hostname) // No hostname added
 }
 
 func TestTagEventHandlerAddsHostname(t *testing.T) {
@@ -424,7 +424,7 @@ func TestTagEventHandlerAddsHostname(t *testing.T) {
 		SourceIP: "1.2.3.4",
 	}
 	th.DispatchEvent(context.Background(), e)
-	assert.Equal(t, 1, len(tch.e))                // Metric tracked
+	assert.Equal(t, 1, len(tch.e)) // Metric tracked
 	assertHasAllTags(t, tch.e[0].Tags)
 	assert.Equal(t, "1.2.3.4", tch.e[0].Hostname) // Hostname injected
 }
@@ -434,9 +434,9 @@ func TestTagEventHandlerAddsDuplicateTags(t *testing.T) {
 	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
-	assert.Equal(t, 1, len(tch.e))            // Metric tracked
+	assert.Equal(t, 1, len(tch.e)) // Metric tracked
 	assertHasAllTags(t, tch.e[0].Tags, "tag1", "tag2", "tag3")
-	assert.Equal(t, "", tch.e[0].Hostname)    // No hostname added
+	assert.Equal(t, "", tch.e[0].Hostname) // No hostname added
 }
 
 func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
@@ -457,7 +457,7 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		metricTags := make(gostatsd.Tags, 0, len(baseTags) + th.EstimatedTags())
+		metricTags := make(gostatsd.Tags, 0, len(baseTags)+th.EstimatedTags())
 		metricTags = append(metricTags, baseTags...)
 		m := &gostatsd.Metric{
 			Tags: metricTags,
@@ -481,7 +481,6 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 		"jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj:jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
 	}, nil)
 
-
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -494,7 +493,7 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		metricTags := make(gostatsd.Tags, 0, len(baseTags) + th.EstimatedTags())
+		metricTags := make(gostatsd.Tags, 0, len(baseTags)+th.EstimatedTags())
 		metricTags = append(metricTags, baseTags...)
 		m := &gostatsd.Metric{
 			Tags: metricTags,

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/stats"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
@@ -21,7 +20,7 @@ const fakeIP = gostatsd.IP("127.0.0.1")
 
 func newTestParser(ignoreHost bool) (*DatagramParser, *countingHandler) {
 	ch := &countingHandler{}
-	return NewDatagramParser(nil, "", ignoreHost, 0, ch, ch, stats.NewNullStatser(), rate.NewLimiter(0, 0)), ch
+	return NewDatagramParser(nil, "", ignoreHost, 0, ch, ch, rate.Limit(0)), ch
 }
 
 func TestParseEmptyDatagram(t *testing.T) {

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -19,7 +19,7 @@ func BenchmarkReceive(b *testing.B) {
 	//
 	// ... so this is pretty arbitrary.
 	ch := make(chan []*Datagram, 5000)
-	mr := NewDatagramReceiver(ch, DefaultReceiveBatchSize)
+	mr := NewDatagramReceiver(ch, nil, 0, DefaultReceiveBatchSize)
 	c, done := fakesocket.NewCountedFakePacketConn(uint64(b.N))
 
 	var wg sync.WaitGroup
@@ -65,7 +65,7 @@ func BenchmarkReceive(b *testing.B) {
 
 func TestDatagramReceiver_Receive(t *testing.T) {
 	ch := make(chan []*Datagram, 1)
-	mr := NewDatagramReceiver(ch, 2)
+	mr := NewDatagramReceiver(ch, nil, 0, 2)
 	c := fakesocket.NewFakePacketConn()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/types.go
+++ b/types.go
@@ -1,5 +1,9 @@
 package gostatsd
 
+import (
+	"context"
+)
+
 // Nanotime is the number of nanoseconds elapsed since January 1, 1970 UTC.
 // Get the value with time.Now().UnixNano().
 type Nanotime int64
@@ -29,4 +33,12 @@ type TimerSubtypes struct {
 	SumPct         bool // pct
 	SumSquares     bool
 	SumSquaresPct  bool // pct
+}
+
+// Runnable is a long running function intended to be launched in a goroutine.
+type Runnable func(ctx context.Context)
+
+// Runner exposes a Runnable through an interface
+type Runner interface {
+	Run(ctx context.Context)
 }


### PR DESCRIPTION
This is a bit of a noisy refactor.

The primary purpose is to simplify `Server.RunWithCustomSocket` as much as possible, as it was getting quite hairy, while also attempting bringing more standardization (not perfect, but better) for how everything starts.  This is a step towards a more modular pipeline.

There is also a ton of fmt changes for some reason, not sure where they got lost.  I think the build process would normally just fix them and move on, rather than rejecting them? I haven't looked in to it.