### PR TITLE
Adds support for graphite tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /cmd/tester/statsd-tester*
 /test-report.xml
 build/dev/data/
+/.idea
 /.vscode
 *.toml

--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -1,0 +1,111 @@
+Configuring backends
+--------------------
+Backends must be configured through the usage of a configuration file (toml, yaml and json are supported), pass via
+`--config-path`.
+
+Documentation is currently provided for `graphite` and `newrelic` backends.  For `datadog`, `statsdaemon`, `stdout`,
+and `cloudwatch` please refer to the source code.
+
+All configuration is in a stanza named after the backend, and takes simple key value pairs.
+
+Graphite
+--------
+#### Example with defaults
+```
+[graphite]
+address = "localhost:2003"
+dial_timeout = '5s'
+write_timeout = '30s'
+
+mode = 'tags'
+
+global_prefix = 'stats'
+global_suffix = ''
+
+prefix_counter = 'counters'
+prefix_timer = 'timers'
+prefix_gauge = 'gauges'
+prefix_sets = 'sets'
+
+```
+
+The configuration settings are as follows:
+- `address`: the graphite server to send aggregated data to
+- `dial_timeout`: the timeout for connecting to the graphite server
+- `write_timeout`: the maximum amount of time to try and write before giving up
+- `mode`: one of `legacy`, `basic`, or `tags` style naming should be used.  Note that `legacy` and `basic` will
+  silently drop all tags.  If there is a need to support tags as Graphite nodes, please raise an issue.
+
+The following 5 options will only be applied if `mode` is `basic` or `tags`.
+- `prefix_counter`: the prefix to add to all counters
+- `prefix_timer`: the prefix to add to all timers
+- `prefix_gauge`: the prefix to add to all gauges
+- `prefix_sets`: the prefix to add to all sets
+- `gloabl_prefix`: a prefix to add to all metrics
+
+This is always applied
+- `global_suffix`: a suffix to add to all metrics
+
+#### Metric names
+When `mode` is `basic` or `tags`, the graphite backend will emit metrics with the following naming scheme:
+
+`[global_prefix.][prefix_<type>.]<metricname>[.aggregation_suffix][.global_suffix]`
+
+The `aggregation_suffix` will be `count` or `rate` for counters, and the configured aggregation functions for timers.
+
+When `mode` is `legacy`, the graphite backend will emit metrics with the following scheme:
+
+- counters: `stats_counts.<metricname>[.global_suffix]` (count) and `stats.<metricname>[.global_suffix]` (rate)
+- timers: `stats.timers.<metricname>.<aggregation_suffix>[.global_suffix]`
+- gauges: `stats.gauges.<metricname>[.global_suffix]`
+- sets: `stats.sets.<metricname>[.global_suffix]`
+
+
+New Relic Backend
+-----------------
+Supports two routes for flushing metrics to New Relic.
+- Directly to the Insights Collector - [Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
+- Via the Infrastructure Agent's inbuilt HTTP Server
+
+### [New Relic Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
+Sending directly to the Event API alleviates the requirement of needing to have the New Relic Infrastructure Agent. Therefore you can run this from nearly anywhere for maximum flexibility. This also becomes a shorter data path with less resource requirements becoming a simpler setup.
+
+To use this method, create an Insert API Key from here: https://insights.newrelic.com/accounts/YOUR_ACCOUNT_ID/manage/api_keys
+
+```
+#Example configuration
+
+[newrelic]
+    address = "https://insights-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events"
+    api-key = "yourEventAPIInsertKey"
+```
+
+### [New Relic Infrastructure Agent](https://newrelic.com/products/infrastructure)
+Sending via the Infrastructure Agent's inbuilt HTTP server provides additional features, such as automatically applying additional metadata to the event the host may have such as AWS tags, instance type, host information, labels etc.
+
+The payload structure required to be accepted by the agent can be viewed [here.](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample)
+
+To enable the HTTP server, modify /etc/newrelic.yml to include the below, and restart the agent ([Step 1.2](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration#install)).
+```
+http_server_enabled: true
+http_server_host: 127.0.0.1 #(default host)
+http_server_port: 8001 #(default port)
+```
+
+Additional options are available to rename attributes if required.
+```
+[newrelic]
+	tag-prefix = ""
+	metric-name = "name"
+	metric-type = "type"
+	per-second = "per_second"
+	value = "value"
+	timer-min = "min"
+	timer-max = "max"
+	timer-count = "samples_count"
+	timer-mean = "samples_mean"
+	timer-median = "samples_median"
+	timer-stddev = "samples_std_dev"
+	timer-sum = "samples_sum"
+	timer-sumsquare = "samples_sum_squares"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+17.0.0
+------
+- BREAKING: Added support for [Graphite 1.1 style tags](https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/),
+  details can be found in [BACKENDS.md].
+- Moved backend documentation from [README.md] to [BACKENDS.md], still lacking documentation for most backends.
+
 16.0.0
 ------
 - Build with Go 1.12.3 for real.

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ check: pb/gostatsd.pb.go
 	go install ./cmd/gostatsd
 	go install ./cmd/tester
 	golangci-lint run --deadline=600s --enable=gocyclo --enable=dupl \
-		--disable=interfacer --disable=golint --disable=gosec
+		--disable=interfacer --disable=golint
 
 check-all: pb/gostatsd.pb.go
 	go install ./cmd/gostatsd

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and again if the dependencies change.  A [protobuf](https://github.com/protocolb
 directory.  Managing this in a platform agnostic way is difficult, but PRs are welcome. Hopefully it will be sufficient to use the generated protobuf
 files in the majority of cases.
 
-If you are unable to build `gostatsd` please try running `make setup` again before reporting a bug.
+If you are unable to build `gostatsd` please check your go version, and try running `make setup` again before reporting a bug.
 
 Running the server
 ------------------
@@ -119,81 +119,18 @@ There is no capability to run an https server at this point in time, and no auth
 addresses).  You could also put a reverse proxy in front of the service.  Documentation for the endpoints can be found
 under HTTP.md
 
-Configuring backends and cloud providers
-----------------------------------------
-Backends and cloud providers are configured using `toml`, `json` or `yaml` configuration file
-passed via the `--config-path` flag. For all configuration options see source code of the backends you
-are interested in. A cloudprovider should not be used on the aggregation server when forwarding data to
-it, as the source IP address is not propagated.  A cloudprovider can be used on the forwarder host, however.
-Configuration file might look like this:
-```
-[graphite]
-	address = "192.168.99.100:2003"
+Configuring backends
+--------------------
+Refer to [BACKENDS.md] for configuration options for the backends
 
-[datadog]
-	api_key = "my-secret-key" # Datadog API key required.
+Cloud providers
+--------------
+Cloud providers are a way to automatically enrich metrics with metadata from a cloud vendor.  Currently only AWS is
+supported.  If enabled, the AWS cloudprovider will set the `host` to the instance id, collect all the EC2 tags, and
+the region.
 
-[statsdaemon]
-	address = "docker.local:8125"
-	disable_tags = false
-
-[aws]
-	max_retries = 4
-
-[newrelic]
-	address = "http://localhost:8001/v1/data"
-	event-type = "GoStatsD"
-	#see full configuration options further below
-```
-
-New Relic Backend
------------------------------
-Supports two routes for flushing metrics to New Relic.
-- Directly to the Insights Collector - [Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
-- Via the Infrastructure Agent's inbuilt HTTP Server
-
-### [New Relic Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
-Sending directly to the Event API alleviates the requirement of needing to have the New Relic Infrastructure Agent. Therefore you can run this from nearly anywhere for maximum flexibility. This also becomes a shorter data path with less resource requirements becoming a simpler setup.
-
-To use this method, create an Insert API Key from here: https://insights.newrelic.com/accounts/YOUR_ACCOUNT_ID/manage/api_keys
-
-```
-#Example configuration
-
-[newrelic]
-    address = "https://insights-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events"
-    api-key = "yourEventAPIInsertKey"
-```
-
-### [New Relic Infrastructure Agent](https://newrelic.com/products/infrastructure)
-Sending via the Infrastructure Agent's inbuilt HTTP server provides additional features, such as automatically applying additional metadata to the event the host may have such as AWS tags, instance type, host information, labels etc.
-
-The payload structure required to be accepted by the agent can be viewed [here.](https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample)
-
-To enable the HTTP server, modify /etc/newrelic.yml to include the below, and restart the agent ([Step 1.2](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration#install)).
-```
-http_server_enabled: true
-http_server_host: 127.0.0.1 #(default host)
-http_server_port: 8001 #(default port)
-```
-
-Additional options are available to rename attributes if required.
-```
-[newrelic]
-	tag-prefix = ""
-	metric-name = "name"
-	metric-type = "type"
-	per-second = "per_second"
-	value = "value"
-	timer-min = "min"
-	timer-max = "max"
-	timer-count = "samples_count"
-	timer-mean = "samples_mean"
-	timer-median = "samples_median"
-	timer-stddev = "samples_std_dev"
-	timer-sum = "samples_sum"
-	timer-sumsquare = "samples_sum_squares"
-```
+They should be disabled on the aggregation server when using http forwarding, as the source IP isn't propagated, and
+that information should be collected on the ingestion server.
 
 
 Configuring timer sub-metrics

--- a/metric_consolidator_test.go
+++ b/metric_consolidator_test.go
@@ -1,16 +1,14 @@
 package gostatsd
 
 import (
-	//"context"
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tilinna/clock"
-	//"fmt"
-	"context"
-	"fmt"
-	"sync"
 )
 
 func TestConsolidation(t *testing.T) {

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"io"
 	"net"
-	"strconv"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,92 +17,103 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPreparePayload(t *testing.T) {
+func TestPreparePayloadLegacy(t *testing.T) {
 	t.Parallel()
-	type testData struct {
-		config *Config
-		result []byte
-	}
-	metrics := metrics()
-	input := []testData{
-		{
-			config: &Config{}, // Use defaults
-			result: []byte("stats_counts.stat1 5 1234\n" +
-				"stats.stat1 1.100000 1234\n" +
-				"stats.timers.t1.lower 0.000000 1234\n" +
-				"stats.timers.t1.upper 0.000000 1234\n" +
-				"stats.timers.t1.count 0 1234\n" +
-				"stats.timers.t1.count_ps 0.000000 1234\n" +
-				"stats.timers.t1.mean 0.000000 1234\n" +
-				"stats.timers.t1.median 0.000000 1234\n" +
-				"stats.timers.t1.std 0.000000 1234\n" +
-				"stats.timers.t1.sum 0.000000 1234\n" +
-				"stats.timers.t1.sum_squares 0.000000 1234\n" +
-				"stats.timers.t1.count_90 90.000000 1234\n" +
-				"stats.gauges.g1 3.000000 1234\n" +
-				"stats.sets.users 3 1234\n"),
-		},
-		{
-			config: &Config{
-				GlobalPrefix:    addr("gp"),
-				PrefixCounter:   addr("pc"),
-				PrefixTimer:     addr("pt"),
-				PrefixGauge:     addr("pg"),
-				PrefixSet:       addr("ps"),
-				GlobalSuffix:    addr("gs"),
-				LegacyNamespace: addrB(true),
-			},
-			result: []byte("stats_counts.stat1.gs 5 1234\n" +
-				"stats.stat1.gs 1.100000 1234\n" +
-				"stats.timers.t1.lower.gs 0.000000 1234\n" +
-				"stats.timers.t1.upper.gs 0.000000 1234\n" +
-				"stats.timers.t1.count.gs 0 1234\n" +
-				"stats.timers.t1.count_ps.gs 0.000000 1234\n" +
-				"stats.timers.t1.mean.gs 0.000000 1234\n" +
-				"stats.timers.t1.median.gs 0.000000 1234\n" +
-				"stats.timers.t1.std.gs 0.000000 1234\n" +
-				"stats.timers.t1.sum.gs 0.000000 1234\n" +
-				"stats.timers.t1.sum_squares.gs 0.000000 1234\n" +
-				"stats.timers.t1.count_90.gs 90.000000 1234\n" +
-				"stats.gauges.g1.gs 3.000000 1234\n" +
-				"stats.sets.users.gs 3 1234\n"),
-		},
-		{
-			config: &Config{
-				GlobalPrefix:    addr("gp"),
-				PrefixCounter:   addr("pc"),
-				PrefixTimer:     addr("pt"),
-				PrefixGauge:     addr("pg"),
-				PrefixSet:       addr("ps"),
-				GlobalSuffix:    addr("gs"),
-				LegacyNamespace: addrB(false),
-			},
-			result: []byte("gp.pc.stat1.count.gs 5 1234\n" +
-				"gp.pc.stat1.rate.gs 1.100000 1234\n" +
-				"gp.pt.t1.lower.gs 0.000000 1234\n" +
-				"gp.pt.t1.upper.gs 0.000000 1234\n" +
-				"gp.pt.t1.count.gs 0 1234\n" +
-				"gp.pt.t1.count_ps.gs 0.000000 1234\n" +
-				"gp.pt.t1.mean.gs 0.000000 1234\n" +
-				"gp.pt.t1.median.gs 0.000000 1234\n" +
-				"gp.pt.t1.std.gs 0.000000 1234\n" +
-				"gp.pt.t1.sum.gs 0.000000 1234\n" +
-				"gp.pt.t1.sum_squares.gs 0.000000 1234\n" +
-				"gp.pt.t1.count_90.gs 90.000000 1234\n" +
-				"gp.pg.g1.gs 3.000000 1234\n" +
-				"gp.ps.users.gs 3 1234\n"),
-		},
-	}
-	for i, td := range input {
-		td := td
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-			cl, err := NewClient(td.config, gostatsd.TimerSubtypes{})
-			require.NoError(t, err)
-			b := cl.preparePayload(metrics, time.Unix(1234, 0))
-			assert.Equal(t, string(td.result), b.String(), "test %d", i)
-		})
-	}
+	metrics := metricsWithTags()
+	expected := "stats_counts.stat1.gs 5 1234\n" +
+		"stats.stat1.gs 1.100000 1234\n" +
+		"stats_counts.stat1.gs 10 1234\n" +
+		"stats.stat1.gs 2.200000 1234\n" +
+		"stats_counts.stat1.gs 15 1234\n" +
+		"stats.stat1.gs 3.300000 1234\n" +
+		"stats_counts.stat1.gs 20 1234\n" +
+		"stats.stat1.gs 4.400000 1234\n" +
+		"stats.timers.t1.lower.gs 0.000000 1234\n" +
+		"stats.timers.t1.upper.gs 0.000000 1234\n" +
+		"stats.timers.t1.count.gs 0 1234\n" +
+		"stats.timers.t1.count_ps.gs 0.000000 1234\n" +
+		"stats.timers.t1.mean.gs 0.000000 1234\n" +
+		"stats.timers.t1.median.gs 0.000000 1234\n" +
+		"stats.timers.t1.std.gs 0.000000 1234\n" +
+		"stats.timers.t1.sum.gs 0.000000 1234\n" +
+		"stats.timers.t1.sum_squares.gs 0.000000 1234\n" +
+		"stats.timers.t1.count_90.gs 90.000000 1234\n" +
+		"stats.gauges.g1.gs 3.000000 1234\n" +
+		"stats.sets.users.gs 3 1234\n"
+	cl, err := NewClient("127.0.0.1:9", 1*time.Second, 1*time.Second, "ignored1", "ignored2", "ignored3", "ignored4", "ignored5", "gs", "legacy", gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+	b := cl.preparePayload(metrics, time.Unix(1234, 0))
+	expected = sortLines(expected)
+	actual := sortLines(b.String())
+	require.Equal(t, expected, actual)
+}
+
+func TestPreparePayloadBasic(t *testing.T) {
+	t.Parallel()
+	metrics := metricsWithTags()
+	expected := "gp.pc.stat1.count.gs 5 1234\n" +
+		"gp.pc.stat1.rate.gs 1.100000 1234\n" +
+		"gp.pc.stat1.count.gs 10 1234\n" +
+		"gp.pc.stat1.rate.gs 2.200000 1234\n" +
+		"gp.pc.stat1.count.gs 15 1234\n" +
+		"gp.pc.stat1.rate.gs 3.300000 1234\n" +
+		"gp.pc.stat1.count.gs 20 1234\n" +
+		"gp.pc.stat1.rate.gs 4.400000 1234\n" +
+		"gp.pt.t1.lower.gs 0.000000 1234\n" +
+		"gp.pt.t1.upper.gs 0.000000 1234\n" +
+		"gp.pt.t1.count.gs 0 1234\n" +
+		"gp.pt.t1.count_ps.gs 0.000000 1234\n" +
+		"gp.pt.t1.mean.gs 0.000000 1234\n" +
+		"gp.pt.t1.median.gs 0.000000 1234\n" +
+		"gp.pt.t1.std.gs 0.000000 1234\n" +
+		"gp.pt.t1.sum.gs 0.000000 1234\n" +
+		"gp.pt.t1.sum_squares.gs 0.000000 1234\n" +
+		"gp.pt.t1.count_90.gs 90.000000 1234\n" +
+		"gp.pg.g1.gs 3.000000 1234\n" +
+		"gp.ps.users.gs 3 1234\n"
+	cl, err := NewClient("127.0.0.1:9", 1*time.Second, 1*time.Second, "gp", "pc", "pt", "pg", "ps", "gs", "basic", gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+	b := cl.preparePayload(metrics, time.Unix(1234, 0))
+	expected = sortLines(expected)
+	actual := sortLines(b.String())
+	require.Equal(t, expected, actual)
+}
+
+func TestPreparePayloadTags(t *testing.T) {
+	t.Parallel()
+	metrics := metricsWithTags()
+	expected := "gp.pc.stat1.count.gs 5 1234\n" +
+		"gp.pc.stat1.rate.gs 1.100000 1234\n" +
+		"gp.pc.stat1.count.gs;unnamed=t 10 1234\n" +
+		"gp.pc.stat1.rate.gs;unnamed=t 2.200000 1234\n" +
+		"gp.pc.stat1.count.gs;k=v 15 1234\n" +
+		"gp.pc.stat1.rate.gs;k=v 3.300000 1234\n" +
+		"gp.pc.stat1.count.gs;k=v;unnamed=t 20 1234\n" +
+		"gp.pc.stat1.rate.gs;k=v;unnamed=t 4.400000 1234\n" +
+		"gp.pt.t1.lower.gs 0.000000 1234\n" +
+		"gp.pt.t1.upper.gs 0.000000 1234\n" +
+		"gp.pt.t1.count.gs 0 1234\n" +
+		"gp.pt.t1.count_ps.gs 0.000000 1234\n" +
+		"gp.pt.t1.mean.gs 0.000000 1234\n" +
+		"gp.pt.t1.median.gs 0.000000 1234\n" +
+		"gp.pt.t1.std.gs 0.000000 1234\n" +
+		"gp.pt.t1.sum.gs 0.000000 1234\n" +
+		"gp.pt.t1.sum_squares.gs 0.000000 1234\n" +
+		"gp.pt.t1.count_90.gs 90.000000 1234\n" +
+		"gp.pg.g1.gs 3.000000 1234\n" +
+		"gp.ps.users.gs 3 1234\n"
+	cl, err := NewClient("127.0.0.1:9", 1*time.Second, 1*time.Second, "gp", "pc", "pt", "pg", "ps", "gs", "tags", gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+	b := cl.preparePayload(metrics, time.Unix(1234, 0))
+	expected = sortLines(expected)
+	actual := sortLines(b.String())
+	require.Equal(t, expected, actual)
+}
+
+func sortLines(s string) string {
+	lines := strings.Split(s, "\n")
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
 }
 
 func TestSendMetricsAsync(t *testing.T) {
@@ -110,9 +122,7 @@ func TestSendMetricsAsync(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 	addr := l.Addr().String()
-	c, err := NewClient(&Config{
-		Address: &addr,
-	}, gostatsd.TimerSubtypes{})
+	c, err := NewClient(addr, 1*time.Second, 10*time.Second, "", "", "", "", "", "", "basic", gostatsd.TimerSubtypes{})
 	require.NoError(t, err)
 
 	var acceptWg sync.WaitGroup
@@ -135,7 +145,6 @@ func TestSendMetricsAsync(t *testing.T) {
 		}
 	}()
 	defer acceptWg.Wait()
-	defer l.Close()
 
 	var wg wait.Group
 	defer wg.Wait()
@@ -156,39 +165,24 @@ func TestSendMetricsAsync(t *testing.T) {
 func metrics() *gostatsd.MetricMap {
 	timestamp := gostatsd.Nanotime(time.Unix(123456, 0).UnixNano())
 
-	return &gostatsd.MetricMap{
-		Counters: gostatsd.Counters{
-			"stat1": map[string]gostatsd.Counter{
-				"tag1": {PerSecond: 1.1, Value: 5, Timestamp: timestamp},
-			},
-		},
-		Timers: gostatsd.Timers{
-			"t1": map[string]gostatsd.Timer{
-				"baz": {
-					Values: []float64{10},
-					Percentiles: gostatsd.Percentiles{
-						gostatsd.Percentile{Float: 90, Str: "count_90"},
-					},
-					Timestamp: timestamp,
-				},
-			},
-		},
-		Gauges: gostatsd.Gauges{
-			"g1": map[string]gostatsd.Gauge{
-				"baz": {Value: 3, Timestamp: timestamp},
-			},
-		},
-		Sets: gostatsd.Sets{
-			"users": map[string]gostatsd.Set{
-				"baz": {
-					Values: map[string]struct{}{
-						"joe":  {},
-						"bob":  {},
-						"john": {},
-					},
-					Timestamp: timestamp,
-				},
-			},
-		},
-	}
+	mm := gostatsd.NewMetricMap()
+	mm.Counters["stat1"] = map[string]gostatsd.Counter{}
+	mm.Counters["stat1"][""] = gostatsd.Counter{PerSecond: 1.1, Value: 5, Timestamp: timestamp}
+	mm.Timers["t1"] = map[string]gostatsd.Timer{}
+	mm.Timers["t1"][""] = gostatsd.Timer{Values: []float64{10}, Percentiles: gostatsd.Percentiles{gostatsd.Percentile{Float: 90, Str: "count_90"}}, Timestamp: timestamp}
+	mm.Gauges["g1"] = map[string]gostatsd.Gauge{}
+	mm.Gauges["g1"][""] = gostatsd.Gauge{Value: 3, Timestamp: timestamp}
+	mm.Sets["users"] = map[string]gostatsd.Set{}
+	mm.Sets["users"][""] = gostatsd.Set{Values: map[string]struct{}{"joe": {}, "bob": {}, "john": {}}, Timestamp: timestamp}
+	return mm
+}
+
+func metricsWithTags() *gostatsd.MetricMap {
+	timestamp := gostatsd.Nanotime(time.Unix(123456, 0).UnixNano())
+
+	m := metrics()
+	m.Counters["stat1"]["t"] = gostatsd.Counter{PerSecond: 2.2, Value: 10, Timestamp: timestamp, Tags: gostatsd.Tags{"t"}}
+	m.Counters["stat1"]["k:v"] = gostatsd.Counter{PerSecond: 3.3, Value: 15, Timestamp: timestamp, Tags: gostatsd.Tags{"k:v"}}
+	m.Counters["stat1"]["k:v.t"] = gostatsd.Counter{PerSecond: 4.4, Value: 20, Timestamp: timestamp, Tags: gostatsd.Tags{"k:v", "t"}}
+	return m
 }


### PR DESCRIPTION
This does a few things:
- Adds support for graphite tags (including a bunch of refactor work), however only using actual tags (#233, #213), and not node style (which is probably what was intended with #78).  I'm calling all 3 resolved by this, however.  If someone actually wants node style tags, a fresh issue should be opened.
- Pulls backend configuration to its own documentation file, because it's getting noisy.
- Fixed #161 