### PR TITLE
Pins golangci-lint to v1.18.0 to address an incompatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ tools/bin/protoc:
 	rm protoc-$(PROTOBUF_VERSION)-linux-x86_64.zip
 
 setup-ci: tools/bin/protoc
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint
+	# Unpin this when gitea 1.10 is released
+	# https://github.com/go-gitea/gitea/issues/8126
+	# https://github.com/atlassian/gostatsd/issues/266
+	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
 
 build-cluster: fmt
 	go build -i -v -o build/bin/$(ARCH)/cluster $(GOBUILD_VERSION_ARGS) $(CLUSTER_PKG)


### PR DESCRIPTION
No changelog on this one, since it's temporary infrastructurey stuff that doesn't impact the binary itself.