### PR TITLE
Use golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,6 @@ linters-settings:
   dupl:
     threshold: 200
   errcheck:
-    ignore: net:Close
+    ignore: net:Close,net/http:Write
   gocyclo:
     min-complexity: 20

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+# golangci-lint project settings
+linters-settings:
+  dupl:
+    threshold: 200
+  errcheck:
+    ignore: net:Close
+  gocyclo:
+    min-complexity: 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
   - make build-all
   - make test-race
-  - METALINTER_CONCURRENCY=2 make check
+  - make check
   - make bench-race
   - make coveralls
 

--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -23,5 +23,5 @@ func main() {
 	c := newCluster()
 	c.AddFlags(pflag.CommandLine)
 	pflag.Parse()
-	c.Run()
+	_ = c.Run()
 }

--- a/cmd/tester/server.go
+++ b/cmd/tester/server.go
@@ -106,7 +106,7 @@ func (s *Server) Run() error {
 	http.HandleFunc("/start", s.startHandler)
 	http.HandleFunc("/stop", s.stopHandler)
 	http.HandleFunc("/exit", s.exitHandler)
-	http.ListenAndServe(s.WebAddr, nil)
+	_ = http.ListenAndServe(s.WebAddr, nil)
 
 	return nil
 }

--- a/pkg/backends/cloudwatch/cloudwatch_test.go
+++ b/pkg/backends/cloudwatch/cloudwatch_test.go
@@ -132,6 +132,7 @@ func TestSendMetricDimensions(t *testing.T) {
 
 }
 
+// nolint:dupl
 func metricsOneOfEach() *gostatsd.MetricMap {
 	return &gostatsd.MetricMap{
 		Counters: gostatsd.Counters{

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -145,6 +145,7 @@ func twoCounters() *gostatsd.MetricMap {
 	}
 }
 
+// nolint:dupl
 func metricsOneOfEach() *gostatsd.MetricMap {
 	return &gostatsd.MetricMap{
 		Counters: gostatsd.Counters{

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -269,7 +269,7 @@ func (n *Client) constructPost(ctx context.Context, buffer *bytes.Buffer, data i
 			headers["Content-Encoding"] = "deflate"
 			var b bytes.Buffer
 			w := zlib.NewWriter(&b)
-			w.Write(mJSON)
+			w.Write(mJSON) // nolint:errcheck
 			w.Close()
 			mJSON = b.Bytes()
 		}

--- a/pkg/cluster/nodes/nodes_redis.go
+++ b/pkg/cluster/nodes/nodes_redis.go
@@ -60,7 +60,7 @@ func (rnt *redisNodeTracker) Run(ctx context.Context) {
 
 	psChan := pubsub.Channel() // Closed when pubsub is Closed
 
-	rnt.emitPresence()
+	_ = rnt.emitPresence()
 
 	for {
 		select {

--- a/pkg/web/http_profilers.go
+++ b/pkg/web/http_profilers.go
@@ -16,7 +16,9 @@ type traceProfiler struct {
 func (tp *traceProfiler) Trace(w http.ResponseWriter, r *http.Request) {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
-	trace.Start(w)
+	if err := trace.Start(w); err != nil {
+		return
+	}
 	defer trace.Stop()
 	time.Sleep(30 * time.Second)
 }
@@ -24,7 +26,9 @@ func (tp *traceProfiler) Trace(w http.ResponseWriter, r *http.Request) {
 func (tp *traceProfiler) PProf(w http.ResponseWriter, r *http.Request) {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
-	pprof.StartCPUProfile(w)
+	if err := pprof.StartCPUProfile(w); err != nil {
+		return
+	}
 	defer pprof.StopCPUProfile()
 	time.Sleep(30 * time.Second)
 }
@@ -33,5 +37,5 @@ func (tp *traceProfiler) MemProf(w http.ResponseWriter, r *http.Request) {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()
 	runtime.GC()
-	pprof.Lookup("heap").WriteTo(w, 0)
+	_ = pprof.Lookup("heap").WriteTo(w, 0)
 }


### PR DESCRIPTION
gometalinter has been deprecated. The replacement tool is golangci-lint. This PR switches linter and handles or silences new warnings introduced by this change.