### PR TITLE
Fix broken internal metrics, and duplicated TagHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+14.1.0
+------
+- Fixes internal metrics for the `dispatch_aggregator` channel stats, and `aggregator.*` metrics.
+
 14.0.0
 ------
 - More internal pipeline refactoring, to optimize the http ingestion path.

--- a/metric_map.go
+++ b/metric_map.go
@@ -130,7 +130,7 @@ func (mm *MetricMap) Merge(mmFrom *MetricMap) {
 }
 
 func (mm *MetricMap) IsEmpty() bool {
-	return len(mm.Counters) + len(mm.Timers) +  len(mm.Sets) + len(mm.Gauges) == 0
+	return len(mm.Counters)+len(mm.Timers)+len(mm.Sets)+len(mm.Gauges) == 0
 }
 
 // Split will split a MetricMap up in to multiple MetricMaps, where each one contains metrics only for its buckets.

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -100,15 +100,13 @@ func (s *Server) createStandaloneSink() (gostatsd.PipelineHandler, []gostatsd.Ru
 	}
 
 	backendHandler := NewBackendHandler(s.Backends, uint(s.MaxConcurrentEvents), s.MaxWorkers, s.MaxQueueSize, &factory)
-	runnables = append(runnables, backendHandler.Run)
+	runnables = append(runnables, backendHandler.Run, backendHandler.RunMetricsContext)
 
 	// Create the Flusher
 	flusher := NewMetricFlusher(s.FlushInterval, backendHandler, s.Backends)
 	runnables = append(runnables, flusher.Run)
 
-	// Create the tag processor
-	handler := NewTagHandlerFromViper(s.Viper, backendHandler, s.DefaultTags)
-	return handler, runnables, nil
+	return backendHandler, runnables, nil
 }
 
 func (s *Server) createForwarderSink() (gostatsd.PipelineHandler, []gostatsd.Runnable, error) {


### PR DESCRIPTION
The BackendHandler.RunMetrics call was lost in some earlier refactoring.  This brings it back in.  It also fixes that we added the TagHandler to the pipeline twice.