### PR TITLE
Fix gometalinter installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ tools/bin/protoc:
 
 setup-ci: tools/bin/protoc
 	go get -u github.com/Masterminds/glide
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
+	curl -L https://git.io/vp6lP | sh # install gometalinter
 	glide install --strip-vendor
 
 build-cluster: fmt


### PR DESCRIPTION
go get installation method is no longer supported and fails for
newer golang versions, refer to: https://github.com/alecthomas/gometalinter/issues/552#issuecomment-434266465

New installation method taken from gometalinter README:
https://github.com/alecthomas/gometalinter/blob/master/README.md#binary-releases