### PR TITLE
Bump to Go 1.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 go:
-  - "1.12.3"
+  - "1.12.3"  # Keep in sync with Makefile
 
 os:
   - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+16.0.0
+------
+- Build with Go 1.12.3 for real.
+
 15.0.2
 ------
 - Fixed events in HTTP style

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOBUILD_VERSION_ARGS_WITH_SYMS := -ldflags "-X $(VERSION_VAR)=$(REPO_VERSION) -X
 BINARY_NAME := gostatsd
 IMAGE_NAME := atlassianlabs/$(BINARY_NAME)
 ARCH ?= $$(uname -s | tr A-Z a-z)
-GOVERSION := 1.10.2
+GOVERSION := 1.12.3  # Keep in sync with .travis.yml
 GP := /gopath
 MAIN_PKG := github.com/atlassian/gostatsd/cmd/gostatsd
 CLUSTER_PKG := github.com/atlassian/gostatsd/cmd/cluster

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ server based on load. The server can also be run HA and be scaled out, see
 
 Building the server
 -------------------
-Gostatsd currently targets Go 1.10.2.  There are no known hard dependencies in the code beween 1.9 and 1.10.2, but some may be introduced in future.
+Gostatsd currently targets Go 1.12.3.  If you are compiling from source, please ensure you are running this version.
 
 From the `gostatsd` directory run `make build`. The binary will be built in `build/bin/<arch>/gostatsd`.
 


### PR DESCRIPTION
The version in `.travis.yml` is used to compile the binary, but the binary is then unused.  We build the docker image through `release` -> `release-normal` -> `release-hash` -> `docker`.

I'm not 100% certain the flow, but I **think** if the versions match, `docker` won't actually try to rebuild it because of the volume mounting.  However with a mismatch, it will definitely rebuild - I've checked the latest docker image.