### PR TITLE
support debug-mode to print custom metrics to stdout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+17.2.0
+------
+- Support `log-raw-metric` configuration
+
 17.1.0
 ------
 - NewRelic event support added by Kav91

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ following configuration options:
   configured parsers (`--max-parsers` option).  Defaults to the value of `--max-parsers`, but may require tuning for
   HTTP based servers.
 - `flush-interval`: duration for how long to batch metrics before flushing. Should be an order of magnitude less than
-  the upstream flush interval. Defaults to `1s`
+  the upstream flush interval. Defaults to `1s`.
+- `log-raw-metric`: print metrics received from network to stdout in JSON format.
 
 Configuring HTTP servers
 ------------------------

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -133,7 +133,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		ReceiveBatchSize:    v.GetInt(statsd.ParamReceiveBatchSize),
 		ConnPerReader:       v.GetBool(statsd.ParamConnPerReader),
 		ServerMode:          v.GetString(statsd.ParamServerMode),
-		DebugMode:           v.GetBool(statsd.ParamDebugMode),
+		LogRawMetric:        v.GetBool(statsd.ParamLogRawMetric),
 		CacheOptions: statsd.CacheOptions{
 			CacheRefreshPeriod:        v.GetDuration(statsd.ParamCacheRefreshPeriod),
 			CacheEvictAfterIdlePeriod: v.GetDuration(statsd.ParamCacheEvictAfterIdlePeriod),

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -133,6 +133,7 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 		ReceiveBatchSize:    v.GetInt(statsd.ParamReceiveBatchSize),
 		ConnPerReader:       v.GetBool(statsd.ParamConnPerReader),
 		ServerMode:          v.GetString(statsd.ParamServerMode),
+		DebugMode:           v.GetBool(statsd.ParamDebugMode),
 		CacheOptions: statsd.CacheOptions{
 			CacheRefreshPeriod:        v.GetDuration(statsd.ParamCacheRefreshPeriod),
 			CacheEvictAfterIdlePeriod: v.GetDuration(statsd.ParamCacheEvictAfterIdlePeriod),

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -20,7 +20,7 @@ const fakeIP = gostatsd.IP("127.0.0.1")
 
 func newTestParser(ignoreHost bool) (*DatagramParser, *countingHandler) {
 	ch := &countingHandler{}
-	return NewDatagramParser(nil, "", ignoreHost, 0, ch, rate.Limit(0)), ch
+	return NewDatagramParser(nil, "", ignoreHost, 0, ch, rate.Limit(0), false), ch
 }
 
 func TestParseEmptyDatagram(t *testing.T) {

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -51,6 +51,7 @@ type Server struct {
 	BadLineRateLimitPerSecond rate.Limit
 	ServerMode                string
 	Hostname                  string
+	DebugMode                 bool
 	CacheOptions
 	Viper *viper.Viper
 }
@@ -168,7 +169,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	datagrams := make(chan []*Datagram)
 
 	// Create the Parser
-	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, handler, s.BadLineRateLimitPerSecond)
+	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, handler, s.BadLineRateLimitPerSecond, s.DebugMode)
 	runnables = append(runnables, parser.RunMetrics)
 	for i := 0; i < s.MaxParsers; i++ {
 		runnables = append(runnables, parser.Run)

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -51,7 +51,7 @@ type Server struct {
 	BadLineRateLimitPerSecond rate.Limit
 	ServerMode                string
 	Hostname                  string
-	DebugMode                 bool
+	LogRawMetric              bool
 	CacheOptions
 	Viper *viper.Viper
 }
@@ -169,7 +169,7 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 	datagrams := make(chan []*Datagram)
 
 	// Create the Parser
-	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, handler, s.BadLineRateLimitPerSecond, s.DebugMode)
+	parser := NewDatagramParser(datagrams, s.Namespace, s.IgnoreHost, s.EstimatedTags, handler, s.BadLineRateLimitPerSecond, s.LogRawMetric)
 	runnables = append(runnables, parser.RunMetrics)
 	for i := 0; i < s.MaxParsers; i++ {
 		runnables = append(runnables, parser.Run)

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -84,6 +84,8 @@ const (
 	DefaultBadLinesPerMinute = 0
 	// DefaultServerMode is the default mode to run as, standalone|forwarder
 	DefaultServerMode = "standalone"
+	// TODO
+	DefaultDebugMode = false
 )
 
 const (
@@ -147,6 +149,8 @@ const (
 	ParamServerMode = "server-mode"
 	// ParamHostname allows hostname overrides
 	ParamHostname = "hostname"
+	// TODO
+	ParamDebugMode = "debug-mode"
 )
 
 // AddFlags adds flags to the specified FlagSet.
@@ -180,6 +184,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Bool(ParamConnPerReader, DefaultConnPerReader, "Create a separate connection per reader (requires system support for reusing addresses)")
 	fs.String(ParamServerMode, DefaultServerMode, "The server mode to run in")
 	fs.String(ParamHostname, getHost(), "overrides the hostname of the server")
+	fs.Bool(ParamDebugMode, DefaultDebugMode, "Print metrics received from network to stdout")
 }
 
 func minInt(a, b int) int {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -84,8 +84,8 @@ const (
 	DefaultBadLinesPerMinute = 0
 	// DefaultServerMode is the default mode to run as, standalone|forwarder
 	DefaultServerMode = "standalone"
-	// TODO
-	DefaultDebugMode = false
+	// DefineLogRawMetric is the default value for debug-mode flag
+	DefineLogRawMetric = false
 )
 
 const (
@@ -149,8 +149,8 @@ const (
 	ParamServerMode = "server-mode"
 	// ParamHostname allows hostname overrides
 	ParamHostname = "hostname"
-	// TODO
-	ParamDebugMode = "debug-mode"
+	// ParamLogRawMetric enables custom metrics to be printed to stdout
+	ParamLogRawMetric = "log-raw-metric"
 )
 
 // AddFlags adds flags to the specified FlagSet.
@@ -184,7 +184,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Bool(ParamConnPerReader, DefaultConnPerReader, "Create a separate connection per reader (requires system support for reusing addresses)")
 	fs.String(ParamServerMode, DefaultServerMode, "The server mode to run in")
 	fs.String(ParamHostname, getHost(), "overrides the hostname of the server")
-	fs.Bool(ParamDebugMode, DefaultDebugMode, "Print metrics received from network to stdout")
+	fs.Bool(ParamLogRawMetric, DefineLogRawMetric, "Print metrics received from network to stdout in JSON format")
 }
 
 func minInt(a, b int) int {

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -84,7 +84,7 @@ const (
 	DefaultBadLinesPerMinute = 0
 	// DefaultServerMode is the default mode to run as, standalone|forwarder
 	DefaultServerMode = "standalone"
-	// DefaultLogRawMetric is the default value for log-raw-metric flag
+	// DefaultLogRawMetric is the default value for whether to log the metrics received from network
 	DefaultLogRawMetric = false
 )
 

--- a/pkg/statsd/statsd_defaults_and_params.go
+++ b/pkg/statsd/statsd_defaults_and_params.go
@@ -84,8 +84,8 @@ const (
 	DefaultBadLinesPerMinute = 0
 	// DefaultServerMode is the default mode to run as, standalone|forwarder
 	DefaultServerMode = "standalone"
-	// DefineLogRawMetric is the default value for debug-mode flag
-	DefineLogRawMetric = false
+	// DefaultLogRawMetric is the default value for log-raw-metric flag
+	DefaultLogRawMetric = false
 )
 
 const (
@@ -184,7 +184,7 @@ func AddFlags(fs *pflag.FlagSet) {
 	fs.Bool(ParamConnPerReader, DefaultConnPerReader, "Create a separate connection per reader (requires system support for reusing addresses)")
 	fs.String(ParamServerMode, DefaultServerMode, "The server mode to run in")
 	fs.String(ParamHostname, getHost(), "overrides the hostname of the server")
-	fs.Bool(ParamLogRawMetric, DefineLogRawMetric, "Print metrics received from network to stdout in JSON format")
+	fs.Bool(ParamLogRawMetric, DefaultLogRawMetric, "Print metrics received from network to stdout in JSON format")
 }
 
 func minInt(a, b int) int {


### PR DESCRIPTION
- Provide a debug-mode configurable item which defaults to false.
- Once the debug-mode is on, the server should print the metrics received from network to stdout.
  - Should ONLY print the custom metrics.
  - If the terminal/stdout speed is less than metrics incoming speed, it’s reasonable to ignore some of them. So you could not see all the metrics sent to the server from the stdout under such circumstances.

Sample Usage
- dummy client
`while [[ 1 ]];do echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125;echo -n '.';sleep 1;done`
- server with --log-raw-metric=true
`{"level":"info","msg":"[{counter, abc.def.g, 10.000000, , }]","time":"2019-08-26T16:04:33+10:00"}`