### PR TITLE
Update Alpine to 3.9 for CVE-2019-5021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+15.0.1
+------
+- Update to Alpine 3.9
+
 15.0.0
 ------
 - Build with Go 1.12.3

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.9
 
 RUN apk --no-cache add \
     ca-certificates

--- a/cmd/tester/Dockerfile
+++ b/cmd/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.9
 RUN apk --no-cache add \
 	ca-certificates
 ADD statsd-tester-linux /bin/statsd-tester


### PR DESCRIPTION
Version 3.5 is not patched.  https://www.alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html