### PR TITLE
Add support for events via New Relic backend

### DIFF
--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -1,9 +1,6 @@
 package newrelic
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/atlassian/gostatsd"
 )
 
@@ -103,20 +100,7 @@ func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, t
 	metricSet[n.metricType] = Type
 	metricSet[n.metricName] = metricName
 	metricSet[n.metricValue] = Value
-
-	for _, tag := range tags {
-		if strings.Contains(tag, ":") {
-			keyvalpair := strings.SplitN(tag, ":", 2)
-			parsed, err := strconv.ParseFloat(keyvalpair[1], 64)
-			if err != nil || strings.EqualFold(keyvalpair[1], "infinity") {
-				metricSet[n.tagPrefix+keyvalpair[0]] = keyvalpair[1]
-			} else {
-				metricSet[n.tagPrefix+keyvalpair[0]] = parsed
-			}
-		} else {
-			metricSet[n.tagPrefix+tag] = "true"
-		}
-	}
+	n.setTags(tags, &metricSet)
 
 	return metricSet
 }

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -100,7 +100,7 @@ func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, t
 	metricSet[n.metricType] = Type
 	metricSet[n.metricName] = metricName
 	metricSet[n.metricValue] = Value
-	n.setTags(tags, &metricSet)
+	n.setTags(tags, metricSet)
 
 	return metricSet
 }

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -329,7 +329,7 @@ func (n *Client) postWrapper(ctx context.Context, mJSON []byte) (func() error, e
 
 		req, err := http.NewRequest("POST", n.address, bytes.NewBuffer(json))
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to create http.Request: %v", err)
 		}
 		req = req.WithContext(ctx)
 		for header, v := range headers {
@@ -337,7 +337,7 @@ func (n *Client) postWrapper(ctx context.Context, mJSON []byte) (func() error, e
 		}
 		resp, err := n.client.Do(req)
 		if err != nil {
-			return err
+			return fmt.Errorf("error POSTing: %s", err.Error())
 		}
 		defer resp.Body.Close()
 		body := io.LimitReader(resp.Body, maxResponseSize)

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -92,11 +93,11 @@ func TestSendMetrics(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.1.0","data":[{"metrics":` +
-			`[{"event_type":"GoStatsD","integration_version":"2.1.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
-			`{"event_type":"GoStatsD","integration_version":"2.1.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
-			`{"event_type":"GoStatsD","integration_version":"2.1.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
-			`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.1.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
+		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.2.0","data":[{"metrics":` +
+			`[{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
+			`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
 			`"samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":0}]}]}`
 		assert.Equal(t, expected, string(data))
 	})
@@ -184,5 +185,45 @@ func metricsOneOfEach() *gostatsd.MetricMap {
 				},
 			},
 		},
+	}
+}
+
+func TestEventFormatter(t *testing.T) {
+	t.Parallel()
+	var requestNum uint32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/data", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		n := atomic.AddUint32(&requestNum, 1)
+		data, err := ioutil.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotEmpty(t, data)
+		if n == 1 {
+			// Return error on first request to trigger a retry
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL+"/v1/data", "GoStatsD", "", "", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent", "tcp",
+		defaultMetricsPerBatch, defaultMaxRequests, false, 1*time.Second, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{})
+	require.NoError(t, err)
+
+	gostatsdEvent := gostatsd.Event{Title: "EventTitle", Text: "hi", Hostname: "blah", Priority: 1}
+
+	formattedEvent := client.EventFormatter(&gostatsdEvent)
+	fevent, err := json.Marshal(formattedEvent)
+	require.NoError(t, err)
+
+	expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.2.0","data":` +
+		`[{"metrics":[{"AggregationKey":"","AlertType":"","DateHappened":0,"Hostname":"blah","Priority":"low","SourceTypeName":"","Text":"hi","Title":"EventTitle","event_type":"GoStatsD","name":"event"}]}]}`
+
+	if string(fevent) != expected {
+		t.Errorf("expected %v got %v", expected, string(fevent))
 	}
 }


### PR DESCRIPTION
When the event is sent through, it is sent as a full New Relic event, so all context is maintained and queryable.

eg.
![image](https://user-images.githubusercontent.com/13043208/61550591-2f7c4380-aa96-11e9-8a3b-175fe2aa9a1d.png)