### PR TITLE
Combine MetricHandler and EventHandler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ build-race: fmt
 build-all:
 	go install -v $$(glide nv)
 
+test-all: fmt test test-race bench bench-race check cover
+
 fmt:
 	gofmt -w=true -s $$(find . -type f -name '*.go' -not -path "./vendor/*")
 	goimports -w=true -d $$(find . -type f -name '*.go' -not -path "./vendor/*")

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -22,7 +22,7 @@ import (
 func BenchmarkCloudHandlerDispatchMetric(b *testing.B) {
 	fp := &fakeProviderIP{}
 	nh := &nopHandler{}
-	ch := NewCloudHandler(fp, nh, nh, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
+	ch := NewCloudHandler(fp, nh, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
 		CacheRefreshPeriod:        100 * time.Millisecond,
 		CacheEvictAfterIdlePeriod: 700 * time.Millisecond,
 		CacheTTL:                  500 * time.Millisecond,
@@ -56,7 +56,7 @@ func TestTransientInstanceFailure(t *testing.T) {
 
 	counting := &countingHandler{}
 
-	ch := NewCloudHandler(fpt, counting, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
+	ch := NewCloudHandler(fpt, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
 		CacheRefreshPeriod:        50 * time.Millisecond,
 		CacheEvictAfterIdlePeriod: 1 * time.Minute,
 		CacheTTL:                  1 * time.Millisecond,
@@ -120,7 +120,7 @@ func testExpire(t *testing.T, expectedIps []gostatsd.IP, f func(*CloudHandler)) 
 	t.Parallel()
 	fp := &fakeProviderIP{}
 	counting := &countingHandler{}
-	ch := NewCloudHandler(fp, counting, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
+	ch := NewCloudHandler(fp, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
 		CacheRefreshPeriod:        100 * time.Millisecond,
 		CacheEvictAfterIdlePeriod: 700 * time.Millisecond,
 		CacheTTL:                  500 * time.Millisecond,
@@ -217,7 +217,7 @@ func TestCloudHandlerFailingProvider(t *testing.T) {
 
 func doCheck(t *testing.T, cloud gostatsd.CloudProvider, m1 gostatsd.Metric, e1 gostatsd.Event, m2 gostatsd.Metric, e2 gostatsd.Event, ips *[]gostatsd.IP, expectedIps []gostatsd.IP, expectedM []gostatsd.Metric, expectedE gostatsd.Events) {
 	counting := &countingHandler{}
-	ch := NewCloudHandler(cloud, counting, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
+	ch := NewCloudHandler(cloud, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
 		CacheRefreshPeriod:        DefaultCacheRefreshPeriod,
 		CacheEvictAfterIdlePeriod: DefaultCacheEvictAfterIdlePeriod,
 		CacheTTL:                  DefaultCacheTTL,

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestFilterPassesNoFilters(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	m := &gostatsd.Metric{
 		Name: "name",
 		Tags: gostatsd.Tags{
@@ -39,7 +39,7 @@ func TestFilterPassesNoFilters(t *testing.T) {
 
 func TestFilterPassesEmptyFilters(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{}
 	m := &gostatsd.Metric{
 		Name: "name",
@@ -65,7 +65,7 @@ func TestFilterPassesEmptyFilters(t *testing.T) {
 
 func TestFilterKeepNonMatch(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics: gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.name")},
@@ -96,7 +96,7 @@ func TestFilterKeepNonMatch(t *testing.T) {
 
 func TestFilterDropsBadName(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics: gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.name")},
@@ -117,7 +117,7 @@ func TestFilterDropsBadName(t *testing.T) {
 
 func TestFilterDropsBadPrefix(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics: gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.*")},
@@ -138,7 +138,7 @@ func TestFilterDropsBadPrefix(t *testing.T) {
 
 func TestFilterKeepsWhitelist(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics:   gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.*")},
@@ -182,7 +182,7 @@ func TestFilterKeepsWhitelist(t *testing.T) {
 
 func TestFilterDropsTag(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics: gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.name")},
@@ -214,7 +214,7 @@ func TestFilterDropsTag(t *testing.T) {
 
 func TestFilterDropsHost(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	th.filters = []Filter{
 		{
 			MatchMetrics: gostatsd.StringMatchList{gostatsd.NewStringMatch("bad.name")},
@@ -282,7 +282,7 @@ drop-tags='host:*'
 	}
 
 	nh := &nopHandler{}
-	th := NewTagHandlerFromViper(v, nh, nh, nil)
+	th := NewTagHandlerFromViper(v, nh, nil)
 
 	empty := gostatsd.StringMatchList{}
 
@@ -337,7 +337,7 @@ func assertHasAllTags(t *testing.T, actual gostatsd.Tags, expected ...string) {
 
 func TestTagMetricHandlerAddsNoTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
 	assert.Equal(t, 1, len(tch.m)) // Metric tracked
@@ -347,7 +347,7 @@ func TestTagMetricHandlerAddsNoTags(t *testing.T) {
 
 func TestTagMetricHandlerAddsSingleTag(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
 	assert.Equal(t, 1, len(tch.m)) // Metric tracked
@@ -357,7 +357,7 @@ func TestTagMetricHandlerAddsSingleTag(t *testing.T) {
 
 func TestTagMetricHandlerAddsMultipleTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1", "tag2"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
 	assert.Equal(t, 1, len(tch.m)) // Metric tracked
@@ -367,7 +367,7 @@ func TestTagMetricHandlerAddsMultipleTags(t *testing.T) {
 
 func TestTagMetricHandlerAddsHostname(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	m := &gostatsd.Metric{
 		SourceIP: "1.2.3.4",
 	}
@@ -379,7 +379,7 @@ func TestTagMetricHandlerAddsHostname(t *testing.T) {
 
 func TestTagMetricHandlerAddsDuplicateTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
 	m := &gostatsd.Metric{}
 	th.DispatchMetric(context.Background(), m)
 	assert.Equal(t, 1, len(tch.m)) // Metric tracked
@@ -389,7 +389,7 @@ func TestTagMetricHandlerAddsDuplicateTags(t *testing.T) {
 
 func TestTagEventHandlerAddsNoTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
 	assert.Equal(t, 1, len(tch.e)) // Metric tracked
@@ -399,7 +399,7 @@ func TestTagEventHandlerAddsNoTags(t *testing.T) {
 
 func TestTagEventHandlerAddsSingleTag(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
 	assert.Equal(t, 1, len(tch.e)) // Metric tracked
@@ -409,7 +409,7 @@ func TestTagEventHandlerAddsSingleTag(t *testing.T) {
 
 func TestTagEventHandlerAddsMultipleTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1", "tag2"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
 	assert.Equal(t, 1, len(tch.e)) // Metric tracked
@@ -419,7 +419,7 @@ func TestTagEventHandlerAddsMultipleTags(t *testing.T) {
 
 func TestTagEventHandlerAddsHostname(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{}, nil)
 	e := &gostatsd.Event{
 		SourceIP: "1.2.3.4",
 	}
@@ -431,7 +431,7 @@ func TestTagEventHandlerAddsHostname(t *testing.T) {
 
 func TestTagEventHandlerAddsDuplicateTags(t *testing.T) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
+	th := NewTagHandler(tch, gostatsd.Tags{"tag1", "tag2", "tag2", "tag3", "tag1"}, nil)
 	e := &gostatsd.Event{}
 	th.DispatchEvent(context.Background(), e)
 	assert.Equal(t, 1, len(tch.e)) // Metric tracked
@@ -441,7 +441,7 @@ func TestTagEventHandlerAddsDuplicateTags(t *testing.T) {
 
 func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{
+	th := NewTagHandler(tch, gostatsd.Tags{
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
@@ -468,7 +468,7 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsSmall(b *testing.B) {
 
 func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{
+	th := NewTagHandler(tch, gostatsd.Tags{
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
@@ -504,7 +504,7 @@ func BenchmarkTagMetricHandlerAddsDuplicateTagsLarge(b *testing.B) {
 
 func BenchmarkTagEventHandlerAddsDuplicateTagsSmall(b *testing.B) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{
+	th := NewTagHandler(tch, gostatsd.Tags{
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",
@@ -529,7 +529,7 @@ func BenchmarkTagEventHandlerAddsDuplicateTagsSmall(b *testing.B) {
 
 func BenchmarkTagEventHandlerAddsDuplicateTagsLarge(b *testing.B) {
 	tch := &TagCapturingHandler{}
-	th := NewTagHandler(tch, tch, gostatsd.Tags{
+	th := NewTagHandler(tch, gostatsd.Tags{
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		"cccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccc",

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -20,7 +20,7 @@ const fakeIP = gostatsd.IP("127.0.0.1")
 
 func newTestParser(ignoreHost bool) (*DatagramParser, *countingHandler) {
 	ch := &countingHandler{}
-	return NewDatagramParser(nil, "", ignoreHost, 0, ch, ch, rate.Limit(0)), ch
+	return NewDatagramParser(nil, "", ignoreHost, 0, ch, rate.Limit(0)), ch
 }
 
 func TestParseEmptyDatagram(t *testing.T) {

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -8,22 +8,6 @@ import (
 	"github.com/atlassian/gostatsd/pkg/stats"
 )
 
-// MetricHandler can be used to handle metrics
-type MetricHandler interface {
-	// EstimatedTags returns a guess for how many tags to pre-allocate
-	EstimatedTags() int
-	// DispatchMetric dispatches a metric to the next step in a pipeline.
-	DispatchMetric(ctx context.Context, m *gostatsd.Metric)
-}
-
-// EventHandler can be used to handle events
-type EventHandler interface {
-	// DispatchEvent dispatches event to the next step in a pipeline.
-	DispatchEvent(ctx context.Context, e *gostatsd.Event)
-	// WaitForEvents waits for all event-dispatching goroutines to finish.
-	WaitForEvents()
-}
-
 // DispatcherProcessFunc is a function that gets executed by Dispatcher for each Aggregator, passing it into the function.
 type DispatcherProcessFunc func(int, Aggregator)
 

--- a/types.go
+++ b/types.go
@@ -42,3 +42,19 @@ type Runnable func(ctx context.Context)
 type Runner interface {
 	Run(ctx context.Context)
 }
+
+// RawMetricHandler is an interface that accepts a Metric for processing.
+type RawMetricHandler interface {
+	DispatchMetric(ctx context.Context, m *Metric)
+}
+
+// PipelineHandler can be used to handle metrics and events, it provides an estimate of how many tags it may add.
+type PipelineHandler interface {
+	RawMetricHandler
+	// EstimatedTags returns a guess for how many tags to pre-allocate
+	EstimatedTags() int
+	// DispatchEvent dispatches event to the next step in a pipeline.
+	DispatchEvent(ctx context.Context, e *Event)
+	// WaitForEvents waits for all event-dispatching goroutines to finish.
+	WaitForEvents()
+}


### PR DESCRIPTION
No real change, just removes redundancy.  RawMetricHandler will be used later with consolidation / forwarding.