### PR TITLE
Add support for New Relic's new dimensional metrics pipeline

### DIFF
--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -63,10 +63,12 @@ When `mode` is `legacy`, the graphite backend will emit metrics with the followi
 
 New Relic Backend
 -----------------
-Supports three routes for flushing metrics to New Relic.
-- Directly to the Insights Collector - [Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
-- Via the Infrastructure Agent's inbuilt HTTP Server
-- Directly to the Metric API - [Metric Event API](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api)
+Supports three flush-types for sending metrics to New Relic:
+- `infra` Via the Infrastructure Agent's inbuilt HTTP Server (default)
+- `insights` Directly to the Insights Collector - [Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
+- `metrics` Directly to the Metric API - [Metric Event API](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api)
+
+An attempt will be made to automatically set the `flush-type` based on the address you have configured, [manual configuration](#manual-flush-type-configuration) is also available.
 
 ### [New Relic Insights Event API](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api)
 Sending directly to the Event API alleviates the requirement of needing to have the New Relic Infrastructure Agent.
@@ -135,6 +137,20 @@ http_server_enabled: true
 http_server_host: 127.0.0.1 #(default host)
 http_server_port: 8001 #(default port)
 ```
+
+### Manual Flush Type Configuration
+The `flush-type` attribute can be configured with the following available  options - `insights`, `metrics` or `infra`.
+
+```
+[newrelic]
+    transport = "default"
+	flush-type = "insights" # <-- 
+    address = "https://another-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events"
+    api-key = "yourEventAPIInsertKey"
+```
+
+### Renaming Attributes
+This option is only available for `insights` and `infra` flush-types.
 
 Additional options are available to rename attributes if required.
 ```

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -174,13 +174,13 @@ func newDimensionalMetricSet(n *Client, f *flush, metricName, Type string, Value
 	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
 	metricSet := NRMetric{
+		Name:      metricName,
 		Timestamp: timestamp / 1e9,
+		Attributes: map[string]interface{}{
+			"statsdType": Type,
+		},
 	}
 
-	metricSet.Name = metricName
-	metricSet.Attributes = map[string]interface{}{
-		"statsdType": Type,
-	}
 	n.setTags(tags, metricSet.Attributes)
 	switch Type {
 	case "timer":

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -175,7 +175,7 @@ func newDimensionalMetricSet(n *Client, f *flush, metricName, Type string, Value
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
 	metricSet := NRMetric{
 		Name:      metricName,
-		Timestamp: timestamp / 1e9,
+		Timestamp: int64(timestamp) / 1e9,
 		Attributes: map[string]interface{}{
 			"statsdType": Type,
 		},

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -1,6 +1,10 @@
 package newrelic
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/atlassian/gostatsd"
 )
 
@@ -20,46 +24,102 @@ type timeSeries struct {
 
 // addMetric adds a metric to the series.
 func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string, timestamp gostatsd.Nanotime) {
-	standardMetric := newMetricSet(n, f, name, metricType, value, tags, timestamp)
-	if metricType == "counter" {
-		standardMetric[n.metricPerSecond] = persecond
+	if n.flushType == flushTypeMetrics {
+		metricName := name
+		if metricType == "counter" {
+			perSecondMetric := newMetricSet(n, f, metricName+".per_second", "gauge", persecond, tags, timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, perSecondMetric)
+		}
+		standardMetric := newMetricSet(n, f, name, metricType, value, tags, timestamp)
+		f.ts.Metrics = append(f.ts.Metrics, standardMetric)
+	} else {
+		standardMetric := newMetricSet(n, f, name, metricType, value, tags, timestamp)
+		if metricType == "counter" {
+			standardMetric[n.metricPerSecond] = persecond
+		}
+		f.ts.Metrics = append(f.ts.Metrics, standardMetric)
 	}
-	f.ts.Metrics = append(f.ts.Metrics, standardMetric)
 }
 
 // addMetric adds a timer metric to the series.
 func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Timer, tagsKey, name string) {
 	timerMetric := newMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags, timer.Timestamp)
 
-	if !n.disabledSubtypes.Lower {
-		timerMetric[n.timerMin] = timer.Min
-	}
-	if !n.disabledSubtypes.Upper {
-		timerMetric[n.timerMax] = timer.Max
-	}
-	if !n.disabledSubtypes.Count {
-		timerMetric[n.timerCount] = float64(timer.Count)
-	}
-	if !n.disabledSubtypes.CountPerSecond {
-		timerMetric[n.metricPerSecond] = timer.PerSecond
-	}
-	if !n.disabledSubtypes.Mean {
-		timerMetric[n.timerMean] = timer.Mean
-	}
-	if !n.disabledSubtypes.Median {
-		timerMetric[n.timerMedian] = timer.Median
-	}
-	if !n.disabledSubtypes.StdDev {
-		timerMetric[n.timerStdDev] = timer.StdDev
-	}
-	if !n.disabledSubtypes.Sum {
-		timerMetric[n.timerSum] = timer.Sum
-	}
-	if !n.disabledSubtypes.SumSquares {
-		timerMetric[n.timerSumSquares] = timer.SumSquares
-	}
-	for _, pct := range timer.Percentiles {
-		timerMetric[pct.Str] = pct.Float
+	if n.flushType == "metrics" {
+		timerMetric["value"] = map[string]float64{
+			"count": float64(timer.Count),
+			"sum":   timer.Sum,
+			"min":   timer.Min,
+			"max":   timer.Max,
+		}
+
+		if !n.disabledSubtypes.CountPerSecond {
+			gaugeMetric := newMetricSet(n, f, name+".per_second", "gauge", timer.PerSecond, timer.Tags, timer.Timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+		}
+		if !n.disabledSubtypes.Mean {
+			gaugeMetric := newMetricSet(n, f, name+".mean", "gauge", timer.Mean, timer.Tags, timer.Timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+		}
+		if !n.disabledSubtypes.Median {
+			gaugeMetric := newMetricSet(n, f, name+".median", "gauge", timer.Median, timer.Tags, timer.Timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+		}
+		if !n.disabledSubtypes.StdDev {
+			gaugeMetric := newMetricSet(n, f, name+".std_dev", "gauge", timer.StdDev, timer.Tags, timer.Timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+		}
+		if !n.disabledSubtypes.SumSquares {
+			gaugeMetric := newMetricSet(n, f, name+".sum_squares", "gauge", timer.SumSquares, timer.Tags, timer.Timestamp)
+			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+		}
+
+		// https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md#percentiles
+		// Percentiles MUST be implemented as a set of metrics, one metric for each percentile.
+		// Each metric MUST be a Gauge metric.
+		// Each metric value MUST represent a calculated percentile.
+		// The percentile attribute MUST be included with each metric. This attribute value MUST represent the percentile being measured as a floating-point number within the range [0.0, 100.0].
+		// Each metric name MUST have a ".percentiles" suffix.
+		for _, pct := range timer.Percentiles {
+			lastUnderscore := strings.LastIndex(pct.Str, "_")
+			gaugeMetric := newMetricSet(n, f, fmt.Sprintf("%v.%v.percentiles", name, pct.Str[:lastUnderscore]), "gauge", pct.Float, timer.Tags, timer.Timestamp)
+			percentileResult, err := strconv.ParseFloat(pct.Str[lastUnderscore+1:], 64) // eg. for sum_squares_90 will return 90
+			if err == nil {
+				gaugeMetric["attributes"].(map[string]interface{})["percentile"] = percentileResult
+				f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
+			}
+		}
+	} else {
+		if !n.disabledSubtypes.Lower {
+			timerMetric[n.timerMin] = timer.Min
+		}
+		if !n.disabledSubtypes.Upper {
+			timerMetric[n.timerMax] = timer.Max
+		}
+		if !n.disabledSubtypes.Count {
+			timerMetric[n.timerCount] = float64(timer.Count)
+		}
+		if !n.disabledSubtypes.Sum {
+			timerMetric[n.timerSum] = timer.Sum
+		}
+		if !n.disabledSubtypes.CountPerSecond {
+			timerMetric[n.metricPerSecond] = timer.PerSecond
+		}
+		if !n.disabledSubtypes.Mean {
+			timerMetric[n.timerMean] = timer.Mean
+		}
+		if !n.disabledSubtypes.Median {
+			timerMetric[n.timerMedian] = timer.Median
+		}
+		if !n.disabledSubtypes.StdDev {
+			timerMetric[n.timerStdDev] = timer.StdDev
+		}
+		if !n.disabledSubtypes.SumSquares {
+			timerMetric[n.timerSumSquares] = timer.SumSquares
+		}
+		for _, pct := range timer.Percentiles {
+			timerMetric[pct.Str] = pct.Float
+		}
 	}
 	f.ts.Metrics = append(f.ts.Metrics, timerMetric)
 }
@@ -81,26 +141,48 @@ func (f *flush) finish() {
 
 func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags, timestamp gostatsd.Nanotime) map[string]interface{} {
 	metricSet := map[string]interface{}{}
-	metricSet["interval"] = f.flushIntervalSec
-	metricSet["integration_version"] = integrationVersion
+
 	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
 	metricSet["timestamp"] = timestamp / 1e9
 
-	// New Relic Insights Event API, expects the "Event Type" to be in camel case format as opposed to an underscore with the Infrastructure Payload
-	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
-	// https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample
-	switch n.flushType {
-	case flushTypeInsights:
-		metricSet["eventType"] = n.eventType
-	default:
-		metricSet["event_type"] = n.eventType
-	}
+	if n.flushType == flushTypeMetrics {
+		metricSet["name"] = metricName
+		if metricSet["attributes"] == nil {
+			metricSet["attributes"] = map[string]interface{}{}
+		}
+		metricSet["attributes"].(map[string]interface{})["statsdType"] = Type
+		n.setTags(tags, metricSet["attributes"].(map[string]interface{}))
+		switch Type {
+		case "timer":
+			metricSet["type"] = "summary"
+			metricSet["name"] = metricSet["name"].(string) + ".summary"
+		case "counter":
+			metricSet["type"] = "count"
+			metricSet["value"] = Value
+		case "gauge":
+			metricSet["type"] = Type
+			metricSet["value"] = Value
+		}
+	} else {
+		metricSet["interval"] = f.flushIntervalSec
+		metricSet["integration_version"] = integrationVersion
 
-	metricSet[n.metricType] = Type
-	metricSet[n.metricName] = metricName
-	metricSet[n.metricValue] = Value
-	n.setTags(tags, metricSet)
+		// New Relic Insights Event API, expects the "Event Type" to be in camel case format as opposed to an underscore with the Infrastructure Payload
+		// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
+		// https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample
+
+		switch n.flushType {
+		case flushTypeInsights:
+			metricSet["eventType"] = n.eventType
+		default:
+			metricSet["event_type"] = n.eventType
+		}
+		metricSet[n.metricType] = Type
+		metricSet[n.metricName] = metricName
+		metricSet[n.metricValue] = Value
+		n.setTags(tags, metricSet)
+	}
 
 	return metricSet
 }

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -102,8 +102,14 @@ type NRInfraPayload struct {
 // NRMetricsPayload represents New Relic Metrics Payload format
 // https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/report-metrics-metric-api#new-relic-guidelines
 type NRMetricsPayload struct {
-	Common  map[string]interface{} `json:"common"`
-	Metrics []interface{}          `json:"metrics"`
+	Common  NRMetricsCommon `json:"common"`
+	Metrics []interface{}   `json:"metrics"`
+}
+
+// NRMetricsCommon common attributes to apply for New Relic Metrics Format
+type NRMetricsCommon struct {
+	Attributes map[string]interface{} `json:"attributes"`
+	IntervalMs float64                `json:"interval.ms"`
 }
 
 // SendMetricsAsync flushes the metrics to New Relic, preparing payload synchronously but doing the send asynchronously.
@@ -541,12 +547,12 @@ func newInfraPayload(data interface{}) NRInfraPayload {
 
 func (n *Client) newMetricsPayload(data []interface{}) NRMetricsPayload {
 	return NRMetricsPayload{
-		Common: map[string]interface{}{
-			"attributes": map[string]interface{}{
+		Common: NRMetricsCommon{
+			Attributes: map[string]interface{}{
 				"integration.version": integrationVersion,
 				"integration.name":    "GoStatsD",
 			},
-			"interval.ms": n.flushInterval.Seconds() * 1000,
+			IntervalMs: n.flushInterval.Seconds() * 1000,
 		},
 		Metrics: data,
 	}

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -117,7 +117,7 @@ type NRMetric struct {
 	Name       string                 `json:"name"`
 	Value      interface{}            `json:"value,omitempty"`
 	Type       string                 `json:"type,omitempty"`
-	Timestamp  gostatsd.Nanotime      `json:"timestamp,omitempty"`
+	Timestamp  int64                  `json:"timestamp,omitempty"`
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 	IntervalMs float64                `json:"interval.ms,omitempty"`
 }

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -112,6 +112,16 @@ type NRMetricsCommon struct {
 	IntervalMs float64                `json:"interval.ms"`
 }
 
+// NRMetric metric for New Relic Metrics Format
+type NRMetric struct {
+	Name       string                 `json:"name"`
+	Value      interface{}            `json:"value,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Timestamp  gostatsd.Nanotime      `json:"timestamp,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+	IntervalMs float64                `json:"interval.ms,omitempty"`
+}
+
 // SendMetricsAsync flushes the metrics to New Relic, preparing payload synchronously but doing the send asynchronously.
 func (n *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
 

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -132,12 +132,16 @@ func TestSendMetrics(t *testing.T) {
 			flushType: "metrics",
 			apiKey:    "some-api-key",
 			expected: `[{"common":{"attributes":{"integration.name":"GoStatsD","integration.version":"2.3.0"},"interval.ms":1000},` +
-				`"metrics":[{"attributes":{"statsdType":"gauge","tag3":"true"},"name":"g1","timestamp":0,"type":"gauge","value":3},{"attributes":{"statsdType":"gauge","tag1":"true"},"name":"c1.per_second","timestamp":0,"type":"gauge","value":1.1},` +
-				`{"attributes":{"statsdType":"counter","tag1":"true"},"name":"c1","timestamp":0,"type":"count","value":5},{"attributes":{"statsdType":"set","tag4":"true"},"name":"users","timestamp":0},` +
-				`{"attributes":{"statsdType":"gauge","tag2":"true"},"name":"t1.per_second","timestamp":0,"type":"gauge","value":1.1},{"attributes":{"statsdType":"gauge","tag2":"true"},"name":"t1.mean","timestamp":0,"type":"gauge","value":0.5},` +
-				`{"attributes":{"statsdType":"gauge","tag2":"true"},"name":"t1.median","timestamp":0,"type":"gauge","value":0.5},{"attributes":{"statsdType":"gauge","tag2":"true"},"name":"t1.std_dev","timestamp":0,"type":"gauge","value":0.1},` +
-				`{"attributes":{"statsdType":"gauge","tag2":"true"},"name":"t1.sum_squares","timestamp":0,"type":"gauge","value":1},{"attributes":{"percentile":90,"statsdType":"gauge","tag2":"true"},"name":"t1.count.percentiles","timestamp":0,"type":"gauge","value":0.1},` +
-				`{"attributes":{"statsdType":"timer","tag2":"true"},"name":"t1.summary","timestamp":0,"type":"summary","value":{"count":1,"max":1,"min":0,"sum":1}}]}]`,
+				`"metrics":[{"name":"g1","value":3,"type":"gauge","attributes":{"statsdType":"gauge","tag3":"true"}},` +
+				`{"name":"c1.per_second","value":1.1,"type":"gauge","attributes":{"statsdType":"gauge","tag1":"true"}},` +
+				`{"name":"c1","value":5,"type":"count","attributes":{"statsdType":"counter","tag1":"true"}},` +
+				`{"name":"users","attributes":{"statsdType":"set","tag4":"true"}},{"name":"t1.per_second","value":1.1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.mean","value":0.5,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.median","value":0.5,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.std_dev","value":0.1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.sum_squares","value":1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.count.percentiles","value":0.1,"type":"gauge","attributes":{"percentile":90,"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.summary","value":{"count":1,"max":1,"min":0,"sum":1},"type":"summary","attributes":{"statsdType":"timer","tag2":"true"}}]}]`,
 		},
 	}
 

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -152,7 +152,7 @@ func TestSendMetrics(t *testing.T) {
 			mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 				enc := r.Header.Get("Content-Encoding")
 				var body string
-				body, done := decodeBody(enc, r, t, body)
+				body, done := decodeBody(enc, r, t)
 				if done {
 					return
 				}
@@ -188,7 +188,8 @@ func TestSendMetrics(t *testing.T) {
 
 }
 
-func decodeBody(enc string, r *http.Request, t *testing.T, body string) (string, bool) {
+func decodeBody(enc string, r *http.Request, t *testing.T) (string, bool) {
+	body := ""
 	if enc == "gzip" {
 		gr, err := gzip.NewReader(r.Body)
 		if !assert.NoError(t, err) {

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -44,7 +44,7 @@ func TestRetries(t *testing.T) {
 	v.SetDefault("transport.default.client-timeout", 1*time.Second)
 	p := transport.NewTransportPool(logrus.New(), v)
 
-	client, err := NewClient("default", ts.URL+"/v1/data", "GoStatsD", "", "", "", "metric_name", "metric_type",
+	client, err := NewClient("default", ts.URL+"/v1/data", "", "GoStatsD", "", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
 		defaultMetricsPerBatch, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, p)
@@ -81,7 +81,7 @@ func TestSendMetricsInMultipleBatches(t *testing.T) {
 	v.SetDefault("transport.default.client-timeout", 1*time.Second)
 	p := transport.NewTransportPool(logrus.New(), v)
 
-	client, err := NewClient("default", ts.URL+"/v1/data", "GoStatsD", "", "", "", "metric_name", "metric_type",
+	client, err := NewClient("default", ts.URL+"/v1/data", "", "GoStatsD", "", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
 		1, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, p)
@@ -105,11 +105,11 @@ func TestSendMetrics(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.2.0","data":[{"metrics":` +
-			`[{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
-			`{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
-			`{"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
-			`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.2.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
+		expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.0","data":[{"metrics":` +
+			`[{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
+			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
+			`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
 			`"samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":0}]}]}`
 		assert.Equal(t, expected, string(data))
 	})
@@ -120,7 +120,7 @@ func TestSendMetrics(t *testing.T) {
 	v.SetDefault("transport.default.client-timeout", 1*time.Second)
 	p := transport.NewTransportPool(logrus.New(), v)
 
-	client, err := NewClient("default", ts.URL+"/v1/data", "GoStatsD", "", "", "", "metric_name", "metric_type",
+	client, err := NewClient("default", ts.URL+"/v1/data", "", "GoStatsD", "", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
 		defaultMetricsPerBatch, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, p)
@@ -211,7 +211,7 @@ func TestEventFormatter(t *testing.T) {
 	v.SetDefault("transport.default.client-timeout", 1*time.Second)
 	p := transport.NewTransportPool(logrus.New(), v)
 
-	client, err := NewClient("default", "v1/data", "GoStatsD", "", "", "", "metric_name", "metric_type",
+	client, err := NewClient("default", "v1/data", "", "GoStatsD", "", "", "", "metric_name", "metric_type",
 		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
 		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
 		defaultMetricsPerBatch, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, p)
@@ -222,7 +222,7 @@ func TestEventFormatter(t *testing.T) {
 	fevent, err := json.Marshal(formattedEvent)
 	require.NoError(t, err)
 
-	expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.2.0","data":` +
+	expected := `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.0","data":` +
 		`[{"metrics":[{"AggregationKey":"","AlertType":"","DateHappened":0,"Hostname":"blah","Priority":"low","SourceTypeName":"","Text":"hi","Title":"EventTitle","event_type":"GoStatsD","name":"event"}]}]}`
 
 	require.Equal(t, expected, string(fevent))


### PR DESCRIPTION
Adds support for New Relic's dimensional metrics via the new metric api.

https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api

BACKENDS.md has been updated with additional information as well as relevant tests.