### PR TITLE
Process metricmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+14.0.0
+------
+- More internal pipeline refactoring, to optimize the http ingestion path.
+
 13.0.1
 ------
 - Adjust log level about forwarding failures and stop logging retries.

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -44,6 +44,11 @@ func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*Metr
 	}
 }
 
+// DispatchMetricMap re-dispatches a metric map through capturingHandler.DispatchMetrics
+func (ch *capturingHandler) DispatchMetricMap(ctx context.Context, mm *MetricMap) {
+	mm.DispatchMetrics(ctx, ch)
+}
+
 func (ch *capturingHandler) DispatchEvent(ctx context.Context, e *Event) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()

--- a/metric_consolidator.go
+++ b/metric_consolidator.go
@@ -86,7 +86,6 @@ func (mc *MetricConsolidator) Flush(ctx context.Context) {
 func (mc *MetricConsolidator) ReceiveMetrics(metrics []*Metric) {
 	mmTo := <-mc.maps
 	for _, m := range metrics {
-		m.TagsKey = m.FormatTagsKey()
 		mmTo.Receive(m)
 	}
 	mc.maps <- mmTo

--- a/metric_map.go
+++ b/metric_map.go
@@ -130,7 +130,7 @@ func (mm *MetricMap) Merge(mmFrom *MetricMap) {
 }
 
 func (mm *MetricMap) IsEmpty() bool {
-	return len(mm.Counters) == 0 && len(mm.Timers) == 0 && len(mm.Sets) == 0 && len(mm.Gauges) == 0
+	return len(mm.Counters) + len(mm.Timers) +  len(mm.Sets) + len(mm.Gauges) == 0
 }
 
 // Split will split a MetricMap up in to multiple MetricMaps, where each one contains metrics only for its buckets.

--- a/metric_map.go
+++ b/metric_map.go
@@ -129,6 +129,53 @@ func (mm *MetricMap) Merge(mmFrom *MetricMap) {
 	})
 }
 
+func (mm *MetricMap) IsEmpty() bool {
+	return len(mm.Counters) == 0 && len(mm.Timers) == 0 && len(mm.Sets) == 0 && len(mm.Gauges) == 0
+}
+
+// Split will split a MetricMap up in to multiple MetricMaps, where each one contains metrics only for its buckets.
+func (mm *MetricMap) Split(count int) []*MetricMap {
+	maps := make([]*MetricMap, count)
+	for i := 0; i < count; i++ {
+		maps[i] = NewMetricMap()
+	}
+
+	mm.Counters.Each(func(metricName string, tagsKey string, c Counter) {
+		mmSplit := maps[Bucket(metricName, c.Hostname, count)]
+		if v, ok := mmSplit.Counters[metricName]; ok {
+			v[tagsKey] = c
+		} else {
+			mmSplit.Counters[metricName] = map[string]Counter{tagsKey: c}
+		}
+	})
+	mm.Gauges.Each(func(metricName string, tagsKey string, g Gauge) {
+		mmSplit := maps[Bucket(metricName, g.Hostname, count)]
+		if v, ok := mmSplit.Gauges[metricName]; ok {
+			v[tagsKey] = g
+		} else {
+			mmSplit.Gauges[metricName] = map[string]Gauge{tagsKey: g}
+		}
+	})
+	mm.Timers.Each(func(metricName string, tagsKey string, t Timer) {
+		mmSplit := maps[Bucket(metricName, t.Hostname, count)]
+		if v, ok := mmSplit.Timers[metricName]; ok {
+			v[tagsKey] = t
+		} else {
+			mmSplit.Timers[metricName] = map[string]Timer{tagsKey: t}
+		}
+	})
+	mm.Sets.Each(func(metricName string, tagsKey string, s Set) {
+		mmSplit := maps[Bucket(metricName, s.Hostname, count)]
+		if v, ok := mmSplit.Sets[metricName]; ok {
+			v[tagsKey] = s
+		} else {
+			mmSplit.Sets[metricName] = map[string]Set{tagsKey: s}
+		}
+	})
+
+	return maps
+}
+
 func (mm *MetricMap) receiveCounter(m *Metric, tagsKey string) {
 	value := int64(m.Value / m.Rate)
 	v, ok := mm.Counters[m.Name]

--- a/metric_map.go
+++ b/metric_map.go
@@ -28,7 +28,7 @@ func NewMetricMap() *MetricMap {
 
 // Receive adds a single Metric to the MetricMap, and releases the Metric.
 func (mm *MetricMap) Receive(m *Metric) {
-	tagsKey := m.TagsKey
+	tagsKey := m.FormatTagsKey()
 
 	switch m.Type {
 	case COUNTER:

--- a/metrics.go
+++ b/metrics.go
@@ -65,11 +65,14 @@ func (m *Metric) Reset() {
 
 // Bucket will pick a distribution bucket for this metric to land in.  max is exclusive.
 func (m *Metric) Bucket(max int) int {
-	bucket := adler32.Checksum([]byte(m.Name))
-	bucket += adler32.Checksum([]byte(m.Hostname))
+	return Bucket(m.Name, m.Hostname, max)
+}
+
+func Bucket(metricName, hostname string, max int) int {
 	// Consider hashing the tags here too
-	bucket %= uint32(max)
-	return int(bucket)
+	bucket := adler32.Checksum([]byte(metricName))
+	bucket += adler32.Checksum([]byte(hostname))
+	return int(bucket % uint32(max))
 }
 
 func (m *Metric) String() string {

--- a/metrics.go
+++ b/metrics.go
@@ -87,11 +87,18 @@ func (m *Metric) Done() {
 }
 
 func (m *Metric) FormatTagsKey() string {
-	t := m.Tags.SortedString()
-	if m.Hostname == "" {
+	if m.TagsKey == "" {
+		m.TagsKey = FormatTagsKey(m.Hostname, m.Tags)
+	}
+	return m.TagsKey
+}
+
+func FormatTagsKey(hostname string, tags Tags) string {
+	t := tags.SortedString()
+	if hostname == "" {
 		return t
 	}
-	return t + "," + StatsdSourceID + ":" + m.Hostname
+	return t + "," + StatsdSourceID + ":" + hostname
 }
 
 // AggregatedMetrics is an interface for aggregated metrics.

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -23,13 +23,14 @@ type percentStruct struct {
 
 // MetricAggregator aggregates metrics.
 type MetricAggregator struct {
-	metricsReceived   uint64
-	expiryInterval    time.Duration // How often to expire metrics
-	percentThresholds map[float64]percentStruct
-	now               func() time.Time // Returns current time. Useful for testing.
-	statser           stats.Statser
-	disabledSubtypes  gostatsd.TimerSubtypes
-	metricMap         *gostatsd.MetricMap
+	metricsReceived    uint64
+	metricMapsReceived uint64
+	expiryInterval     time.Duration // How often to expire metrics
+	percentThresholds  map[float64]percentStruct
+	now                func() time.Time // Returns current time. Useful for testing.
+	statser            stats.Statser
+	disabledSubtypes   gostatsd.TimerSubtypes
+	metricMap          *gostatsd.MetricMap
 }
 
 // NewMetricAggregator creates a new MetricAggregator object.
@@ -65,6 +66,7 @@ func round(v float64) float64 {
 // Flush prepares the contents of a MetricAggregator for sending via the Sender.
 func (a *MetricAggregator) Flush(flushInterval time.Duration) {
 	a.statser.Gauge("aggregator.metrics_received", float64(a.metricsReceived), nil)
+	a.statser.Gauge("aggregator.metricmaps_received", float64(a.metricMapsReceived), nil)
 
 	flushInSeconds := float64(flushInterval) / float64(time.Second)
 
@@ -246,4 +248,9 @@ func (a *MetricAggregator) Receive(ms ...*gostatsd.Metric) {
 	for _, m := range ms {
 		a.metricMap.Receive(m)
 	}
+}
+
+func (a *MetricAggregator) ReceiveMap(mm *gostatsd.MetricMap) {
+	a.metricMapsReceived++
+	a.metricMap.Merge(mm)
 }

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -241,7 +241,9 @@ func (a *MetricAggregator) Reset() {
 }
 
 // Receive aggregates an incoming metric.
-func (a *MetricAggregator) Receive(m *gostatsd.Metric) {
-	a.metricsReceived++
-	a.metricMap.Receive(m)
+func (a *MetricAggregator) Receive(ms ...*gostatsd.Metric) {
+	a.metricsReceived += uint64(len(ms))
+	for _, m := range ms {
+		a.metricMap.Receive(m)
+	}
 }

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -120,6 +120,11 @@ func (bh *BackendHandler) DispatchMetrics(ctx context.Context, metrics []*gostat
 	}
 }
 
+// DispatchMetricMap re-dispatches a metric map through BackendHandler.DispatchMetrics
+func (bh *BackendHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	mm.DispatchMetrics(ctx, bh)
+}
+
 // Process concurrently executes provided function in goroutines that own Aggregators.
 // DispatcherProcessFunc function may be executed zero or up to numWorkers times. It is executed
 // less than numWorkers times if the context signals "done".

--- a/pkg/statsd/handler_backend_test.go
+++ b/pkg/statsd/handler_backend_test.go
@@ -31,6 +31,12 @@ func (a *testAggregator) Receive(m ...*gostatsd.Metric) {
 	a.af.receiveInvocations[a.agrNumber] += len(m)
 }
 
+func (a *testAggregator) ReceiveMap(mm *gostatsd.MetricMap) {
+	a.af.Mutex.Lock()
+	defer a.af.Mutex.Unlock()
+	a.af.receiveMapInvocations[a.agrNumber]++
+}
+
 func (a *testAggregator) Flush(interval time.Duration) {
 	a.af.Mutex.Lock()
 	defer a.af.Mutex.Unlock()
@@ -52,17 +58,19 @@ func (a *testAggregator) Reset() {
 
 type testAggregatorFactory struct {
 	sync.Mutex
-	receiveInvocations map[int]int
-	flushInvocations   map[int]int
-	processInvocations map[int]int
-	resetInvocations   map[int]int
-	numAgrs            int
+	receiveInvocations    map[int]int
+	receiveMapInvocations map[int]int
+	flushInvocations      map[int]int
+	processInvocations    map[int]int
+	resetInvocations      map[int]int
+	numAgrs               int
 }
 
 func (af *testAggregatorFactory) Create() Aggregator {
 	agrNumber := af.numAgrs
 	af.numAgrs++
 	af.receiveInvocations[agrNumber] = 0
+	af.receiveMapInvocations[agrNumber] = 0
 	af.flushInvocations[agrNumber] = 0
 	af.processInvocations[agrNumber] = 0
 	af.resetInvocations[agrNumber] = 0
@@ -81,10 +89,11 @@ func (af *testAggregatorFactory) Create() Aggregator {
 
 func newTestFactory() *testAggregatorFactory {
 	return &testAggregatorFactory{
-		receiveInvocations: make(map[int]int),
-		flushInvocations:   make(map[int]int),
-		processInvocations: make(map[int]int),
-		resetInvocations:   make(map[int]int),
+		receiveInvocations:    make(map[int]int),
+		receiveMapInvocations: make(map[int]int),
+		flushInvocations:      make(map[int]int),
+		processInvocations:    make(map[int]int),
+		resetInvocations:      make(map[int]int),
 	}
 }
 
@@ -106,7 +115,7 @@ func TestRunShouldReturnWhenContextCancelled(t *testing.T) {
 	h.Run(ctx)
 }
 
-func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
+func TestDispatchMetricsShouldDistributeMetrics(t *testing.T) {
 	t.Parallel()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	n := r.Intn(5) + 1
@@ -140,6 +149,48 @@ func TestDispatchMetricShouldDistributeMetrics(t *testing.T) {
 	for agrNum, count := range factory.receiveInvocations {
 		if count == 0 {
 			t.Errorf("aggregator %d was never invoked", agrNum)
+		} else {
+			t.Logf("aggregator %d was invoked %d time(s)", agrNum, count)
+		}
+	}
+}
+
+func TestDispatchMetricMapShouldDistributeMetrics(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	numAggregators := r.Intn(5) + 1
+	factory := newTestFactory()
+	// use a sync channel to force the workers to process events before the context is cancelled
+	h := NewBackendHandler(nil, 0, numAggregators, 0, factory)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	var wgFinish wait.Group
+	wgFinish.StartWithContext(ctx, h.Run)
+
+	mm := gostatsd.NewMetricMap()
+	for i := 0; i < numAggregators*100; i++ {
+		m := &gostatsd.Metric{
+			Type:  gostatsd.COUNTER,
+			Name:  fmt.Sprintf("counter.metric.%d", r.Int63()),
+			Tags:  nil,
+			Value: r.Float64(),
+		}
+		m.TagsKey = m.FormatTagsKey()
+		mm.Receive(m)
+	}
+
+	h.DispatchMetricMap(ctx, mm)
+
+	cancelFunc()    // After dispatch, we signal dispatcher to shut down
+	wgFinish.Wait() // Wait for dispatcher to shutdown
+
+	for agrNum, count := range factory.receiveMapInvocations {
+		assert.NotZerof(t, count, "aggregator=%d", agrNum)
+		if count == 0 {
+			t.Errorf("aggregator %d was never invoked", agrNum)
+			for idx, mmSplit := range mm.Split(numAggregators) {
+				fmt.Printf("aggr %d, names %d\n", idx, len(mmSplit.Counters))
+			}
 		} else {
 			t.Logf("aggregator %d was invoked %d time(s)", agrNum, count)
 		}

--- a/pkg/statsd/handler_backend_test.go
+++ b/pkg/statsd/handler_backend_test.go
@@ -25,10 +25,10 @@ type testAggregator struct {
 func (a *testAggregator) TrackMetrics(statser stats.Statser) {
 }
 
-func (a *testAggregator) Receive(m *gostatsd.Metric) {
+func (a *testAggregator) Receive(m ...*gostatsd.Metric) {
 	a.af.Mutex.Lock()
 	defer a.af.Mutex.Unlock()
-	a.af.receiveInvocations[a.agrNumber]++
+	a.af.receiveInvocations[a.agrNumber] += len(m)
 }
 
 func (a *testAggregator) Flush(interval time.Duration) {

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -127,6 +127,14 @@ func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd
 	}
 }
 
+// DispatchMetricMap re-dispatches a metric map through CloudHandler.DispatchMetrics
+// TODO: This is inefficient, and should be handled first class, however that is a major re-factor of
+//  the CloudHandler.  It is also recommended to not use a CloudHandler in an http receiver based
+//  service, as the IP is not propagated.
+func (ch *CloudHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	mm.DispatchMetrics(ctx, ch)
+}
+
 func (ch *CloudHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	if ch.updateTagsAndHostname(e.SourceIP, &e.Tags, &e.Hostname) {
 		atomic.AddUint64(&ch.statsCacheHit, 1)

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -20,6 +20,10 @@ func (tch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*gos
 	tch.m = append(tch.m, metrics...)
 }
 
+func (tch *capturingHandler) DispatchMetricMap(ctx context.Context, metrics *gostatsd.MetricMap) {
+	metrics.DispatchMetrics(ctx, tch)
+}
+
 func (tch *capturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	tch.e = append(tch.e, e)
 }
@@ -34,6 +38,9 @@ func (nh *nopHandler) EstimatedTags() int {
 }
 
 func (nh *nopHandler) DispatchMetrics(ctx context.Context, m []*gostatsd.Metric) {
+}
+
+func (nh *nopHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
 }
 
 func (nh *nopHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
@@ -59,6 +66,11 @@ func (ch *countingHandler) DispatchMetrics(ctx context.Context, metrics []*gosta
 		m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data which interferes with the tests
 		ch.metrics = append(ch.metrics, *m)
 	}
+}
+
+// DispatchMetricMap re-dispatches a metric map through BackendHandler.DispatchMetrics
+func (ch *countingHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	mm.DispatchMetrics(ctx, ch)
 }
 
 func (ch *countingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 type capturingHandler struct {
-	m []*gostatsd.Metric
-	e []*gostatsd.Event
+	m  []*gostatsd.Metric
+	mm []*gostatsd.MetricMap
+	e  []*gostatsd.Event
 }
 
 func (tch *capturingHandler) EstimatedTags() int {
@@ -21,7 +22,7 @@ func (tch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*gos
 }
 
 func (tch *capturingHandler) DispatchMetricMap(ctx context.Context, metrics *gostatsd.MetricMap) {
-	metrics.DispatchMetrics(ctx, tch)
+	tch.mm = append(tch.mm, metrics)
 }
 
 func (tch *capturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -173,6 +173,11 @@ func (hfh *HttpForwarderHandlerV2) DispatchMetrics(ctx context.Context, metrics 
 	hfh.consolidator.ReceiveMetrics(metrics)
 }
 
+// DispatchMetricMap re-dispatches a metric map through HttpForwarderHandlerV2.DispatchMetrics
+func (hfh *HttpForwarderHandlerV2) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	mm.DispatchMetrics(ctx, hfh)
+}
+
 func (hfh *HttpForwarderHandlerV2) RunMetrics(ctx context.Context) {
 	statser := stats.FromContext(ctx)
 

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -175,7 +175,7 @@ func (hfh *HttpForwarderHandlerV2) DispatchMetrics(ctx context.Context, metrics 
 
 // DispatchMetricMap re-dispatches a metric map through HttpForwarderHandlerV2.DispatchMetrics
 func (hfh *HttpForwarderHandlerV2) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
-	mm.DispatchMetrics(ctx, hfh)
+	hfh.consolidator.ReceiveMetricMap(mm)
 }
 
 func (hfh *HttpForwarderHandlerV2) RunMetrics(ctx context.Context) {

--- a/pkg/statsd/handler_http_forwarder_v2_test.go
+++ b/pkg/statsd/handler_http_forwarder_v2_test.go
@@ -80,7 +80,6 @@ func TestHttpForwarderV2Translation(t *testing.T) {
 
 	mm := gostatsd.NewMetricMap()
 	for _, metric := range metrics {
-		metric.TagsKey = metric.FormatTagsKey()
 		mm.Receive(metric)
 	}
 

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -67,6 +67,11 @@ func (th *TagHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.M
 	}
 }
 
+// DispatchMetricMap re-dispatches a metric map through TagHandler.DispatchMetrics
+func (th *TagHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	mm.DispatchMetrics(ctx, th)
+}
+
 // uniqueFilterMetricAndAddTags will perform 3 tasks:
 // - Add static tags configured to the metric
 // - De-duplicate tags

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -67,12 +67,93 @@ func (th *TagHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.M
 	}
 }
 
-// DispatchMetricMap re-dispatches a metric map through TagHandler.DispatchMetrics
+// DispatchMetricMap adds the unique tags from the TagHandler to each consolidated metric in the map and passes it to
+// the next stage in the pipeline
+//
+// There is potential to optimize here: if the tagsKey doesn't change, we don't need to re-calculate it.  But we're
+// keeping things simple for now.
 func (th *TagHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
-	mm.DispatchMetrics(ctx, th)
+	mmNew := gostatsd.NewMetricMap()
+
+	mm.Counters.Each(func(metricName, x string, cOriginal gostatsd.Counter) {
+		if th.uniqueFilterAndAddTags(metricName, &cOriginal.Hostname, &cOriginal.Tags) {
+			newTagsKey := gostatsd.FormatTagsKey(cOriginal.Hostname, cOriginal.Tags)
+			if cs, ok := mmNew.Counters[metricName]; ok {
+				if cNew, ok := cs[newTagsKey]; ok {
+					cNew.Value += cOriginal.Value
+					cNew.Timestamp = gostatsd.NanoMax(cNew.Timestamp, cOriginal.Timestamp)
+					cs[newTagsKey] = cNew
+				} else {
+					cs[newTagsKey] = cOriginal
+				}
+			} else {
+				mmNew.Counters[metricName] = map[string]gostatsd.Counter{newTagsKey: cOriginal}
+			}
+		}
+	})
+
+	mm.Gauges.Each(func(metricName, _ string, gOriginal gostatsd.Gauge) {
+		if th.uniqueFilterAndAddTags(metricName, &gOriginal.Hostname, &gOriginal.Tags) {
+			newTagsKey := gostatsd.FormatTagsKey(gOriginal.Hostname, gOriginal.Tags)
+			if gs, ok := mmNew.Gauges[metricName]; ok {
+				if gNew, ok := gs[newTagsKey]; ok {
+					if gOriginal.Timestamp > gNew.Timestamp {
+						gNew.Value = gOriginal.Value
+						gNew.Timestamp = gOriginal.Timestamp
+						gs[newTagsKey] = gNew
+					}
+				} else {
+					gs[newTagsKey] = gOriginal
+				}
+			} else {
+				mmNew.Gauges[metricName] = map[string]gostatsd.Gauge{newTagsKey: gOriginal}
+			}
+		}
+	})
+
+	mm.Timers.Each(func(metricName, _ string, tOriginal gostatsd.Timer) {
+		if th.uniqueFilterAndAddTags(metricName, &tOriginal.Hostname, &tOriginal.Tags) {
+			newTagsKey := gostatsd.FormatTagsKey(tOriginal.Hostname, tOriginal.Tags)
+			if ts, ok := mmNew.Timers[metricName]; ok {
+				if tNew, ok := ts[newTagsKey]; ok {
+					tNew.Values = append(tNew.Values, tOriginal.Values...)
+					tNew.Timestamp = gostatsd.NanoMax(tNew.Timestamp, tOriginal.Timestamp)
+					tNew.SampledCount += tOriginal.SampledCount
+					ts[newTagsKey] = tNew
+				} else {
+					ts[newTagsKey] = tOriginal
+				}
+			} else {
+				mmNew.Timers[metricName] = map[string]gostatsd.Timer{newTagsKey: tOriginal}
+			}
+		}
+	})
+
+	mm.Sets.Each(func(metricName, _ string, sOriginal gostatsd.Set) {
+		if th.uniqueFilterAndAddTags(metricName, &sOriginal.Hostname, &sOriginal.Tags) {
+			newTagsKey := gostatsd.FormatTagsKey(sOriginal.Hostname, sOriginal.Tags)
+			if ss, ok := mmNew.Sets[metricName]; ok {
+				if sNew, ok := ss[newTagsKey]; ok {
+					for key := range sOriginal.Values {
+						sNew.Values[key] = struct{}{}
+					}
+					sNew.Timestamp = gostatsd.NanoMax(sNew.Timestamp, sOriginal.Timestamp)
+					ss[newTagsKey] = sNew
+				} else {
+					ss[newTagsKey] = sOriginal
+				}
+			} else {
+				mmNew.Sets[metricName] = map[string]gostatsd.Set{newTagsKey: sOriginal}
+			}
+		}
+	})
+
+	if !mmNew.IsEmpty() {
+		th.handler.DispatchMetricMap(ctx, mmNew)
+	}
 }
 
-// uniqueFilterMetricAndAddTags will perform 3 tasks:
+// uniqueFilterAndAddTags will perform 3 tasks:
 // - Add static tags configured to the metric
 // - De-duplicate tags
 // - Perform rule based filtering
@@ -81,27 +162,27 @@ func (th *TagHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.Metric
 // hot code path.
 //
 // Returns true if the metric should be processed further, or false to drop it.
-func (th *TagHandler) uniqueFilterMetricAndAddTags(m *gostatsd.Metric) bool {
+func (th *TagHandler) uniqueFilterAndAddTags(mName string, mHostname *string, mTags *gostatsd.Tags) bool {
 	if len(th.filters) == 0 {
-		m.Tags = uniqueTags(m.Tags, th.tags)
+		*mTags = uniqueTags(*mTags, th.tags)
 		return true
 	}
 
 	dropTags := map[string]struct{}{}
 
 	for _, filter := range th.filters {
-		if len(filter.MatchMetrics) > 0 && !filter.MatchMetrics.MatchAny(m.Name) { // returns false if nothing present
+		if len(filter.MatchMetrics) > 0 && !filter.MatchMetrics.MatchAny(mName) { // returns false if nothing present
 			// name doesn't match an include, stop
 			continue
 		}
 
 		// this list may be empty, and therefore return false
-		if filter.ExcludeMetrics.MatchAny(m.Name) { // returns false if nothing present
+		if filter.ExcludeMetrics.MatchAny(mName) { // returns false if nothing present
 			// name matches an exclude, stop
 			continue
 		}
 
-		if len(filter.MatchTags) > 0 && !filter.MatchTags.MatchAnyMultiple(m.Tags) { // returns false if either list is empty
+		if len(filter.MatchTags) > 0 && !filter.MatchTags.MatchAnyMultiple(*mTags) { // returns false if either list is empty
 			// no tags match
 			continue
 		}
@@ -111,7 +192,7 @@ func (th *TagHandler) uniqueFilterMetricAndAddTags(m *gostatsd.Metric) bool {
 		}
 
 		for _, dropFilter := range filter.DropTags {
-			for _, tag := range m.Tags {
+			for _, tag := range *mTags {
 				if dropFilter.Match(tag) {
 					dropTags[tag] = present
 				}
@@ -119,12 +200,16 @@ func (th *TagHandler) uniqueFilterMetricAndAddTags(m *gostatsd.Metric) bool {
 		}
 
 		if filter.DropHost {
-			m.Hostname = ""
+			*mHostname = ""
 		}
 	}
 
-	m.Tags = uniqueTagsWithSeen(dropTags, m.Tags, th.tags)
+	*mTags = uniqueTagsWithSeen(dropTags, *mTags, th.tags)
 	return true
+}
+
+func (th *TagHandler) uniqueFilterMetricAndAddTags(m *gostatsd.Metric) bool {
+	return th.uniqueFilterAndAddTags(m.Name, &m.Hostname, &m.Tags)
 }
 
 // DispatchEvent adds the unique tags from the TagHandler to the event and passes it to the next stage in the pipeline

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -3,6 +3,7 @@ package statsd
 import (
 	"bytes"
 	"context"
+	"sort"
 	"strings"
 	"testing"
 
@@ -10,7 +11,79 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTagStripMergesCounters(t *testing.T) {
+	tch := &capturingHandler{}
+	th := NewTagHandler(tch, gostatsd.Tags{}, []Filter{
+		{DropTags: gostatsd.StringMatchList{gostatsd.NewStringMatch("key2:*")}},
+	})
+	mm := gostatsd.NewMetricMap()
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.COUNTER, Name: "metric", Timestamp: 20, Tags: gostatsd.Tags{"key:value", "key2:value2"}, Value: 1, Rate: 0.1})
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.COUNTER, Name: "metric", Timestamp: 10, Tags: gostatsd.Tags{"key:value"}, Value: 20, Rate: 1})
+	th.DispatchMetricMap(context.Background(), mm)
+
+	expected := gostatsd.NewMetricMap()
+	expected.Counters["metric"] = map[string]gostatsd.Counter{
+		"key:value": {Timestamp: 20, Value: 30, Tags: gostatsd.Tags{"key:value"}},
+	}
+	require.EqualValues(t, expected, tch.mm[0])
+}
+
+func TestTagStripMergesGauges(t *testing.T) {
+	tch := &capturingHandler{}
+	th := NewTagHandler(tch, gostatsd.Tags{}, []Filter{
+		{DropTags: gostatsd.StringMatchList{gostatsd.NewStringMatch("key2:*")}},
+	})
+	mm := gostatsd.NewMetricMap()
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.GAUGE, Name: "metric", Timestamp: 10, Tags: gostatsd.Tags{"key:value", "key2:value2"}, Value: 10})
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.GAUGE, Name: "metric", Timestamp: 20, Tags: gostatsd.Tags{"key:value"}, Value: 20})
+	th.DispatchMetricMap(context.Background(), mm)
+
+	expected := gostatsd.NewMetricMap()
+	expected.Gauges["metric"] = map[string]gostatsd.Gauge{
+		"key:value": {Timestamp: 20, Value: 20, Tags: gostatsd.Tags{"key:value"}},
+	}
+	require.EqualValues(t, expected, tch.mm[0])
+}
+
+func TestTagStripMergesTimers(t *testing.T) {
+	tch := &capturingHandler{}
+	th := NewTagHandler(tch, gostatsd.Tags{}, []Filter{
+		{DropTags: gostatsd.StringMatchList{gostatsd.NewStringMatch("key2:*")}},
+	})
+	mm := gostatsd.NewMetricMap()
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.TIMER, Name: "metric", Timestamp: 10, Tags: gostatsd.Tags{"key:value", "key2:value2"}, Value: 10, Rate: 1})
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.TIMER, Name: "metric", Timestamp: 20, Tags: gostatsd.Tags{"key:value"}, Value: 20, Rate: 1})
+	th.DispatchMetricMap(context.Background(), mm)
+
+	// Make sure the actual values are deterministic
+	sort.Float64s(tch.mm[0].Timers["metric"]["key:value"].Values)
+
+	expected := gostatsd.NewMetricMap()
+	expected.Timers["metric"] = map[string]gostatsd.Timer{
+		"key:value": {Timestamp: 20, Values: []float64{10, 20}, Tags: gostatsd.Tags{"key:value"}, SampledCount: 2},
+	}
+	require.EqualValues(t, expected, tch.mm[0])
+}
+
+func TestTagStripMergesSets(t *testing.T) {
+	tch := &capturingHandler{}
+	th := NewTagHandler(tch, gostatsd.Tags{}, []Filter{
+		{DropTags: gostatsd.StringMatchList{gostatsd.NewStringMatch("key2:*")}},
+	})
+	mm := gostatsd.NewMetricMap()
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.SET, Name: "metric", Timestamp: 10, Tags: gostatsd.Tags{"key:value", "key2:value2"}, StringValue: "abc"})
+	mm.Receive(&gostatsd.Metric{Type: gostatsd.SET, Name: "metric", Timestamp: 20, Tags: gostatsd.Tags{"key:value"}, StringValue: "def"})
+	th.DispatchMetricMap(context.Background(), mm)
+
+	expected := gostatsd.NewMetricMap()
+	expected.Sets["metric"] = map[string]gostatsd.Set{
+		"key:value": {Timestamp: 20, Values: map[string]struct{}{"abc": {}, "def": {}}, Tags: gostatsd.Tags{"key:value"}},
+	}
+	require.EqualValues(t, expected, tch.mm[0])
+}
 
 func TestFilterPassesNoFilters(t *testing.T) {
 	tch := &capturingHandler{}

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -25,7 +25,8 @@ type ProcessFunc func(*gostatsd.MetricMap)
 //
 // Incoming metrics should be passed via Receive function.
 type Aggregator interface {
-	Receive(...*gostatsd.Metric)
+	Receive(metrics ...*gostatsd.Metric)
+	ReceiveMap(mm *gostatsd.MetricMap)
 	Flush(interval time.Duration)
 	Process(ProcessFunc)
 	Reset()

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -25,7 +25,7 @@ type ProcessFunc func(*gostatsd.MetricMap)
 //
 // Incoming metrics should be passed via Receive function.
 type Aggregator interface {
-	Receive(*gostatsd.Metric)
+	Receive(...*gostatsd.Metric)
 	Flush(interval time.Duration)
 	Process(ProcessFunc)
 	Reset()

--- a/pkg/statsd/worker.go
+++ b/pkg/statsd/worker.go
@@ -15,10 +15,11 @@ type processCommand struct {
 }
 
 type worker struct {
-	aggr         Aggregator
-	metricsQueue chan []*gostatsd.Metric
-	processChan  chan *processCommand
-	id           int
+	aggr           Aggregator
+	metricsQueue   chan []*gostatsd.Metric
+	metricMapQueue chan *gostatsd.MetricMap
+	processChan    chan *processCommand
+	id             int
 }
 
 func (w *worker) work() {
@@ -29,6 +30,11 @@ func (w *worker) work() {
 				return
 			}
 			w.aggr.Receive(metrics...)
+		case mm, ok := <-w.metricMapQueue:
+			if !ok {
+				return
+			}
+			w.aggr.ReceiveMap(mm)
 		case cmd := <-w.processChan:
 			w.executeProcess(cmd)
 		}

--- a/pkg/statsd/worker.go
+++ b/pkg/statsd/worker.go
@@ -16,7 +16,7 @@ type processCommand struct {
 
 type worker struct {
 	aggr         Aggregator
-	metricsQueue chan *gostatsd.Metric
+	metricsQueue chan []*gostatsd.Metric
 	processChan  chan *processCommand
 	id           int
 }
@@ -24,11 +24,11 @@ type worker struct {
 func (w *worker) work() {
 	for {
 		select {
-		case metric, ok := <-w.metricsQueue:
+		case metrics, ok := <-w.metricsQueue:
 			if !ok {
 				return
 			}
-			w.aggr.Receive(metric)
+			w.aggr.Receive(metrics...)
 		case cmd := <-w.processChan:
 			w.executeProcess(cmd)
 		}

--- a/pkg/web/fixtures_test.go
+++ b/pkg/web/fixtures_test.go
@@ -30,6 +30,10 @@ func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*gost
 	}
 }
 
+func (ch *capturingHandler) DispatchMetricMap(ctx context.Context, metrics *gostatsd.MetricMap) {
+	metrics.DispatchMetrics(ctx, ch)
+}
+
 func (ch *capturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()

--- a/pkg/web/http_receiver_v2.go
+++ b/pkg/web/http_receiver_v2.go
@@ -121,7 +121,7 @@ func (rhh *rawHttpHandlerV2) MetricHandler(w http.ResponseWriter, req *http.Requ
 	}
 
 	mm := translateFromProtobufV2(&msg)
-	mm.DispatchMetrics(req.Context(), rhh.handler)
+	rhh.handler.DispatchMetricMap(req.Context(), mm)
 
 	atomic.AddUint64(&rhh.requestSuccess, 1)
 	w.WriteHeader(http.StatusAccepted)

--- a/types.go
+++ b/types.go
@@ -52,6 +52,7 @@ type Runner interface {
 // pre-consolidation.
 type RawMetricHandler interface {
 	DispatchMetrics(ctx context.Context, m []*Metric)
+	DispatchMetricMap(ctx context.Context, mm *MetricMap)
 }
 
 // PipelineHandler can be used to handle metrics and events, it provides an estimate of how many tags it may add.

--- a/types.go
+++ b/types.go
@@ -13,6 +13,13 @@ func NanoNow() Nanotime {
 	return Nanotime(time.Now().UnixNano())
 }
 
+func NanoMax(t1, t2 Nanotime) Nanotime {
+	if t1 > t2 {
+		return t1
+	}
+	return t2
+}
+
 // IP is a v4/v6 IP address.
 // We do not use net.IP because it will involve conversion to string and back several times.
 type IP string


### PR DESCRIPTION
This brings `*MetricMap`s and `[]*Metric`s all through the pipeline, including to the `Aggregator`.  The `CloudHandler` does not have first class support for `*MetricMap` handling due to:
1) requiring a big refactor to support it
2) a CH shouldn't be required in http mode, as anything that would be looked up should be statically added on a forwarder

It's probably best to review each commit in isolation.  Each commit should build and test clean.