### PR TITLE
Add timeout context to dispatchEvent

### DIFF
--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -194,6 +194,7 @@ func (bh *BackendHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) 
 		case bh.concurrentEvents <- struct{}{}:
 			// Creates a new context for dispatching the event.
 			// We create a new one otherwise it uses the request context which is cancelled as soon as this function returns.
+			//nolint:govet
 			timeoutCtx, _ := context.WithTimeout(context.Background(), 20*time.Second)
 			go bh.internalDispatchEvent(timeoutCtx, backend, e)
 			eventsDispatched++

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -194,12 +194,12 @@ func (bh *BackendHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) 
 		case bh.concurrentEvents <- struct{}{}:
 			// Creates a new context for dispatching the event.
 			// We create a new one otherwise it uses the request context which is cancelled as soon as this function returns.
-			go func() {
+			go func(b gostatsd.Backend) {
 				timeoutCtx, cancelTimeout := context.WithTimeout(context.Background(), 20*time.Second)
 				defer cancelTimeout()
-				bh.internalDispatchEvent(timeoutCtx, backend, e)
-				eventsDispatched++
-			}()
+				bh.internalDispatchEvent(timeoutCtx, b, e)
+			}(backend)
+			eventsDispatched++
 		}
 	}
 }

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -194,10 +194,12 @@ func (bh *BackendHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) 
 		case bh.concurrentEvents <- struct{}{}:
 			// Creates a new context for dispatching the event.
 			// We create a new one otherwise it uses the request context which is cancelled as soon as this function returns.
-			//nolint:govet
-			timeoutCtx, _ := context.WithTimeout(context.Background(), 20*time.Second)
-			go bh.internalDispatchEvent(timeoutCtx, backend, e)
-			eventsDispatched++
+			go func() {
+				timeoutCtx, cancelTimeout := context.WithTimeout(context.Background(), 20*time.Second)
+				defer cancelTimeout()
+				bh.internalDispatchEvent(timeoutCtx, backend, e)
+				eventsDispatched++
+			}()
 		}
 	}
 }


### PR DESCRIPTION
Events were not always being sent due to the context being cancelled as it was returned back up to the request. This meant that `dispatchEvent` was not always executed due to the context being cancelled. This PR adds a new timeout context for `internalDispatchEvent`.