### PR TITLE
Changing this debug rather than info

### DIFF
--- a/pkg/web/httpservers.go
+++ b/pkg/web/httpservers.go
@@ -183,7 +183,7 @@ func (hs *httpServer) logRequest(handler http.Handler) http.Handler {
 		dur := time.Since(start)
 
 		logFields["duration"] = float64(dur) / float64(time.Millisecond)
-		hs.logger.WithFields(logFields).Info("request")
+		hs.logger.WithFields(logFields).Debug("request")
 	})
 }
 


### PR DESCRIPTION
This has become a rather noisey log line and isn't operationally useful.

To avoid a breaking change of adding configurable config level, I opted to set this to debug so it can still be enabled with the verbose flag.