### PR TITLE
This fixes TestCloudHandlerExpirationAndRefresh

### DIFF
--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -101,30 +101,49 @@ func TestTransientInstanceFailure(t *testing.T) {
 }
 
 func TestCloudHandlerExpirationAndRefresh(t *testing.T) {
-	t.Parallel()
+	// These still use a real clock, which means they're more susceptible to
+	// CPU load triggering a race condition, therefore there's no t.Parallel()
 	t.Run("4.3.2.1", func(t *testing.T) {
-		testExpire(t, []gostatsd.IP{"4.3.2.1", "4.3.2.1"}, func(h *CloudHandler) {
+		testExpireAndRefresh(t, "4.3.2.1", func(h *CloudHandler) {
 			e := se1()
 			h.DispatchEvent(context.Background(), &e)
 		})
 	})
 	t.Run("1.2.3.4", func(t *testing.T) {
-		testExpire(t, []gostatsd.IP{"1.2.3.4", "1.2.3.4"}, func(h *CloudHandler) {
+		testExpireAndRefresh(t, "1.2.3.4", func(h *CloudHandler) {
 			m := sm1()
 			h.DispatchMetrics(context.Background(), []*gostatsd.Metric{&m})
 		})
 	})
 }
 
-func testExpire(t *testing.T, expectedIps []gostatsd.IP, f func(*CloudHandler)) {
-	t.Parallel()
+func testExpireAndRefresh(t *testing.T, expectedIp gostatsd.IP, f func(*CloudHandler)) {
 	fp := &fakeProviderIP{}
 	counting := &countingHandler{}
+	/*
+		Note: lookup reads in to a batch for up to 10ms
+
+		T+0: IP is sent to lookup
+		T+10: lookup is performed, cached with eviction time = T+10+50=60, refresh time = T+10+10=20
+		T+11: refresh loop, nothing to do
+		T+20: cache entry passes refresh time
+		T+22: refresh loop, cache item is dispatched for refreshing
+		T+32: cache lookup is performed, eviction time is unchanged, refresh time = T+32+10=42
+		T+33: refresh loop, nothing to do
+		T+42: cache entry passes refresh time
+		T+44: refresh loop, cache item is dispatched for refreshing
+		T+54: cache lookup is performed, eviction time is unchanged, refresh time = T+54+10=64
+		T+55: refresh loop, nothing to do
+		T+60: cache entry passes expiry time
+		T+64: cache entry passes refresh time
+		T+65: refresh loop, entry is expired
+		T+70: sleep completes
+	*/
 	ch := NewCloudHandler(fp, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{
-		CacheRefreshPeriod:        100 * time.Millisecond,
-		CacheEvictAfterIdlePeriod: 700 * time.Millisecond,
-		CacheTTL:                  500 * time.Millisecond,
-		CacheNegativeTTL:          500 * time.Millisecond,
+		CacheRefreshPeriod:        11 * time.Millisecond,
+		CacheEvictAfterIdlePeriod: 50 * time.Millisecond,
+		CacheTTL:                  10 * time.Millisecond,
+		CacheNegativeTTL:          100 * time.Millisecond,
 	})
 	var wg wait.Group
 	defer wg.Wait()
@@ -132,13 +151,17 @@ func testExpire(t *testing.T, expectedIps []gostatsd.IP, f func(*CloudHandler)) 
 	defer cancelFunc()
 	wg.StartWithContext(ctx, ch.Run)
 	f(ch)
-	time.Sleep(900 * time.Millisecond) // Should be refreshed couple of times and evicted.
+	time.Sleep(70 * time.Millisecond) // Should be refreshed couple of times and evicted.
 
 	cancelFunc()
 	wg.Wait()
 
-	assert.Equal(t, expectedIps, fp.ips)
-	assert.Zero(t, len(ch.cache))
+	// Cache might refresh multiple times, ensure it only refreshed with the expected IP
+	for _, ip := range fp.ips {
+		assert.Equal(t, expectedIp, ip)
+	}
+	assert.GreaterOrEqual(t, len(fp.ips), 2) // Ensure it does at least 1 lookup + 1 refresh
+	assert.Zero(t, len(ch.cache))            // Ensure it eventually expired
 }
 
 func TestCloudHandlerDispatch(t *testing.T) {

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -136,7 +136,7 @@ func testExpireAndRefresh(t *testing.T, expectedIp gostatsd.IP, f func(*CloudHan
 		T+55: refresh loop, nothing to do
 		T+60: cache entry passes expiry time
 		T+64: cache entry passes refresh time
-		T+65: refresh loop, entry is expired
+		T+66: refresh loop, entry is expired
 		T+70: sleep completes
 	*/
 	ch := NewCloudHandler(fp, counting, logrus.StandardLogger(), rate.NewLimiter(100, 120), &CacheOptions{


### PR DESCRIPTION
The core of this fix is to effectively de-duplicate the list of IPs refreshed, so it doesn't matter if we refresh 2 or 3 times.  However as there was also a 900ms sleep, this also trims that down and adds a
comment explaining the theoretical timing breakdown.  It also serializes the test to try and minimize other CPU load on the test.

The real fix would involve a virtual clock, but that's too much effort for now.

Fixes #111