### PR TITLE
Adding support for custom headers when sending requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+17.2.1
+------
+- Support for `custom-headers` for http_forwarder_v2
+
 17.2.0
 ------
 - Support `log-raw-metric` configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-17.2.1
+18.0.0
 ------
 - Support for `custom-headers` for http_forwarder_v2
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ following configuration options:
 - `flush-interval`: duration for how long to batch metrics before flushing. Should be an order of magnitude less than
   the upstream flush interval. Defaults to `1s`.
 - `log-raw-metric`: print metrics received from network to stdout in JSON format.
-- `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection . 
-  Not required, default is empty.
+- `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection. 
+  Not required, default is empty. Example: `--custom-headers='{'region' : 'us-east-1', 'service' : 'event-producer'}'`
 
 Configuring HTTP servers
 ------------------------

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ following configuration options:
 - `flush-interval`: duration for how long to batch metrics before flushing. Should be an order of magnitude less than
   the upstream flush interval. Defaults to `1s`.
 - `log-raw-metric`: print metrics received from network to stdout in JSON format.
+- `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection . 
+  Not required, default is empty.
 
 Configuring HTTP servers
 ------------------------

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ following configuration options:
   the upstream flush interval. Defaults to `1s`.
 - `log-raw-metric`: print metrics received from network to stdout in JSON format.
 - `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection. 
-  Not required, default is empty. Example: `--custom-headers='{'region' : 'us-east-1', 'service' : 'event-producer'}'`
+  Not required, default is empty. Example: `--custom-headers='{"region" : "us-east-1", "service" : "event-producer"}'`
 
 Configuring HTTP servers
 ------------------------

--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,3 @@ require (
 	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 )
+
+go 1.13

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -376,6 +376,18 @@ func (hfh *HttpForwarderHandlerV2) post(ctx context.Context, message proto.Messa
 	}
 }
 
+// debug rendering
+/*
+func (hh *HttpForwarderHandlerV2) serializeText(message proto.Message) ([]byte, error) {
+       buf := &bytes.Buffer{}
+       err := proto.MarshalText(buf, message)
+       if err != nil {
+               return nil, err
+       }
+       return buf.Bytes(), nil
+}
+*/
+
 func (hfh *HttpForwarderHandlerV2) serialize(message proto.Message) ([]byte, error) {
 	buf, err := proto.Marshal(message)
 	if err != nil {

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -129,10 +128,8 @@ func NewHttpForwarderHandlerV2(logger logrus.FieldLogger, apiEndpoint, network s
 	}
 
 	// Adding extra headers to the default block of headers to emit.
-	// Convert the header to uppercase to ensure known mapping when
-	// inspected by proxies or load balancers
 	for k, v := range xheaders {
-		k = strings.ToUpper(k)
+		k = http.CanonicalHeaderKey(k)
 		headers[k] = v
 	}
 

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -50,6 +50,7 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		10*time.Second,
 		10*time.Second,
 		10*time.Millisecond,
+		nil,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
In order to forward requests to different target groups, adding the ability to add additional custom headers gives that opportunity at no cost. 

Since we do not have cluster ready yet, running a singular instance has proven problematic since we can't reason who is sending us data and rely on IP addresses to investigate further. Adding custom headers allows us to inspect these at the ALB and shard noisy neighbours onto their own deployment stack.
