### PR TITLE
Semi-RFC: Consolidate http behavior

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -63,6 +63,9 @@ Metrics:
 | http.forwarder.dropped                      | counter             |                              | The number of batches dropped due to inability to forward upstream
 | http.incoming                               | counter             | server-name, result, failure | The number of batches forwarded to the server, and the results of processing them
 | http.incoming.metrics                       | counter             | server-name                  | The number of metrics received over http
+| transport.fail                              | gauge (cumulative)  | transport, failure           | The number of hard failures to send a message over this transport
+| transport.retried                           | gauge (cumulative)  | transport                    | The number of retries sending a message over this transport
+| transport.sent                              | gauge (cumulative)  | transport                    | The number of messages successfully sent over this transport
 
 | Tag           | Description
 | ------------- | -----------
@@ -75,6 +78,7 @@ Metrics:
 | result        | Success to indicate a batch of metrics was successfully processed, failure to indicate a batch of metrics was not processed, with additional failure tag for why)
 | failure       | The reason a batch of metrics was not processed
 | server-name   | The name of an http-server as specified in the config file
+| transport     | A named transport
 
 A number of channels are tracked internally, they emit metrics under the channel.* space.  They will all have a
 channel tag, and may have additional tags specified below.  Channels are sampled at a regular interval. After a

--- a/TRANSPORT.md
+++ b/TRANSPORT.md
@@ -8,6 +8,8 @@ client is configured in the following manner:
 [transport.<name>]
 client-timeout = '10s'
 type = 'http'
+
+retry-* = ... see section on retries below ...
 ```
 
 - `client-timeout`: The maximum time for the roundtrip to execute. Set to `0` to disable timeout.
@@ -17,6 +19,45 @@ type = 'http'
 
 If a transport is not configured, it will fallback to the transport named `default` (ie, `transport.default`) and
 emit a warning message.
+
+Retry configuration
+-------------------
+All the retry options are listed below, not all options apply to all policies.
+- `retry-policy`: the retry policy to apply, one of `exponential` (default), `constant`, and `disabled`.
+- `retry-interval`: the interval between retries, applies only to the `constant` policy.  Default value is `1s`, must
+  be positive.
+- `retry-max-count`: the maximum number of retries to apply.  Applies to `exponential` and `constant` policies.  A
+  value of `0` means unlimited.  Must be zero or positive.  Default value is `0` (unlimited)
+- `retry-max-time`: the maximum amount of time to try applying retries.  Applies to `exponential` and `constant`
+  policies.  Must be positive.  Default value is `15s`.
+
+The actual delay between individual retries will be +/- 0.5 * interval, where the interval depends on the policy.
+
+Retry examples
+--------------
+```
+# No retries
+[transport.no-retries]
+retry-policy = 'disabled'
+
+# Retry "forever" with a 10 second retry interval
+[transport.retry-forever-constant]
+retry-policy = 'constant'
+retry-interval = '10s'
+retry-max-time = '1y'  # there's no actual "forever"
+
+# Retry forever with an exponential backoff
+[transport.retry-forever-exponential]
+retry-policy = 'exponential'
+retry-max-time = '1y'  # there's no actual "forever"
+
+# Retry a maximum of 5 times (6 actual attempts)
+[transport.retry-max-count]
+retry-policy = 'constant'
+retry-interval = '1s'
+retry-duration = '1m'  # Will not be reached, retry-max-count will take priority
+retry-max-count = 5
+```
 
 HTTP transport configuration
 ----------------------------

--- a/TRANSPORT.md
+++ b/TRANSPORT.md
@@ -7,7 +7,9 @@ client is configured in the following manner:
 ```
 [transport.<name>]
 client-timeout = '10s'
+compress = true
 custom-headers = {}
+debug-body = false
 max-parallel-requests = 1000
 type = 'http'
 user-agent = "gostatsd"
@@ -15,9 +17,13 @@ user-agent = "gostatsd"
 retry-* = ... see section on retries below ...
 ```
 
-- `client-timeout`: The maximum time for a roundtrip to execute. Set to `0` to disable timeout.  Retries will
-  allow the total time to run for longer than this value.  Corresponds to `http.Client.Timeout`.
+- `client-timeout`: The maximum time for a single roundtrip to execute. Set to `0` to disable timeout.  Retries
+  will allow the total time to run for longer than this value.  Corresponds to `http.Client.Timeout`.
+- `compress`: Indicates if data should be compressed if possible (some backends don't support compression)
 - `custom-headers`: Allows for custom headers to be set.  See `HTTP Headers` section below for further information.
+- `debug-body`: Attempts to serialize a request in a more human friendly format.  For protobuf this means text, and
+  for JSON this means with new lines and indentation.  Disables compression.  Warning: Text encoded protobuf will not
+  typically be accepted by servers.
 - `max-parallel-requests`: The maximum number of requests in flight on this transport.  This is network only, and
   doesn't include CPU bound work (serialization and compression).
 - `type`: There is currently only a type of `http`, however others are planned (Kinesis, Kafka, etc).  Each type

--- a/TRANSPORT.md
+++ b/TRANSPORT.md
@@ -24,6 +24,7 @@ retry-* = ... see section on retries below ...
 - `debug-body`: Attempts to serialize a request in a more human friendly format.  For protobuf this means text, and
   for JSON this means with new lines and indentation.  Disables compression.  Warning: Text encoded protobuf will not
   typically be accepted by servers.
+- `enable-metrics`: Enables or disables sending of metrics for this transport.  Defaults to `false`.
 - `max-parallel-requests`: The maximum number of requests in flight on this transport.  This is network only, and
   doesn't include CPU bound work (serialization and compression).
 - `type`: There is currently only a type of `http`, however others are planned (Kinesis, Kafka, etc).  Each type

--- a/TRANSPORT.md
+++ b/TRANSPORT.md
@@ -81,9 +81,9 @@ There are 3 layers of headers which are on every request.  They are processed in
 3. User headers.  These always take precedence, and setting a value of `""` allows for a header set at an earlier
    layer to be removed.
 
-Custom headers can be specified as:
+Custom headers can be specified in TOML as:
 ```
-custom-headers={"header1"="value1", "header2"="value2"}
+custom-headers={header1="value1", header2="value2"}
 ```
 
 or

--- a/backend.go
+++ b/backend.go
@@ -2,14 +2,7 @@ package gostatsd
 
 import (
 	"context"
-
-	"github.com/spf13/viper"
-
-	"github.com/atlassian/gostatsd/pkg/transport"
 )
-
-// BackendFactory is a function that returns a Backend.
-type BackendFactory func(config *viper.Viper, pool *transport.TransportPool) (Backend, error)
 
 // SendCallback is called by Backend.SendMetricsAsync() to notify about the result of operation.
 // A list of errors is passed to the callback. It may be empty or contain nil values. Every non-nil value is an error

--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,5 @@ require (
 	k8s.io/client-go v0.17.3
 	k8s.io/utils v0.0.0-20200124190032-861946025e34 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/libp2p/go-reuseport v0.0.1
 	github.com/magiconair/properties v1.8.1
-	github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd
+	github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
@@ -34,5 +34,3 @@ require (
 	k8s.io/client-go v0.17.3
 	k8s.io/utils v0.0.0-20200124190032-861946025e34 // indirect
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,7 @@ google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEt
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -17,8 +17,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+// BackendFactory is a function that returns a Backend.
+type BackendFactory func(config *viper.Viper, pool *transport.TransportPool) (gostatsd.Backend, error)
+
 // All known backends.
-var backends = map[string]gostatsd.BackendFactory{
+var backends = map[string]BackendFactory{
 	datadog.BackendName:     datadog.NewClientFromViper,
 	graphite.BackendName:    graphite.NewClientFromViper,
 	null.BackendName:        null.NewClientFromViper,

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -422,7 +422,7 @@ func NewClient(
 	logger := log.WithField("backend", BackendName)
 	httpClient, err := pool.Get(transport)
 	if err != nil {
-		logger.WithError(err).Error("failed to create http client")
+		logger.WithError(err).Error("failed to create transport")
 		return nil, err
 	}
 	logger.WithFields(log.Fields{

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -517,7 +517,7 @@ func NewClient(transport, address, addressMetrics, eventType, flushType, apiKey,
 
 	httpClient, err := pool.Get(transport)
 	if err != nil {
-		logger.WithError(err).Error("failed to create http client")
+		logger.WithError(err).Error("failed to create transport")
 		return nil, err
 	}
 	logger.WithFields(log.Fields{

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -116,7 +116,7 @@ func NewHttpForwarderHandlerV2(
 
 	httpClient, err := pool.Get(transport)
 	if err != nil {
-		logger.WithError(err).Error("failed to create http client")
+		logger.WithError(err).Error("failed to create transport")
 		return nil, err
 	}
 

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -191,6 +191,9 @@ func (s *Server) RunWithCustomSocket(ctx context.Context, sf SocketFactory) erro
 		runnables = gostatsd.MaybeAppendRunnable(runnables, server)
 	}
 
+	// Make sure the TransportPool metrics are ready
+	runnables = append(runnables, s.TransportPool.RunMetrics)
+
 	// Start the world!
 	runCtx := stats.NewContext(context.Background(), statser)
 	stgr := stager.New()

--- a/pkg/statsd/statsd_test.go
+++ b/pkg/statsd/statsd_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cachedinstances/cloudprovider"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
+	"github.com/atlassian/gostatsd/pkg/transport"
 )
 
 // TestStatsdThroughput emulates statsd work using fake network socket and null backend to
@@ -60,6 +61,7 @@ func TestStatsdThroughput(t *testing.T) {
 		ReceiveBatchSize:      gostatsd.DefaultReceiveBatchSize,
 		MaxConcurrentEvents:   2,
 		ServerMode:            "standalone",
+		TransportPool:         transport.NewTransportPool(logrus.StandardLogger(), viper.New()),
 		Viper:                 viper.New(),
 	}
 	ctxCached, cancelCached := context.WithCancel(context.Background())

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -1,13 +1,122 @@
 package transport
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"sync/atomic"
+
+	"github.com/cenkalti/backoff"
+	"github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
-// Client is a holder of an http.Client.  In future it will have some high level logic
-// attached to it (PostProtobuf, PostJson, retries, metrics, etc).  The underlying Client
-// is exposed so that things that require a real http.Client (such as Cloudwatch) can
-// still utilize the TransportPool.
 type Client struct {
+	messagesSent     uint64 // atomic - messages successfully sent
+	messagesRetried  uint64 // atomic - retries (first attempt is not a retry, final failure is not a retry)
+	messagesDropped  uint64 // atomic - final failure, does not include semaphore timeout
+	messagesTimedOut uint64 // atomic - messages timed out waiting for a semaphore slot
+
+	logger        logrus.FieldLogger
+	customHeaders map[string]string
+	requestSem    util.Semaphore
+	userAgent     string
+	backoff       util.BackoffFactory
+
 	Client *http.Client
+}
+
+// PostRaw will start a goroutine (semaphore allowing) which attempts to POST the provided data
+// to the provided URL.  It is fire-and-forget by design.
+func (hc *Client) PostRaw(ctx context.Context, url, contentType, encoding string, headers map[string]string, body []byte) {
+	if !hc.requestSem.Acquire(ctx) {
+		atomic.AddUint64(&hc.messagesTimedOut, 1)
+		return
+	}
+
+	go func() {
+		defer hc.requestSem.Release()
+		hc.do(ctx, url, contentType, encoding, body, headers)
+	}()
+}
+
+func (hc *Client) do(ctx context.Context, url, contentType, encoding string, body []byte, headers map[string]string) {
+	var err error
+
+	bo := hc.backoff()
+	doPost := hc.constructPost(ctx, body, url, contentType, encoding, headers)
+
+	for {
+		if err = doPost(); err == nil {
+			atomic.AddUint64(&hc.messagesSent, 1)
+			return
+		}
+
+		next := bo.NextBackOff()
+		if next == backoff.Stop {
+			break
+		}
+
+		hc.logger.WithError(err).Warn("failed to send, retrying")
+
+		if !interruptableSleep(ctx, next) {
+			break
+		}
+
+		atomic.AddUint64(&hc.messagesRetried, 1)
+	}
+
+	atomic.AddUint64(&hc.messagesDropped, 1)
+	hc.logger.WithError(err).Info("failed to send, giving up")
+}
+
+func (hc *Client) constructPost(ctx context.Context, body []byte, url, contentType, encoding string, headers map[string]string) func() error {
+	return func() error {
+		req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("unable to create http.Request: %v", err)
+		}
+
+		req = req.WithContext(ctx)
+
+		// Base headers
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("Content-Encoding", encoding)
+		req.Header.Set("User-Agent", hc.userAgent)
+
+		// Caller headers
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+
+		// Custom headers always win
+		for key, value := range hc.customHeaders {
+			if value == "" { // Provide a way to delete headers
+				req.Header.Del(key)
+			} else {
+				req.Header.Set(key, value)
+			}
+		}
+
+		// Perform the request
+		resp, err := hc.Client.Do(req)
+		if err != nil {
+			return fmt.Errorf("error POSTing: %v", err)
+		}
+		defer consumeAndClose(resp.Body)
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			bodyStart, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 512))
+			hc.logger.WithFields(logrus.Fields{
+				"status": resp.StatusCode,
+				"body":   string(bodyStart),
+			}).Info("failed request")
+			return fmt.Errorf("received bad status code %d", resp.StatusCode)
+		}
+		return nil
+	}
 }

--- a/pkg/transport/client_high.go
+++ b/pkg/transport/client_high.go
@@ -1,0 +1,93 @@
+package transport
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// TransportOptions allows for the caller to override default behaviors.
+type TransportOptions struct {
+	// DisableCompression will force compression to be off
+	DisableCompression bool
+
+	// Headers allows a caller to pass additional headers
+	Headers map[string]string
+}
+
+// PostMessage will post a protobuf or json message to the provided URL.
+func (hc *Client) PostMessage(ctx context.Context, url string, message interface{}, options *TransportOptions) {
+	var headers map[string]string
+	disableCompression := hc.debugBody // debug is always uncompressed
+	if options != nil {
+		headers = options.Headers
+		if options.DisableCompression {
+			disableCompression = true
+		}
+	}
+
+	if pb, ok := message.(proto.Message); ok {
+		if hc.debugBody {
+			hc.postProtobufText(ctx, url, headers, pb)
+		} else {
+			hc.postProtobuf(ctx, url, headers, disableCompression, pb)
+		}
+		return
+	}
+	hc.postJson(ctx, url, headers, disableCompression, message)
+}
+
+// postProtobuf will serialize a proto.Message and post it.
+func (hc *Client) postProtobuf(ctx context.Context, url string, headers map[string]string, disableCompression bool, message proto.Message) {
+	body, err := proto.Marshal(message)
+	if err != nil {
+		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		return
+	}
+
+	encoding := "identity"
+	if hc.compress && !disableCompression {
+		body, err = compress(body)
+		encoding = "deflate"
+		if err != nil {
+			atomic.AddUint64(&hc.messagesFailCompress, 1)
+			return
+		}
+	}
+
+	hc.PostRaw(ctx, url, "application/x-protobuf", encoding, nil, body)
+}
+
+// postProtobufText will serialize a proto.Message in text form and post it.  This is intended for debugging purposes
+// only, and the remote side will likely reject the message.
+func (hc *Client) postProtobufText(ctx context.Context, url string, headers map[string]string, message proto.Message) {
+	body := proto.MarshalTextString(message)
+	if body == "" {
+		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		return
+	}
+	contentType := "text/x-protobuf" // FIXME: I'm not sure what the text version of protobuf is meant to be.
+	encoding := "identity"           // No compression for the debug rendering
+	hc.PostRaw(ctx, url, contentType, encoding, nil, []byte(body))
+}
+
+func (hc *Client) postJson(ctx context.Context, url string, headers map[string]string, disableCompression bool, data interface{}) {
+	body, err := marshalJson(data, hc.debugBody)
+	if err != nil {
+		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		return
+	}
+
+	encoding := "identity"
+	if hc.compress && !disableCompression {
+		body, err = compress(body)
+		encoding = "deflate"
+		if err != nil {
+			atomic.AddUint64(&hc.messagesFailCompress, 1)
+			return
+		}
+	}
+
+	hc.PostRaw(ctx, url, "application/json", encoding, nil, body)
+}

--- a/pkg/transport/client_high.go
+++ b/pkg/transport/client_high.go
@@ -42,7 +42,7 @@ func (hc *Client) PostMessage(ctx context.Context, url string, message interface
 func (hc *Client) postProtobuf(ctx context.Context, url string, headers map[string]string, disableCompression bool, message proto.Message) {
 	body, err := proto.Marshal(message)
 	if err != nil {
-		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		atomic.AddUint64(&hc.messagesFailMarshal.cur, 1)
 		return
 	}
 
@@ -51,7 +51,7 @@ func (hc *Client) postProtobuf(ctx context.Context, url string, headers map[stri
 		body, err = compress(body)
 		encoding = "deflate"
 		if err != nil {
-			atomic.AddUint64(&hc.messagesFailCompress, 1)
+			atomic.AddUint64(&hc.messagesFailCompress.cur, 1)
 			return
 		}
 	}
@@ -64,7 +64,7 @@ func (hc *Client) postProtobuf(ctx context.Context, url string, headers map[stri
 func (hc *Client) postProtobufText(ctx context.Context, url string, headers map[string]string, message proto.Message) {
 	body := proto.MarshalTextString(message)
 	if body == "" {
-		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		atomic.AddUint64(&hc.messagesFailMarshal.cur, 1)
 		return
 	}
 	contentType := "text/x-protobuf" // FIXME: I'm not sure what the text version of protobuf is meant to be.
@@ -75,7 +75,7 @@ func (hc *Client) postProtobufText(ctx context.Context, url string, headers map[
 func (hc *Client) postJson(ctx context.Context, url string, headers map[string]string, disableCompression bool, data interface{}) {
 	body, err := marshalJson(data, hc.debugBody)
 	if err != nil {
-		atomic.AddUint64(&hc.messagesFailMarshal, 1)
+		atomic.AddUint64(&hc.messagesFailMarshal.cur, 1)
 		return
 	}
 
@@ -84,7 +84,7 @@ func (hc *Client) postJson(ctx context.Context, url string, headers map[string]s
 		body, err = compress(body)
 		encoding = "deflate"
 		if err != nil {
-			atomic.AddUint64(&hc.messagesFailCompress, 1)
+			atomic.AddUint64(&hc.messagesFailCompress.cur, 1)
 			return
 		}
 	}

--- a/pkg/transport/client_low.go
+++ b/pkg/transport/client_low.go
@@ -16,13 +16,17 @@ import (
 )
 
 type Client struct {
-	messagesSent     uint64 // atomic - messages successfully sent
-	messagesRetried  uint64 // atomic - retries (first attempt is not a retry, final failure is not a retry)
-	messagesDropped  uint64 // atomic - final failure, does not include semaphore timeout
-	messagesTimedOut uint64 // atomic - messages timed out waiting for a semaphore slot
+	messagesFailMarshal  uint64 // atomic - messages which failed to be marshalled
+	messagesFailCompress uint64 // atomic - messages which failed to be compressed
+	messagesSent         uint64 // atomic - messages successfully sent
+	messagesRetried      uint64 // atomic - retries (first attempt is not a retry, final failure is not a retry)
+	messagesDropped      uint64 // atomic - final failure, does not include semaphore timeout
+	messagesTimedOut     uint64 // atomic - messages timed out waiting for a semaphore slot
 
 	logger        logrus.FieldLogger
+	compress      bool
 	customHeaders map[string]string
+	debugBody     bool
 	requestSem    util.Semaphore
 	userAgent     string
 	backoff       util.BackoffFactory

--- a/pkg/transport/client_low.go
+++ b/pkg/transport/client_low.go
@@ -12,21 +12,36 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/sirupsen/logrus"
 
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/stats"
 	"github.com/atlassian/gostatsd/pkg/util"
 )
 
+// metricTracker is used to hold the current and previous values in a
+// metric. Because the majority of the time failures will be zero, or
+// only have a short-term bursts of activity, we track the last value
+// and trigger sending on change. We'll also repeat a few times after
+// a change as we probably only try to send some of the values during
+// fault conditions.
+type metricTracker struct {
+	cur     uint64 // atomic
+	prev    uint64
+	pending uint64 // number of times to re-send
+}
+
 type Client struct {
-	messagesFailMarshal  uint64 // atomic - messages which failed to be marshalled
-	messagesFailCompress uint64 // atomic - messages which failed to be compressed
-	messagesSent         uint64 // atomic - messages successfully sent
-	messagesRetried      uint64 // atomic - retries (first attempt is not a retry, final failure is not a retry)
-	messagesDropped      uint64 // atomic - final failure, does not include semaphore timeout
-	messagesTimedOut     uint64 // atomic - messages timed out waiting for a semaphore slot
+	messagesDropped      metricTracker // atomic - final failure, does not include semaphore timeout
+	messagesFailCompress metricTracker // atomic - messages which failed to be compressed
+	messagesFailMarshal  metricTracker // atomic - messages which failed to be marshalled
+	messagesRetried      metricTracker // atomic - retries (first attempt is not a retry, final failure is not a retry)
+	messagesSent         metricTracker // atomic - messages successfully sent
+	messagesTimedOut     metricTracker // atomic - messages timed out waiting for a semaphore slot
 
 	logger        logrus.FieldLogger
 	compress      bool
 	customHeaders map[string]string
 	debugBody     bool
+	enableMetrics bool
 	requestSem    util.Semaphore
 	userAgent     string
 	backoff       util.BackoffFactory
@@ -34,11 +49,35 @@ type Client struct {
 	Client *http.Client
 }
 
+func sendMetricIfChanged(statser stats.Statser, metricName string, tags gostatsd.Tags, m *metricTracker) {
+	v := atomic.LoadUint64(&m.cur)
+	if v != m.prev {
+		m.prev = v
+		m.pending = 3 // send this metric for the next 3 intervals
+	}
+	if m.pending > 0 {
+		m.pending--
+		statser.Gauge(metricName, float64(v), tags)
+	}
+}
+
+func (hc *Client) emitMetrics(statser stats.Statser) {
+	if !hc.enableMetrics {
+		return
+	}
+	sendMetricIfChanged(statser, "transport.fail", gostatsd.Tags{"failure:send"}, &hc.messagesDropped)
+	sendMetricIfChanged(statser, "transport.fail", gostatsd.Tags{"failure:compress"}, &hc.messagesFailCompress)
+	sendMetricIfChanged(statser, "transport.fail", gostatsd.Tags{"failure:marshal"}, &hc.messagesFailMarshal)
+	sendMetricIfChanged(statser, "transport.retried", nil, &hc.messagesRetried)
+	sendMetricIfChanged(statser, "transport.sent", nil, &hc.messagesSent)
+	sendMetricIfChanged(statser, "transport.fail", gostatsd.Tags{"failure:mutex"}, &hc.messagesTimedOut)
+}
+
 // PostRaw will start a goroutine (semaphore allowing) which attempts to POST the provided data
 // to the provided URL.  It is fire-and-forget by design.
 func (hc *Client) PostRaw(ctx context.Context, url, contentType, encoding string, headers map[string]string, body []byte) {
 	if !hc.requestSem.Acquire(ctx) {
-		atomic.AddUint64(&hc.messagesTimedOut, 1)
+		atomic.AddUint64(&hc.messagesTimedOut.cur, 1)
 		return
 	}
 
@@ -56,7 +95,7 @@ func (hc *Client) do(ctx context.Context, url, contentType, encoding string, bod
 
 	for {
 		if err = doPost(); err == nil {
-			atomic.AddUint64(&hc.messagesSent, 1)
+			atomic.AddUint64(&hc.messagesSent.cur, 1)
 			return
 		}
 
@@ -71,10 +110,10 @@ func (hc *Client) do(ctx context.Context, url, contentType, encoding string, bod
 			break
 		}
 
-		atomic.AddUint64(&hc.messagesRetried, 1)
+		atomic.AddUint64(&hc.messagesRetried.cur, 1)
 	}
 
-	atomic.AddUint64(&hc.messagesDropped, 1)
+	atomic.AddUint64(&hc.messagesDropped.cur, 1)
 	hc.logger.WithError(err).Info("failed to send, giving up")
 }
 

--- a/pkg/transport/client_test.go
+++ b/pkg/transport/client_test.go
@@ -54,7 +54,7 @@ func TestClientBasicPost(t *testing.T) {
 	p := poolFromConfig(t, "")
 	c, err := p.Get("default")
 	require.NoError(t, err)
-	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", nil, []byte("body"))
+	c.PostRaw(context.Background(), ts.URL+"/test", ContentTypeTextPlain,  EncodingIdentity, nil, []byte("body"))
 	wg.Wait()
 }
 
@@ -89,7 +89,7 @@ func TestClientCallerHeaders(t *testing.T) {
 		"key":        "value",
 		"user-agent": "custom",
 	}
-	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", headers, nil)
+	c.PostRaw(context.Background(), ts.URL+"/test", ContentTypeTextPlain, EncodingIdentity, headers, nil)
 	wg.Wait()
 }
 
@@ -121,7 +121,7 @@ func TestClientUserAddHeaders(t *testing.T) {
 
 	p := poolFromConfig(t, `
 [transport.default]
-custom-headers = {"foo"="bar", "key1"=""}
+custom-headers = {foo="bar", key1=""}
 `)
 	c, err := p.Get("default")
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ custom-headers = {"foo"="bar", "key1"=""}
 		"key2":       "value2",
 		"user-agent": "custom",
 	}
-	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", headers, nil)
+	c.PostRaw(context.Background(), ts.URL+"/test", ContentTypeTextPlain, EncodingIdentity, headers, nil)
 	wg.Wait()
 }
 
@@ -159,6 +159,6 @@ retry-interval='1ns'
 `)
 	c, err := p.Get("default")
 	require.NoError(t, err)
-	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", nil, nil)
+	c.PostRaw(context.Background(), ts.URL+"/test", ContentTypeTextPlain, EncodingIdentity, nil, nil)
 	wg.Wait()
 }

--- a/pkg/transport/client_test.go
+++ b/pkg/transport/client_test.go
@@ -1,0 +1,164 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func poolFromConfig(t *testing.T, config string) *TransportPool {
+	v := viper.New()
+	v.SetConfigType("toml")
+	err := v.ReadConfig(bytes.NewBufferString(config))
+	require.NoError(t, err)
+	p := NewTransportPool(logrus.New(), v)
+	return p
+}
+
+func TestClientBasicPost(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		defer wg.Done()
+
+		// Remove the headers added by the library
+		r.Header.Del("accept-encoding")
+		r.Header.Del("content-length")
+
+		expected := http.Header{}
+		expected.Set("content-type", "text/plain")
+		expected.Set("content-encoding", "identity")
+		expected.Set("user-agent", "gostatsd")
+		require.EqualValues(t, expected, r.Header)
+
+		data, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, r.Body.Close())
+		require.EqualValues(t, "body", string(data))
+		w.WriteHeader(200)
+	})
+	ts := httptest.NewServer(mux)
+
+	p := poolFromConfig(t, "")
+	c, err := p.Get("default")
+	require.NoError(t, err)
+	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", nil, []byte("body"))
+	wg.Wait()
+}
+
+func TestClientCallerHeaders(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		defer wg.Done()
+		// Remove the headers added by the library
+		r.Header.Del("accept-encoding")
+		r.Header.Del("content-length")
+
+		expected := http.Header{}
+		expected.Set("content-type", "text/plain")
+		expected.Set("content-encoding", "identity")
+		expected.Set("user-agent", "custom") // caller override
+		expected.Set("key", "value")         // caller added
+		require.EqualValues(t, expected, r.Header)
+
+		consumeAndClose(r.Body)
+		w.WriteHeader(200)
+	})
+	ts := httptest.NewServer(mux)
+
+	p := poolFromConfig(t, "")
+	c, err := p.Get("default")
+	require.NoError(t, err)
+	headers := map[string]string{
+		"key":        "value",
+		"user-agent": "custom",
+	}
+	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", headers, nil)
+	wg.Wait()
+}
+
+func TestClientUserAddHeaders(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		defer wg.Done()
+		// Remove the headers added by the library
+		r.Header.Del("accept-encoding")
+		r.Header.Del("content-length")
+
+		expected := http.Header{}
+		expected.Set("content-type", "text/plain")
+		expected.Set("content-encoding", "identity")
+		// key1 not present, removed by user
+		expected.Set("key2", "value2")       // caller added
+		expected.Set("user-agent", "custom") // caller added + user override
+		expected.Set("foo", "bar")           // user added
+		require.EqualValues(t, expected, r.Header)
+
+		consumeAndClose(r.Body)
+		w.WriteHeader(200)
+	})
+	ts := httptest.NewServer(mux)
+
+	p := poolFromConfig(t, `
+[transport.default]
+custom-headers = {"foo"="bar", "key1"=""}
+`)
+	c, err := p.Get("default")
+	require.NoError(t, err)
+	headers := map[string]string{
+		"key1":       "value1",
+		"key2":       "value2",
+		"user-agent": "custom",
+	}
+	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", headers, nil)
+	wg.Wait()
+}
+
+func TestClientRetries(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	count := uint64(0)
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		consumeAndClose(r.Body)
+		if atomic.AddUint64(&count, 1) == 2 {
+			w.WriteHeader(200)
+			defer wg.Done()
+		} else {
+			w.WriteHeader(500)
+		}
+	})
+	ts := httptest.NewServer(mux)
+
+	p := poolFromConfig(t, `
+[transport.default]
+retry-policy='constant'
+retry-interval='1ns'
+`)
+	c, err := p.Get("default")
+	require.NoError(t, err)
+	c.PostRaw(context.Background(), ts.URL+"/test", "text/plain", "identity", nil, nil)
+	wg.Wait()
+}

--- a/pkg/transport/helpers.go
+++ b/pkg/transport/helpers.go
@@ -69,11 +69,11 @@ func marshalJson(data interface{}, debug bool) ([]byte, error) {
 		json = jsonConfig
 	}
 	stream := json.BorrowStream(buf)
+	defer json.ReturnStream(stream)
 	stream.WriteVal(data)
 	err := stream.Flush()
 	if err != nil {
 		return nil, err
 	}
-	json.ReturnStream(stream)
 	return buf.Bytes(), nil
 }

--- a/pkg/transport/helpers.go
+++ b/pkg/transport/helpers.go
@@ -1,13 +1,27 @@
 package transport
 
 import (
+	"bytes"
+	"compress/zlib"
 	"context"
 	"io"
 	"io/ioutil"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tilinna/clock"
 )
+
+var jsonConfig = jsoniter.Config{
+	EscapeHTML:  false,
+	SortMapKeys: false,
+}.Froze()
+
+var jsonDebug = jsoniter.Config{
+	EscapeHTML:    false,
+	SortMapKeys:   true,
+	IndentionStep: 4,
+}.Froze()
 
 // interruptableSleep will sleep for the specified duration, or until the context is
 // cancelled, whichever comes first.  Returns true if the sleep completes, false if
@@ -28,4 +42,38 @@ func interruptableSleep(ctx context.Context, d time.Duration) bool {
 func consumeAndClose(r io.ReadCloser) {
 	_, _ = io.Copy(ioutil.Discard, r)
 	_ = r.Close()
+}
+
+func compress(raw []byte) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	compressor, err := zlib.NewWriterLevel(buf, zlib.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+
+	_, _ = compressor.Write(raw) // error is propagated through Close
+	err = compressor.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func marshalJson(data interface{}, debug bool) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	var json jsoniter.API
+	if debug {
+		json = jsonDebug
+	} else {
+		json = jsonConfig
+	}
+	stream := json.BorrowStream(buf)
+	stream.WriteVal(data)
+	err := stream.Flush()
+	if err != nil {
+		return nil, err
+	}
+	json.ReturnStream(stream)
+	return buf.Bytes(), nil
 }

--- a/pkg/transport/helpers.go
+++ b/pkg/transport/helpers.go
@@ -1,0 +1,31 @@
+package transport
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/tilinna/clock"
+)
+
+// interruptableSleep will sleep for the specified duration, or until the context is
+// cancelled, whichever comes first.  Returns true if the sleep completes, false if
+// the context is canceled.
+func interruptableSleep(ctx context.Context, d time.Duration) bool {
+	timer := clock.NewTimer(ctx, d)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// consumeAndClose will read all the data from the provided io.ReadCloser, then close
+// it.  Intended to safely drain HTTP connections.
+func consumeAndClose(r io.ReadCloser) {
+	_, _ = io.Copy(ioutil.Discard, r)
+	_ = r.Close()
+}

--- a/pkg/transport/pool.go
+++ b/pkg/transport/pool.go
@@ -139,8 +139,8 @@ func (tp *TransportPool) newClient(name string) (*Client, error) {
 		return nil, err
 	}
 
-	headers := map[string]string{}
-	headerKeys := []string{}
+	headers := make(map[string]string, len(customHeaders))
+	headerKeys := make([]string, 0, len(customHeaders))
 	for key, value := range customHeaders {
 		headers[http.CanonicalHeaderKey(key)] = value
 		headerKeys = append(headerKeys, key)

--- a/pkg/transport/transport_http.go
+++ b/pkg/transport/transport_http.go
@@ -15,23 +15,24 @@ import (
 // There are other options on http.Transport, but these are the
 // ones which have been configured in gostatsd historically.
 
-const paramHttpDialerKeepAlive = "dialer-keep-alive"
-const paramHttpDialerTimeout = "dialer-timeout"
-const paramHttpEnableHttp2 = "enable-http2"
-const paramHttpIdleConnectionTimeout = "idle-connection-timeout"
-const paramHttpMaxIdleConnections = "max-idle-connections"
-const paramHttpNetwork = "network"
-const paramHttpTLSHandshakeTimeout = "tls-handshake-timeout"
-const paramHttpResponseHeaderTimeout = "response-header-timeout"
+const (
+	paramHttpDialerKeepAlive       = "dialer-keep-alive"
+	paramHttpDialerTimeout         = "dialer-timeout"
+	paramHttpEnableHttp2           = "enable-http2"
+	paramHttpIdleConnectionTimeout = "idle-connection-timeout"
+	paramHttpMaxIdleConnections    = "max-idle-connections"
+	paramHttpNetwork               = "network"
+	paramHttpTLSHandshakeTimeout   = "tls-handshake-timeout"
+	paramHttpResponseHeaderTimeout = "response-header-timeout"
 
-const defaultHttpDialerKeepAlive = 30 * time.Second
-const defaultHttpDialerTimeout = 5 * time.Second
-const defaultHttpEnableHttp2 = false
-const defaultHttpIdleConnectionTimeout = 1 * time.Minute
-const defaultHttpMaxIdleConnections = 50
-const defaultHttpNetwork = "tcp"
-const defaultHttpTLSHandshakeTimeout = 3 * time.Second
-const defaultHttpResponseHeaderTimeout = time.Duration(0)
+	defaultHttpDialerKeepAlive       = 30 * time.Second
+	defaultHttpDialerTimeout         = 5 * time.Second
+	defaultHttpEnableHttp2           = false
+	defaultHttpIdleConnectionTimeout = 1 * time.Minute
+	defaultHttpMaxIdleConnections    = 50
+	defaultHttpNetwork               = "tcp"
+	defaultHttpTLSHandshakeTimeout   = 3 * time.Second
+)
 
 func (tp *TransportPool) newHttpTransport(name string, v *viper.Viper) (*http.Transport, error) {
 	v.SetDefault(paramHttpDialerKeepAlive, defaultHttpDialerKeepAlive)

--- a/pkg/transport/transport_http.go
+++ b/pkg/transport/transport_http.go
@@ -32,6 +32,7 @@ const (
 	defaultHttpMaxIdleConnections    = 50
 	defaultHttpNetwork               = "tcp"
 	defaultHttpTLSHandshakeTimeout   = 3 * time.Second
+	defaultHttpResponseHeaderTimeout = 0
 )
 
 func (tp *TransportPool) newHttpTransport(name string, v *viper.Viper) (*http.Transport, error) {

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/spf13/viper"
+)
+
+const (
+	paramRetryInterval = "retry-interval"  // constant
+	paramRetryMaxCount = "retry-max-count" // constant + exponential
+	paramRetryMaxTime  = "retry-max-time"  // constant + exponential
+	paramRetryPolicy   = "retry-policy"
+
+	defaultRetryInterval = 1 * time.Second  // constant
+	defaultRetryMaxCount = 0                // constant + exponential
+	defaultRetryMaxTime  = 15 * time.Second // constant + exponential
+	defaultRetryPolicy   = policyExponential
+
+	policyConstant    = "constant"
+	policyDisabled    = "disabled"
+	policyExponential = "exponential"
+)
+
+type BackoffFactory func() backoff.BackOff
+
+// NewBackoffFactory creates a new BackoffFactory based on a backoff.ExponentialBackoff
+//
+// backoff.ConstantBackoff appears to be more of a debug/testing backoff policy, rather than a real
+// implementation.  It lacks features such as randomization of interval, and a maximum duration. Therefore,
+// we use a backoff.ExponentialBackOff with a Multiplier of 1.0 as a replacement.
+func NewBackoffFactory(multiplier float64, maxElapsedTime, interval time.Duration, maxRetries uint64) BackoffFactory {
+	return func() backoff.BackOff {
+		bo := backoff.NewExponentialBackOff()
+		bo.Multiplier = multiplier
+		bo.MaxElapsedTime = maxElapsedTime
+		bo.InitialInterval = interval
+		bo.Reset() // Reset is required to make the InitialInterval change take effect.
+		if maxRetries == 0 {
+			return bo
+		}
+		return backoff.WithMaxRetries(bo, maxRetries)
+	}
+}
+
+func GetRetryFromViper(v *viper.Viper) (BackoffFactory, error) {
+	v.SetDefault(paramRetryInterval, defaultRetryInterval) // constant
+	v.SetDefault(paramRetryMaxCount, defaultRetryMaxCount) // constant + exponential
+	v.SetDefault(paramRetryMaxTime, defaultRetryMaxTime)   // constant + exponential
+	v.SetDefault(paramRetryPolicy, defaultRetryPolicy)
+
+	retryInterval := v.GetDuration(paramRetryInterval) // constant
+	retryMaxCount := v.GetInt64(paramRetryMaxCount)    // constant + exponential
+	retryMaxTime := v.GetDuration(paramRetryMaxTime)   // constant + exponential
+	retryPolicy := v.GetString(paramRetryPolicy)
+
+	if retryInterval <= 0 {
+		return nil, errors.New(paramRetryInterval + " must be positive")
+	}
+
+	if retryMaxCount < 0 {
+		return nil, errors.New(paramRetryMaxCount + " must be zero or positive")
+	}
+
+	if retryMaxTime <= 0 {
+		return nil, errors.New(paramRetryMaxTime + " must be positive")
+	}
+
+	switch retryPolicy {
+	case policyDisabled:
+		return func() backoff.BackOff { return &backoff.StopBackOff{} }, nil
+	case policyExponential:
+		return NewBackoffFactory(backoff.DefaultMultiplier, retryMaxTime, backoff.DefaultInitialInterval, uint64(retryMaxCount)), nil
+	case policyConstant:
+		return NewBackoffFactory(1.0, retryMaxTime, retryInterval, uint64(retryMaxCount)), nil
+	default:
+		return nil, fmt.Errorf("%s (%s) not one of %s, %s, or %s", paramRetryPolicy, retryPolicy, policyDisabled, policyConstant, policyExponential)
+	}
+}

--- a/pkg/util/backoff_test.go
+++ b/pkg/util/backoff_test.go
@@ -1,0 +1,121 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// Note: This test suite doesn't validate retry-max-time, as that requires a mock clock to be injected, or real time.
+
+func newByViper(policy string, interval, maxTime time.Duration, maxCount int64) (BackoffFactory, error) {
+	v := viper.New()
+	v.Set(paramRetryInterval, interval)
+	v.Set(paramRetryMaxCount, maxCount)
+	v.Set(paramRetryMaxTime, maxTime)
+	v.Set(paramRetryPolicy, policy)
+	return GetRetryFromViper(v)
+}
+
+func TestDisabledRetries(t *testing.T) {
+	t.Parallel()
+	f, err := newByViper(policyDisabled, 10*time.Second, 10*time.Second, 10)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	bo := f()
+	require.Equal(t, backoff.Stop, bo.NextBackOff())
+}
+
+func TestConstantInterval(t *testing.T) {
+	t.Parallel()
+	f, err := newByViper(policyConstant, 1*time.Second, 10*time.Second, 0)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	bo := f()
+	for i := 0; i < 10; i++ {
+		// Ensure it doesn't start growing
+		d := bo.NextBackOff()
+		require.LessOrEqual(t, uint64(d), uint64(time.Second*2))
+		require.GreaterOrEqual(t, uint64(d), uint64(time.Second/2))
+	}
+}
+
+func TestConstantIntervalMaxCount(t *testing.T) {
+	t.Parallel()
+	f, err := newByViper(policyConstant, 1*time.Second, 10*time.Second, 10)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	bo := f()
+	for i := 0; i < 10; i++ {
+		d := bo.NextBackOff()
+		require.NotEqual(t, backoff.Stop, d)
+	}
+	d := bo.NextBackOff()
+	require.Equal(t, backoff.Stop, d)
+}
+
+func TestExponentialInterval(t *testing.T) {
+	t.Parallel()
+	f, err := newByViper(policyExponential, 1*time.Second, 10*time.Second, 0)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	bo := f()
+	prevInterval := time.Duration(0)
+	for i := 0; i < 10; i++ {
+		// Ensure it grows.  We need the scaling factor to account for the randomization in the interval.
+		d := bo.NextBackOff()
+		require.GreaterOrEqual(t, uint64(d), uint64(prevInterval/2))
+		prevInterval = d
+	}
+}
+
+func TestExponentialIntervalMaxCount(t *testing.T) {
+	t.Parallel()
+	f, err := newByViper(policyExponential, 1*time.Second, 10*time.Second, 10)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	bo := f()
+	prevInterval := time.Duration(0)
+	for i := 0; i < 10; i++ {
+		// Ensure it grows.  We need the scaling factor to account for the randomization in the interval.
+		d := bo.NextBackOff()
+		require.GreaterOrEqual(t, uint64(d), uint64(prevInterval/2))
+		prevInterval = d
+	}
+	d := bo.NextBackOff()
+	require.Equal(t, backoff.Stop, d)
+}
+
+func TestInvalidConfigurations(t *testing.T) {
+	tests := []struct {
+		interval time.Duration
+		maxCount int64
+		maxTime  time.Duration
+		policy   string
+		failure  string
+	}{
+		{-1 * time.Second, 0, 1 * time.Second, policyConstant, paramRetryInterval},
+		{0, 0, 1 * time.Second, policyConstant, paramRetryInterval},
+		{1 * time.Second, -1, 1 * time.Second, policyConstant, paramRetryMaxCount},
+		{1 * time.Second, 0, -1 * time.Second, policyConstant, paramRetryMaxTime},
+		{1 * time.Second, 0, 0, policyConstant, paramRetryMaxTime},
+		{1 * time.Second, 1, 1 * time.Second, "invalid", paramRetryPolicy},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f, err := newByViper(test.policy, test.interval, test.maxTime, test.maxCount)
+			require.Nil(t, f)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.failure)
+		})
+	}
+}

--- a/pkg/util/semaphore.go
+++ b/pkg/util/semaphore.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"context"
+)
+
+// Semaphore provides a semaphore interface with Acquire operations taking a context.
+type Semaphore interface {
+	// Acquire will attempt to acquire a lock on the semaphore.  Returns true if successful, and false is the
+	// context is cancelled.
+	Acquire(ctx context.Context) bool
+	Release()
+}
+
+// NewSemaphore returns a new Semaphore with a capacity of the provided count.  If count is zero, the capacity
+// is unlimited.
+func NewSemaphore(count int) Semaphore {
+	if count == 0 {
+		return &nullSemaphore{}
+	}
+	ch := make(chan struct{}, count)
+	for i := 0; i < count; i++ {
+		ch <- struct{}{}
+	}
+	return &chanSemaphore{
+		sem: ch,
+	}
+}
+
+type chanSemaphore struct {
+	sem chan struct{}
+}
+
+func (c *chanSemaphore) Acquire(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-c.sem:
+		return true
+	}
+
+}
+
+func (c *chanSemaphore) Release() {
+	c.sem <- struct{}{}
+}
+
+type nullSemaphore struct{}
+
+func (ns *nullSemaphore) Acquire(ctx context.Context) bool { return true }
+func (ns *nullSemaphore) Release()                         {}

--- a/pkg/util/semaphore_test.go
+++ b/pkg/util/semaphore_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSemaphoreUnlimited(t *testing.T) {
+	t.Parallel()
 	s := NewSemaphore(0)
 	for i := 0; i < 10; i++ {
 		s.Acquire(context.Background())

--- a/pkg/util/semaphore_test.go
+++ b/pkg/util/semaphore_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemaphoreUnlimited(t *testing.T) {
+	s := NewSemaphore(0)
+	for i := 0; i < 10; i++ {
+		s.Acquire(context.Background())
+	}
+	for i := 0; i < 10; i++ {
+		s.Release()
+	}
+}
+
+func TestSemaphoreNormal(t *testing.T) {
+	t.Parallel()
+	s := NewSemaphore(5)
+	var c uint64
+	var wg sync.WaitGroup
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			s.Acquire(context.Background())
+			ctr := atomic.AddUint64(&c, 1)
+			require.LessOrEqual(t, ctr, uint64(5))
+			atomic.AddUint64(&c, ^uint64(0))
+			s.Release()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSemaphoreCancelled(t *testing.T) {
+	t.Parallel()
+	s := NewSemaphore(1)
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.True(t, s.Acquire(context.Background()))
+	require.False(t, s.Acquire(cancelledContext))
+	s.Release()
+}


### PR DESCRIPTION
This is the next change in the whole transport refactor saga, leading towards streaming (#10, #84, #159), InfluxDB (#14), and clustering.  Nothing here is consumed currently, it's just the primitives.  As it's getting rather large already, I wanted to minimize the review size.  Commits are relatively stand-alone.

This PR is not expected to be merged yet, because there's documentation mismatches (due to lack of consumption).  I'll be working on updating consumers in a subsequent PR, but didn't want to get too deep in to that in case there's feedback on the API (I'm not a huge fan of the `TransportOptions` for example)