### PR TITLE
Cloud provider refactor

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -52,7 +52,6 @@ Metrics:
 | cloudprovider.cache_refresh_positive        | gauge (cumulative)  |                              | The cumulative number of positive refreshes
 | cloudprovider.cache_refresh_negative        | gauge (cumulative)  |                              | The cumulative number of refreshes which had an error refreshing and used old data
 | cloudprovider.cache_hit                     | gauge (cumulative)  |                              | The cumulative number of cache hits (host was in the cache)
-| cloudprovider.cache_late_hit                | gauge (cumulative)  |                              | The cumulative number of late cache hits (host was not in the cache, but had a lookup
 |                                             |                     |                              | in progress which completed)
 | cloudprovider.cache_miss                    | gauge (cumulative)  |                              | The cumulative number of cache misses
 | cloudprovider.hosts_queued                  | gauge (flush)       | type                         | The absolute number of hosts waiting to be looked up

--- a/backend.go
+++ b/backend.go
@@ -17,6 +17,7 @@ type BackendFactory func(config *viper.Viper, pool *transport.TransportPool) (Ba
 type SendCallback func([]error)
 
 // Backend represents a backend.
+// If Backend implements the Runner interface, it's started in a new goroutine at creation.
 type Backend interface {
 	// Name returns the name of the backend.
 	Name() string

--- a/cloudprovider.go
+++ b/cloudprovider.go
@@ -2,6 +2,7 @@ package gostatsd
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -31,4 +32,31 @@ type CloudProvider interface {
 	SelfIP() (IP, error)
 	// EstimatedTags returns a guess of how many tags are likely to be added by the CloudProvider
 	EstimatedTags() int
+}
+
+type InstanceInfo struct {
+	IP IP
+	// Instance may be nil if the lookup resulted in an error or instance was not found.
+	Instance *Instance
+}
+
+type CachedInstances interface {
+	// Peek fetches instance information from the cache.
+	// The cache is also a negative cache - may be a cache hit but the returned instance is nil.
+	Peek(IP) (*Instance, bool /*is a cache hit*/)
+	// IpSink returns a channel that can be used to supply IP addresses for which information needs
+	// to be fetched and cached.
+	IpSink() chan<- IP
+	// InfoSource returns a channel that can be used to receive information about IPs.
+	InfoSource() <-chan InstanceInfo
+	// EstimatedTags returns a guess for how many tags to pre-allocate
+	EstimatedTags() int
+}
+
+// CacheOptions holds cache behaviour configuration.
+type CacheOptions struct {
+	CacheRefreshPeriod        time.Duration
+	CacheEvictAfterIdlePeriod time.Duration
+	CacheTTL                  time.Duration
+	CacheNegativeTTL          time.Duration
 }

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -8,9 +8,9 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/atlassian/gostatsd/pkg/statsd"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -37,14 +37,14 @@ func main() {
 	}
 	if s.Benchmark != 0 {
 		server := statsd.Server{
-			DefaultTags:      statsd.DefaultTags,
-			ExpiryInterval:   statsd.DefaultExpiryInterval,
-			FlushInterval:    statsd.DefaultFlushInterval,
-			MaxReaders:       statsd.DefaultMaxReaders,
-			MaxWorkers:       statsd.DefaultMaxWorkers,
-			MaxQueueSize:     statsd.DefaultMaxQueueSize,
-			PercentThreshold: statsd.DefaultPercentThreshold,
-			ReceiveBatchSize: statsd.DefaultReceiveBatchSize,
+			DefaultTags:      gostatsd.DefaultTags,
+			ExpiryInterval:   gostatsd.DefaultExpiryInterval,
+			FlushInterval:    gostatsd.DefaultFlushInterval,
+			MaxReaders:       gostatsd.DefaultMaxReaders,
+			MaxWorkers:       gostatsd.DefaultMaxWorkers,
+			MaxQueueSize:     gostatsd.DefaultMaxQueueSize,
+			PercentThreshold: gostatsd.DefaultPercentThreshold,
+			ReceiveBatchSize: gostatsd.DefaultReceiveBatchSize,
 			Viper:            viper.New(),
 		}
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(s.Benchmark)*time.Second)

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider.go
@@ -1,0 +1,261 @@
+package cloudprovider
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ash2k/stager/wait"
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/stats"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+)
+
+func NewCachedCloudProvider(logger logrus.FieldLogger, limiter *rate.Limiter, cloudProvider gostatsd.CloudProvider, cacheOpts gostatsd.CacheOptions) *CachedCloudProvider {
+	return &CachedCloudProvider{
+		logger:         logger,
+		limiter:        limiter,
+		cloudProvider:  cloudProvider,
+		cacheOpts:      cacheOpts,
+		ipSinkSource:   make(chan gostatsd.IP),
+		infoSinkSource: make(chan gostatsd.InstanceInfo),
+		emitChan:       make(chan stats.Statser),
+		cache:          make(map[gostatsd.IP]*instanceHolder),
+	}
+}
+
+type CachedCloudProvider struct {
+	// These fields may only be read or written by the main CachedCloudProvider.Run goroutine
+	statsCacheRefreshPositive uint64 // Cumulative number of positive refreshes (ie, a refresh which succeeded)
+	statsCacheRefreshNegative uint64 // Cumulative number of negative refreshes (ie, a refresh which failed and used old data)
+	statsCachePositive        uint64 // Absolute number of positive entries in cache
+	statsCacheNegative        uint64 // Absolute number of negative entries in cache
+
+	logger         logrus.FieldLogger
+	limiter        *rate.Limiter
+	cloudProvider  gostatsd.CloudProvider
+	cacheOpts      gostatsd.CacheOptions
+	ipSinkSource   chan gostatsd.IP
+	infoSinkSource chan gostatsd.InstanceInfo
+
+	// emitChan triggers a write of all the current stats when it is given a Statser
+	emitChan     chan stats.Statser
+	rw           sync.RWMutex // Protects cache
+	cache        map[gostatsd.IP]*instanceHolder
+	toLookupIPs  []gostatsd.IP
+	toReturnInfo []gostatsd.InstanceInfo
+}
+
+func (ccp *CachedCloudProvider) Run(ctx context.Context) {
+	var (
+		toLookupC     chan<- gostatsd.IP
+		toLookupIP    gostatsd.IP
+		toReturnInfoC chan<- gostatsd.InstanceInfo
+		toReturnInfo  gostatsd.InstanceInfo
+		wg            wait.Group
+	)
+	// this goroutine needs to populate/update the cache so an intermediate InstanceInfo channel is used below that allows
+	// to intercept, update the cache and then push the information through to the cache consumer.
+	ownInfoSource := make(chan gostatsd.InstanceInfo)
+	ld := cloudProviderLookupDispatcher{
+		logger:        ccp.logger,
+		limiter:       ccp.limiter,
+		cloudProvider: ccp.cloudProvider,
+		ipSource:      ccp.ipSinkSource, // our sink is their source
+		infoSink:      ownInfoSource,    // their sink is our source
+	}
+
+	defer wg.Wait() // Wait for cloudProviderLookupDispatcher to stop
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // Tell cloudProviderLookupDispatcher to stop
+
+	wg.StartWithContext(ctx, ld.run)
+
+	refreshTicker := time.NewTicker(ccp.cacheOpts.CacheRefreshPeriod)
+	defer refreshTicker.Stop()
+	// No locking for ccp.cache READ access required - this goroutine owns the object and only it mutates it.
+	// So reads from the same goroutine are always safe (no concurrent mutations).
+	// When we mutate the cache, we hold the exclusive (write) lock to avoid concurrent reads.
+	// When we read from the cache from other goroutines in the Peek() method, we obtain the read lock.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case toLookupC <- toLookupIP:
+			toLookupIP = gostatsd.UnknownIP // enable GC
+			toLookupC = nil                 // ip has been sent; if there is nothing to send, the case is disabled
+		case toReturnInfoC <- toReturnInfo:
+			toReturnInfo = gostatsd.InstanceInfo{} // enable GC
+			toReturnInfoC = nil                    // info has been sent; if there is nothing to send, the case is disabled
+		case info := <-ownInfoSource:
+			ccp.handleInstanceInfo(info)
+		case t := <-refreshTicker.C:
+			ccp.doRefresh(t)
+		case statser := <-ccp.emitChan:
+			ccp.emit(statser)
+		}
+		if toLookupC == nil && len(ccp.toLookupIPs) > 0 {
+			last := len(ccp.toLookupIPs) - 1
+			toLookupIP = ccp.toLookupIPs[last]
+			ccp.toLookupIPs[last] = gostatsd.UnknownIP // enable GC
+			ccp.toLookupIPs = ccp.toLookupIPs[:last]
+			toLookupC = ccp.ipSinkSource
+		}
+		if toReturnInfoC == nil && len(ccp.toReturnInfo) > 0 {
+			last := len(ccp.toReturnInfo) - 1
+			toReturnInfo = ccp.toReturnInfo[last]
+			ccp.toReturnInfo[last] = gostatsd.InstanceInfo{} // enable GC
+			ccp.toReturnInfo = ccp.toReturnInfo[:last]
+			toReturnInfoC = ccp.infoSinkSource
+		}
+	}
+}
+
+func (ccp *CachedCloudProvider) Peek(ip gostatsd.IP) (*gostatsd.Instance, bool /*is a cache hit*/) {
+	ccp.rw.RLock()
+	holder, existsInCache := ccp.cache[ip]
+	ccp.rw.RUnlock()
+	if !existsInCache {
+		return nil, false
+	}
+	holder.updateAccess()
+	return holder.instance, true // can be nil, true
+}
+
+func (ccp *CachedCloudProvider) IpSink() chan<- gostatsd.IP {
+	return ccp.ipSinkSource
+}
+
+func (ccp *CachedCloudProvider) InfoSource() <-chan gostatsd.InstanceInfo {
+	return ccp.infoSinkSource
+}
+
+func (ccp *CachedCloudProvider) EstimatedTags() int {
+	return ccp.cloudProvider.EstimatedTags()
+}
+
+func (ccp *CachedCloudProvider) RunMetrics(ctx context.Context, statser stats.Statser) {
+	// All the channels are unbuffered, so no CSWs
+	flushed, unregister := statser.RegisterFlush()
+	defer unregister()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-flushed:
+			ccp.scheduleEmit(ctx, statser)
+		}
+	}
+}
+
+// scheduleEmit is used to push a request to the main goroutine requesting metrics
+// be emitted.  This is done so we can skip atomic operations on most of our metric
+// counters.  In line with the flush notifier, it is fire and forget and won't block
+func (ccp *CachedCloudProvider) scheduleEmit(ctx context.Context, statser stats.Statser) {
+	select {
+	case ccp.emitChan <- statser:
+		// success
+	case <-ctx.Done():
+		// success-ish
+	default:
+		// at least we tried
+	}
+}
+
+func (ccp *CachedCloudProvider) emit(statser stats.Statser) {
+	// regular
+	statser.Gauge("cloudprovider.cache_positive", float64(ccp.statsCachePositive), nil)
+	statser.Gauge("cloudprovider.cache_negative", float64(ccp.statsCacheNegative), nil)
+	statser.Gauge("cloudprovider.cache_refresh_positive", float64(ccp.statsCacheRefreshPositive), nil)
+	statser.Gauge("cloudprovider.cache_refresh_negative", float64(ccp.statsCacheRefreshNegative), nil)
+}
+
+func (ccp *CachedCloudProvider) doRefresh(t time.Time) {
+	var toDelete []gostatsd.IP
+	now := t.UnixNano()
+	idleNano := ccp.cacheOpts.CacheEvictAfterIdlePeriod.Nanoseconds()
+
+	for ip, holder := range ccp.cache {
+		if now-holder.lastAccess() > idleNano {
+			// Entry was not used recently, remove it.
+			toDelete = append(toDelete, ip)
+			if holder.instance == nil {
+				ccp.statsCacheNegative--
+			} else {
+				ccp.statsCachePositive--
+			}
+		} else if t.After(holder.expires) {
+			// Entry needs a refresh.
+			ccp.toLookupIPs = append(ccp.toLookupIPs, ip)
+		}
+	}
+
+	if len(toDelete) > 0 {
+		ccp.rw.Lock()
+		defer ccp.rw.Unlock()
+		for _, ip := range toDelete {
+			delete(ccp.cache, ip)
+		}
+	}
+}
+
+func (ccp *CachedCloudProvider) handleInstanceInfo(info gostatsd.InstanceInfo) {
+	var ttl time.Duration
+	if info.Instance == nil {
+		ttl = ccp.cacheOpts.CacheNegativeTTL
+	} else {
+		ttl = ccp.cacheOpts.CacheTTL
+	}
+	now := time.Now()
+	newHolder := &instanceHolder{
+		expires:  now.Add(ttl),
+		instance: info.Instance,
+	}
+	currentHolder := ccp.cache[info.IP]
+	if currentHolder == nil {
+		// Not in cache, count it
+		if info.Instance == nil {
+			ccp.statsCacheNegative++
+		} else {
+			ccp.statsCachePositive++
+		}
+		newHolder.lastAccessNano = now.UnixNano()
+	} else {
+		// In cache, don't count it
+		newHolder.lastAccessNano = currentHolder.lastAccess()
+		if info.Instance == nil {
+			// Use the old instance if there was a lookup error.
+			newHolder.instance = currentHolder.instance
+			ccp.statsCacheRefreshNegative++
+		} else {
+			if currentHolder.instance == nil && newHolder.instance != nil {
+				// An entry has flipped from invalid to valid
+				ccp.statsCacheNegative--
+				ccp.statsCachePositive++
+			}
+			ccp.statsCacheRefreshPositive++
+		}
+	}
+	ccp.rw.Lock()
+	ccp.cache[info.IP] = newHolder
+	ccp.rw.Unlock()
+	ccp.toReturnInfo = append(ccp.toReturnInfo, info)
+}
+
+type instanceHolder struct {
+	lastAccessNano int64
+	expires        time.Time          // When this record expires.
+	instance       *gostatsd.Instance // Can be nil if the lookup resulted in an error or instance was not found
+}
+
+func (ih *instanceHolder) updateAccess() {
+	atomic.StoreInt64(&ih.lastAccessNano, time.Now().UnixNano())
+}
+
+func (ih *instanceHolder) lastAccess() int64 {
+	return atomic.LoadInt64(&ih.lastAccessNano)
+}

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider_lookup.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider_lookup.go
@@ -1,36 +1,35 @@
-package statsd
+package cloudprovider
 
 import (
 	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
-
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 
 const (
-	maxLookupIPs  = 32
 	batchDuration = 10 * time.Millisecond
 )
 
-type lookupDispatcher struct {
-	limiter       *rate.Limiter
-	cloud         gostatsd.CloudProvider // Cloud provider interface
-	toLookup      <-chan gostatsd.IP
-	lookupResults chan<- *lookupResult
+type cloudProviderLookupDispatcher struct {
 	logger        logrus.FieldLogger
+	limiter       *rate.Limiter
+	cloudProvider gostatsd.CloudProvider
+	ipSource      <-chan gostatsd.IP
+	infoSink      chan<- gostatsd.InstanceInfo
 }
 
-func (ld *lookupDispatcher) run(ctx context.Context) {
+func (ld *cloudProviderLookupDispatcher) run(ctx context.Context) {
+	maxLookupIPs := ld.cloudProvider.MaxInstancesBatch()
 	ips := make([]gostatsd.IP, 0, maxLookupIPs)
 	var c <-chan time.Time
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case ip := <-ld.toLookup:
+		case ip := <-ld.ipSource:
 			ips = append(ips, ip)
 			if len(ips) >= maxLookupIPs {
 				break // enough ips, exit select
@@ -38,7 +37,7 @@ func (ld *lookupDispatcher) run(ctx context.Context) {
 			if c == nil {
 				c = time.After(batchDuration)
 			}
-			continue // have some more time to collect ips
+			continue // have some more space-time to collect ips
 		case <-c: // time to do the lookup
 		}
 		c = nil
@@ -59,32 +58,22 @@ func (ld *lookupDispatcher) run(ctx context.Context) {
 	}
 }
 
-func (ld *lookupDispatcher) doLookup(ctx context.Context, ips []gostatsd.IP) {
+func (ld *cloudProviderLookupDispatcher) doLookup(ctx context.Context, ips []gostatsd.IP) {
 	// instances may contain partial result even if err != nil
-	instances, err := ld.cloud.Instance(ctx, ips...)
+	instances, err := ld.cloudProvider.Instance(ctx, ips...)
 	if err != nil {
 		// Something bad happened, but process what we have still
 		ld.logger.Infof("Error retrieving instance details from cloud provider: %v", err)
 	}
 	for _, ip := range ips {
-		instance := instances[ip]
-		var res *lookupResult
-		if instance != nil {
-			res = &lookupResult{
-				ip:       ip,
-				instance: instance,
-			}
-
-		} else {
-			res = &lookupResult{
-				ip:       ip,
-				instance: nil,
-			}
+		res := gostatsd.InstanceInfo{
+			IP:       ip,
+			Instance: instances[ip],
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case ld.lookupResults <- res:
+		case ld.infoSink <- res:
 		}
 	}
 }

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider_test.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider_test.go
@@ -1,0 +1,67 @@
+package cloudprovider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ash2k/stager/wait"
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/cloudproviders/fakeprovider"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestCachedCloudProviderExpirationAndRefresh(t *testing.T) {
+	// These still use a real clock, which means they're more susceptible to
+	// CPU load triggering a race condition, therefore there's no t.Parallel()
+	fp := &fakeprovider.IP{}
+	/*
+		Note: lookup reads in to a batch for up to 10ms
+
+		T+0: IP is sent to lookup
+		T+10: lookup is performed, cached with eviction time = T+10+50=60, refresh time = T+10+10=20
+		T+11: refresh loop, nothing to do
+		T+20: cache entry passes refresh time
+		T+22: refresh loop, cache item is dispatched for refreshing
+		T+32: cache lookup is performed, eviction time is unchanged, refresh time = T+32+10=42
+		T+33: refresh loop, nothing to do
+		T+42: cache entry passes refresh time
+		T+44: refresh loop, cache item is dispatched for refreshing
+		T+54: cache lookup is performed, eviction time is unchanged, refresh time = T+54+10=64
+		T+55: refresh loop, nothing to do
+		T+60: cache entry passes expiry time
+		T+64: cache entry passes refresh time
+		T+66: refresh loop, entry is expired
+		T+70: sleep completes
+	*/
+	ci := NewCachedCloudProvider(logrus.StandardLogger(), rate.NewLimiter(100, 120), fp, gostatsd.CacheOptions{
+		CacheRefreshPeriod:        11 * time.Millisecond,
+		CacheEvictAfterIdlePeriod: 50 * time.Millisecond,
+		CacheTTL:                  10 * time.Millisecond,
+		CacheNegativeTTL:          100 * time.Millisecond,
+	})
+	var wg wait.Group
+	defer wg.Wait()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	wg.StartWithContext(ctx, ci.Run)
+	const peekIp gostatsd.IP = "1.2.3.4"
+	instance, exists := ci.Peek(peekIp)
+	require.Nil(t, instance)
+	require.False(t, exists)
+	ci.IpSink() <- peekIp
+	time.Sleep(70 * time.Millisecond) // Should be refreshed couple of times and evicted.
+
+	cancelFunc()
+	wg.Wait()
+
+	// Cache might refresh multiple times, ensure it only refreshed with the expected IP
+	for _, ip := range fp.IPs() {
+		assert.Equal(t, peekIp, ip)
+	}
+	assert.GreaterOrEqual(t, len(fp.IPs()), 2) // Ensure it does at least 1 lookup + 1 refresh
+	assert.Zero(t, len(ci.cache))              // Ensure it eventually expired
+}

--- a/pkg/cachedinstances/factory.go
+++ b/pkg/cachedinstances/factory.go
@@ -1,0 +1,85 @@
+package cachedinstances
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/cachedinstances/cloudprovider"
+	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
+	"github.com/atlassian/gostatsd/pkg/cloudproviders/k8s"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"golang.org/x/time/rate"
+)
+
+var (
+	// defaultCloudProviderCacheValues contains the default cache values for each cloud provider.
+	defaultCloudProviderCacheValues = map[string]gostatsd.CacheOptions{
+		k8s.ProviderName: {
+			// The refresh period is low for k8s provider since there is no network cost to looking up pods
+			CacheRefreshPeriod:        15 * time.Second,
+			CacheEvictAfterIdlePeriod: gostatsd.DefaultCacheEvictAfterIdlePeriod,
+			// TTLs are low for the k8s provider because there is no network cost to doing a refresh of the data
+			// This means we get fresh data every time the refresh period is up
+			CacheTTL:         1 * time.Millisecond,
+			CacheNegativeTTL: 1 * time.Millisecond,
+		},
+		aws.ProviderName: {
+			CacheRefreshPeriod:        gostatsd.DefaultCacheRefreshPeriod,
+			CacheEvictAfterIdlePeriod: gostatsd.DefaultCacheEvictAfterIdlePeriod,
+			CacheTTL:                  gostatsd.DefaultCacheTTL,
+			CacheNegativeTTL:          gostatsd.DefaultCacheNegativeTTL,
+		},
+	}
+
+	// defaultCloudProviderLimiterValues contains the default limiter values for each cloud provider.
+	defaultCloudProviderLimiterValues = map[string]limiterValues{
+		k8s.ProviderName: {
+			// High limit for k8s since we don't make network requests for each data request
+			maxCloudRequests:   10000,
+			burstCloudRequests: 5000,
+		},
+		aws.ProviderName: {
+			maxCloudRequests:   gostatsd.DefaultMaxCloudRequests,
+			burstCloudRequests: gostatsd.DefaultBurstCloudRequests,
+		},
+	}
+)
+
+type limiterValues struct {
+	maxCloudRequests   int
+	burstCloudRequests int
+}
+
+// NewCachedInstancesFromViper initialises a new cached instances.
+func NewCachedInstancesFromViper(logger logrus.FieldLogger, cloudProvider gostatsd.CloudProvider, v *viper.Viper) (gostatsd.CachedInstances, error) {
+	// Cloud provider defaults
+	cloudProviderName := cloudProvider.Name()
+	cpDefaultCacheOpts, ok := defaultCloudProviderCacheValues[cloudProviderName]
+	if !ok {
+		return nil, fmt.Errorf("could not find default cache values for cloud provider %q", cloudProviderName)
+	}
+	cpDefaultLimiterOpts, ok := defaultCloudProviderLimiterValues[cloudProviderName]
+	if !ok {
+		return nil, fmt.Errorf("could not find default cache values for cloud provider %q", cloudProviderName)
+	}
+
+	// Set the defaults in Viper based on the cloud provider values before we manipulate things
+	v.SetDefault(gostatsd.ParamCacheRefreshPeriod, cpDefaultCacheOpts.CacheRefreshPeriod)
+	v.SetDefault(gostatsd.ParamCacheEvictAfterIdlePeriod, cpDefaultCacheOpts.CacheEvictAfterIdlePeriod)
+	v.SetDefault(gostatsd.ParamCacheTTL, cpDefaultCacheOpts.CacheTTL)
+	v.SetDefault(gostatsd.ParamCacheNegativeTTL, cpDefaultCacheOpts.CacheNegativeTTL)
+	v.SetDefault(gostatsd.ParamMaxCloudRequests, cpDefaultLimiterOpts.maxCloudRequests)
+	v.SetDefault(gostatsd.ParamBurstCloudRequests, cpDefaultLimiterOpts.burstCloudRequests)
+
+	// Set the used values based on the defaults merged with any overrides
+	cacheOptions := gostatsd.CacheOptions{
+		CacheRefreshPeriod:        v.GetDuration(gostatsd.ParamCacheRefreshPeriod),
+		CacheEvictAfterIdlePeriod: v.GetDuration(gostatsd.ParamCacheEvictAfterIdlePeriod),
+		CacheTTL:                  v.GetDuration(gostatsd.ParamCacheTTL),
+		CacheNegativeTTL:          v.GetDuration(gostatsd.ParamCacheNegativeTTL),
+	}
+	limiter := rate.NewLimiter(rate.Limit(v.GetInt(gostatsd.ParamMaxCloudRequests)), v.GetInt(gostatsd.ParamBurstCloudRequests))
+	return cloudprovider.NewCachedCloudProvider(logger, limiter, cloudProvider, cacheOptions), nil
+}

--- a/pkg/cloudproviders/cloudproviders.go
+++ b/pkg/cloudproviders/cloudproviders.go
@@ -3,13 +3,11 @@ package cloudproviders
 import (
 	"fmt"
 
-	"github.com/spf13/viper"
-
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/k8s"
-
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // All registered cloud providers.
@@ -18,32 +16,11 @@ var providers = map[string]gostatsd.CloudProviderFactory{
 	k8s.ProviderName: k8s.NewProviderFromViper,
 }
 
-// Get creates an instance of the named provider, or nil if
-// the name is not known.  The error return is only used if the named provider
-// was known but failed to initialize.
-func Get(name string, v *viper.Viper, logger logrus.FieldLogger, version string) (gostatsd.CloudProvider, error) {
+// Get creates an instance of the named provider.
+func Get(logger logrus.FieldLogger, name string, v *viper.Viper, version string) (gostatsd.CloudProvider, error) {
 	f, found := providers[name]
 	if !found {
-		return nil, nil
-	}
-	return f(v, logger, version)
-}
-
-// Init creates an instance of the named cloud provider.
-func Init(name string, v *viper.Viper, logger logrus.FieldLogger, version string) (gostatsd.CloudProvider, error) {
-	if name == "" {
-		logrus.Info("No cloud provider specified")
-		return nil, nil
-	}
-
-	provider, err := Get(name, v, logger.WithField("cloud_provider", name), version)
-	if err != nil {
-		return nil, fmt.Errorf("could not init cloud provider %q: %v", name, err)
-	}
-	if provider == nil {
 		return nil, fmt.Errorf("unknown cloud provider %q", name)
 	}
-	logrus.Infof("Initialised cloud provider %q", name)
-
-	return provider, nil
+	return f(v, logger.WithField("cloud_provider", name), version)
 }

--- a/pkg/cloudproviders/fakeprovider/fake.go
+++ b/pkg/cloudproviders/fakeprovider/fake.go
@@ -1,0 +1,154 @@
+package fakeprovider
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/atlassian/gostatsd"
+)
+
+type Counting struct {
+	mu          sync.Mutex
+	ips         []gostatsd.IP
+	invocations uint64
+}
+
+func (fp *Counting) IPs() []gostatsd.IP {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	result := make([]gostatsd.IP, len(fp.ips))
+	copy(result, fp.ips)
+	return result
+}
+
+func (fp *Counting) EstimatedTags() int {
+	return 0
+}
+
+func (fp *Counting) MaxInstancesBatch() int {
+	return 16
+}
+
+func (fp *Counting) Invocations() uint64 {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return fp.invocations
+}
+
+func (fp *Counting) count(ips ...gostatsd.IP) {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	fp.ips = append(fp.ips, ips...)
+	fp.invocations++
+}
+
+func (fp *Counting) SelfIP() (gostatsd.IP, error) {
+	return gostatsd.UnknownIP, nil
+}
+
+type IP struct {
+	Counting
+	Region string
+	Tags   gostatsd.Tags
+}
+
+func (fp *IP) Name() string {
+	return "FakeProviderIP"
+}
+
+func (fp *IP) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
+	fp.count(ips...)
+	instances := make(map[gostatsd.IP]*gostatsd.Instance, len(ips))
+	for _, ip := range ips {
+		instances[ip] = &gostatsd.Instance{
+			ID:   "i-" + string(ip),
+			Tags: fp.Tags,
+		}
+	}
+	return instances, nil
+}
+
+type NotFound struct {
+	Counting
+}
+
+func (fp *NotFound) Name() string {
+	return "FakeProviderNotFound"
+}
+
+func (fp *NotFound) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
+	fp.count(ips...)
+	return nil, nil
+}
+
+type Failing struct {
+	Counting
+}
+
+func (fp *Failing) Name() string {
+	return "FakeFailingProvider"
+}
+
+func (fp *Failing) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
+	fp.count(ips...)
+	return nil, errors.New("clear skies, no clouds available")
+}
+
+type Transient struct {
+	call        uint64
+	FailureMode []int
+}
+
+func (fpt *Transient) Name() string {
+	return "FakeProviderTransient"
+}
+
+func (fpt *Transient) EstimatedTags() int {
+	return 1
+}
+
+func (fpt *Transient) MaxInstancesBatch() int {
+	return 1
+}
+
+func (fpt *Transient) SelfIP() (gostatsd.IP, error) {
+	return gostatsd.UnknownIP, nil
+}
+
+// Instance emulates a lookup based on the supplied criteria.
+// A failure mode of 0 is a successful lookup
+// A failure mode of 1 is nil instance, no error (lookup failure)
+// A failure mode of 2 is nil instance, with error
+// Repeats the last specified failure mode
+func (fpt *Transient) Instance(ctx context.Context, ips ...gostatsd.IP) (map[gostatsd.IP]*gostatsd.Instance, error) {
+	r := make(map[gostatsd.IP]*gostatsd.Instance)
+
+	c := atomic.AddUint64(&fpt.call, 1) - 1
+	if c >= uint64(len(fpt.FailureMode)) {
+		c = uint64(len(fpt.FailureMode) - 1)
+	}
+	switch fpt.FailureMode[c] {
+	case 0:
+		for _, ip := range ips {
+			r[ip] = &gostatsd.Instance{
+				ID:   string(ip),
+				Tags: gostatsd.Tags{"tag:value"},
+			}
+		}
+		return r, nil
+	case 1:
+		for _, ip := range ips {
+			r[ip] = nil
+		}
+		return r, nil
+	case 2:
+		for _, ip := range ips {
+			r[ip] = nil
+		}
+		return r, errors.New("failure mode 2")
+	default:
+		panic("fake misuse")
+	}
+}

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -2,176 +2,52 @@ package statsd
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/cloudproviders"
-	"github.com/atlassian/gostatsd/pkg/stats"
-
-	"github.com/ash2k/stager"
 	"github.com/ash2k/stager/wait"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"golang.org/x/time/rate"
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/stats"
 )
-
-type lookupResult struct {
-	ip       gostatsd.IP
-	instance *gostatsd.Instance // Can be nil if lookup failed or instance was not found
-}
-
-type instanceHolder struct {
-	lastAccessNano int64
-	expires        time.Time          // When this record expires.
-	instance       *gostatsd.Instance // Can be nil if the lookup resulted in an error or instance was not found
-}
-
-func (ih *instanceHolder) updateAccess() {
-	atomic.StoreInt64(&ih.lastAccessNano, time.Now().UnixNano())
-}
-
-func (ih *instanceHolder) lastAccess() int64 {
-	return atomic.LoadInt64(&ih.lastAccessNano)
-}
-
-// CacheOptions holds cache behaviour configuration.
-type CacheOptions struct {
-	CacheRefreshPeriod        time.Duration
-	CacheEvictAfterIdlePeriod time.Duration
-	CacheTTL                  time.Duration
-	CacheNegativeTTL          time.Duration
-}
-
-// CloudHandlerFactory creates a CloudHandler based on some predefined options.
-type CloudHandlerFactory struct {
-	cloudProviderName string
-	version           string
-	cloudProvider     gostatsd.CloudProvider
-	logger            logrus.FieldLogger
-	limiter           *rate.Limiter
-	cacheOptions      CacheOptions
-}
-
-// newCloudHandlerFactory initialises a new cloud handler factory
-func newCloudHandlerFactory(cloudProviderName string, logger logrus.FieldLogger, cacheOptions CacheOptions, limiter *rate.Limiter, version string) *CloudHandlerFactory {
-	return &CloudHandlerFactory{
-		cacheOptions:      cacheOptions,
-		logger:            logger,
-		limiter:           limiter,
-		cloudProvider:     nil,
-		cloudProviderName: cloudProviderName,
-		version:           version,
-	}
-}
-
-// NewCloudHandlerFactoryFromViper initialises a new cloud handler factory with defaults based on the name of the cloud
-// provider requested.
-func NewCloudHandlerFactoryFromViper(v *viper.Viper, logger logrus.FieldLogger, version string) (*CloudHandlerFactory, error) {
-	cloudProviderName := v.GetString(ParamCloudProvider)
-	if cloudProviderName == "" {
-		return nil, nil
-	}
-
-	if _, ok := DefaultCloudProviderCacheValues[cloudProviderName]; !ok {
-		return nil, fmt.Errorf("unknown cloud provider %q", cloudProviderName)
-	}
-
-	// Cloud provider defaults
-	cpDefaultCacheOpts := DefaultCloudProviderCacheValues[cloudProviderName]
-	cpDefaultLimiterOpts := DefaultCloudProviderLimiterValues[cloudProviderName]
-
-	// Set the defaults in Viper based on the cloud provider values before we manipulate things
-	v.SetDefault(ParamCacheRefreshPeriod, cpDefaultCacheOpts.CacheRefreshPeriod)
-	v.SetDefault(ParamCacheEvictAfterIdlePeriod, cpDefaultCacheOpts.CacheEvictAfterIdlePeriod)
-	v.SetDefault(ParamCacheTTL, cpDefaultCacheOpts.CacheTTL)
-	v.SetDefault(ParamCacheNegativeTTL, cpDefaultCacheOpts.CacheNegativeTTL)
-	v.SetDefault(ParamMaxCloudRequests, cpDefaultLimiterOpts.MaxCloudRequests)
-	v.SetDefault(ParamBurstCloudRequests, cpDefaultLimiterOpts.BurstCloudRequests)
-
-	// Set the used values based on the defaults merged with any overrides
-	cacheOptions := CacheOptions{
-		CacheRefreshPeriod:        v.GetDuration(ParamCacheRefreshPeriod),
-		CacheEvictAfterIdlePeriod: v.GetDuration(ParamCacheEvictAfterIdlePeriod),
-		CacheTTL:                  v.GetDuration(ParamCacheTTL),
-		CacheNegativeTTL:          v.GetDuration(ParamCacheNegativeTTL),
-	}
-	limiter := rate.NewLimiter(rate.Limit(v.GetInt(ParamMaxCloudRequests)), v.GetInt(ParamBurstCloudRequests))
-	return newCloudHandlerFactory(cloudProviderName, logger, cacheOptions, limiter, version), nil
-}
-
-// InitCloudProvider initialises the cloud provider given some already parsed defaults.
-// This is mainly split out to enable testing the config parsing separately from the cloud providers.
-func (f *CloudHandlerFactory) InitCloudProvider(v *viper.Viper) error {
-	cloudProvider, err := cloudproviders.Init(f.cloudProviderName, v, f.logger, f.version)
-	if err != nil {
-		return err
-	}
-	f.cloudProvider = cloudProvider
-	return nil
-}
-
-// NewCloudHandler creates a new Cloud Handler based on the options set in the CloudHandlerFactory.
-func (f *CloudHandlerFactory) NewCloudHandler(handler gostatsd.PipelineHandler) *CloudHandler {
-	return NewCloudHandler(f.cloudProvider, handler, f.logger, f.limiter, f.cacheOptions)
-}
 
 // CloudHandler enriches metrics and events with additional information fetched from cloud provider.
 type CloudHandler struct {
-	// statsCacheHit is accessed by any go routine, must use atomic ops
-	statsCacheHit uint64 // Cumulative number of cache hits
+	// These fields are accessed by any go routine, must use atomic ops
+	statsCacheHit  uint64 // Cumulative number of cache hits
+	statsCacheMiss uint64 // Cumulative number of cache misses
 
 	// All other stats fields may only be read or written by the main CloudHandler.Run goroutine
-	statsCacheLateHit         uint64 // Cumulative number of late cache hits
-	statsCacheMiss            uint64 // Cumulative number of cache misses
-	statsCachePositive        uint64 // Absolute number of positive entries in cache
-	statsCacheNegative        uint64 // Absolute number of negative entries in cache
-	statsCacheRefreshPositive uint64 // Cumulative number of positive refreshes (ie, a refresh which succeeded)
-	statsCacheRefreshNegative uint64 // Cumulative number of negative refreshes (ie, a refresh which failed and used old data)
-	statsMetricItemsQueued    uint64 // Absolute number of metrics queued, waiting for a CP to respond
-	statsMetricHostsQueued    uint64 // Absolute number of IPs waiting for a CP to respond for metrics
-	statsEventItemsQueued     uint64 // Absolute number of events queued, waiting for a CP to respond
-	statsEventHostsQueued     uint64 // Absolute number of IPs waiting for a CP to respond for events
+	statsMetricItemsQueued uint64 // Absolute number of metrics queued, waiting for a CP to respond
+	statsMetricHostsQueued uint64 // Absolute number of IPs waiting for a CP to respond for metrics
+	statsEventItemsQueued  uint64 // Absolute number of events queued, waiting for a CP to respond
+	statsEventHostsQueued  uint64 // Absolute number of IPs waiting for a CP to respond for events
+
+	cachedInstances gostatsd.CachedInstances
+	handler         gostatsd.PipelineHandler
+	incomingMetrics chan []*gostatsd.Metric
+	incomingEvents  chan *gostatsd.Event
 
 	// emitChan triggers a write of all the current stats when it is given a Statser
-	emitChan chan stats.Statser
-
-	cacheOpts       CacheOptions
-	cloud           gostatsd.CloudProvider // Cloud provider interface
-	handler         gostatsd.PipelineHandler
-	limiter         *rate.Limiter
-	metricSource    chan []*gostatsd.Metric
-	eventSource     chan *gostatsd.Event
+	emitChan        chan stats.Statser
 	awaitingEvents  map[gostatsd.IP][]*gostatsd.Event
 	awaitingMetrics map[gostatsd.IP][]*gostatsd.Metric
 	toLookupIPs     []gostatsd.IP
 	wg              sync.WaitGroup
 
-	rw    sync.RWMutex // Protects cache
-	cache map[gostatsd.IP]*instanceHolder
-
-	logger logrus.FieldLogger
-
 	estimatedTags int
 }
 
 // NewCloudHandler initialises a new cloud handler.
-func NewCloudHandler(cloud gostatsd.CloudProvider, handler gostatsd.PipelineHandler, logger logrus.FieldLogger, limiter *rate.Limiter, cacheOptions CacheOptions) *CloudHandler {
+func NewCloudHandler(cachedInstances gostatsd.CachedInstances, handler gostatsd.PipelineHandler) *CloudHandler {
 	return &CloudHandler{
-		cacheOpts:       cacheOptions,
-		cloud:           cloud,
+		cachedInstances: cachedInstances,
 		handler:         handler,
-		limiter:         limiter,
-		metricSource:    make(chan []*gostatsd.Metric),
-		eventSource:     make(chan *gostatsd.Event),
+		incomingMetrics: make(chan []*gostatsd.Metric),
+		incomingEvents:  make(chan *gostatsd.Event),
 		emitChan:        make(chan stats.Statser),
 		awaitingEvents:  make(map[gostatsd.IP][]*gostatsd.Event),
 		awaitingMetrics: make(map[gostatsd.IP][]*gostatsd.Metric),
-		cache:           make(map[gostatsd.IP]*instanceHolder),
-		estimatedTags:   handler.EstimatedTags() + cloud.EstimatedTags(),
-		logger:          logger,
+		estimatedTags:   handler.EstimatedTags() + cachedInstances.EstimatedTags(),
 	}
 }
 
@@ -185,7 +61,6 @@ func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd
 	var toHandle []*gostatsd.Metric
 	for _, m := range metrics {
 		if ch.updateTagsAndHostname(m.SourceIP, &m.Tags, &m.Hostname) {
-			atomic.AddUint64(&ch.statsCacheHit, 1)
 			toDispatch = append(toDispatch, m)
 		} else {
 			toHandle = append(toHandle, m)
@@ -199,7 +74,7 @@ func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd
 	if len(toHandle) > 0 {
 		select {
 		case <-ctx.Done():
-		case ch.metricSource <- toHandle:
+		case ch.incomingMetrics <- toHandle:
 		}
 	}
 }
@@ -214,7 +89,6 @@ func (ch *CloudHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.Metr
 
 func (ch *CloudHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	if ch.updateTagsAndHostname(e.SourceIP, &e.Tags, &e.Hostname) {
-		atomic.AddUint64(&ch.statsCacheHit, 1)
 		ch.handler.DispatchEvent(ctx, e)
 		return
 	}
@@ -222,7 +96,7 @@ func (ch *CloudHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	select {
 	case <-ctx.Done():
 		ch.wg.Done()
-	case ch.eventSource <- e:
+	case ch.incomingEvents <- e:
 	}
 }
 
@@ -233,7 +107,7 @@ func (ch *CloudHandler) WaitForEvents() {
 }
 
 func (ch *CloudHandler) RunMetrics(ctx context.Context, statser stats.Statser) {
-	if me, ok := ch.cloud.(MetricEmitter); ok {
+	if me, ok := ch.cachedInstances.(MetricEmitter); ok {
 		var wg wait.Group
 		defer wg.Wait()
 		wg.Start(func() {
@@ -272,13 +146,7 @@ func (ch *CloudHandler) scheduleEmit(ctx context.Context, statser stats.Statser)
 func (ch *CloudHandler) emit(statser stats.Statser) {
 	// atomic
 	statser.Gauge("cloudprovider.cache_hit", float64(atomic.LoadUint64(&ch.statsCacheHit)), nil)
-	// regular
-	statser.Gauge("cloudprovider.cache_late_hit", float64(ch.statsCacheLateHit), nil)
-	statser.Gauge("cloudprovider.cache_miss", float64(ch.statsCacheMiss), nil)
-	statser.Gauge("cloudprovider.cache_positive", float64(ch.statsCachePositive), nil)
-	statser.Gauge("cloudprovider.cache_negative", float64(ch.statsCacheNegative), nil)
-	statser.Gauge("cloudprovider.cache_refresh_positive", float64(ch.statsCacheRefreshPositive), nil)
-	statser.Gauge("cloudprovider.cache_refresh_negative", float64(ch.statsCacheRefreshNegative), nil)
+	statser.Gauge("cloudprovider.cache_miss", float64(atomic.LoadUint64(&ch.statsCacheMiss)), nil)
 	t := gostatsd.Tags{"type:metric"}
 	statser.Gauge("cloudprovider.hosts_queued", float64(ch.statsMetricHostsQueued), t)
 	statser.Gauge("cloudprovider.items_queued", float64(ch.statsMetricItemsQueued), t)
@@ -288,58 +156,27 @@ func (ch *CloudHandler) emit(statser stats.Statser) {
 }
 
 func (ch *CloudHandler) Run(ctx context.Context) {
-	// IPs to lookup. Can make the channel bigger or smaller but this is the perfect size.
-	toLookup := make(chan gostatsd.IP, ch.cloud.MaxInstancesBatch())
-	var toLookupC chan<- gostatsd.IP
-	var toLookupIP gostatsd.IP
-
-	lookupResults := make(chan *lookupResult)
-
-	ld := lookupDispatcher{
-		limiter:       ch.limiter,
-		cloud:         ch.cloud,
-		toLookup:      toLookup,
-		lookupResults: lookupResults,
-		logger:        ch.logger,
-	}
-
-	// Stager will perform ordered, graceful shutdown. Stage by stage in reverse startup order.
-	stgr := stager.New()
-	defer stgr.Shutdown() // Wait for CloudProvider and lookupDispatcher to stop
-
-	stage := stgr.NextStage()
-
-	// If the cloud provider implements runnable, it has things to do. It must start before anything that
-	// accesses it
-	if ch.cloud != nil {
-		if r, ok := ch.cloud.(gostatsd.Runner); ok {
-			go r.Run(ctx) // fork
-		}
-	}
-
-	stage.StartWithContext(ld.run) // Start the lookup mechanism
-
-	refreshTicker := time.NewTicker(ch.cacheOpts.CacheRefreshPeriod)
-	defer refreshTicker.Stop()
-	// No locking for ch.cache READ access required - this goroutine owns the object and only it mutates it.
-	// So reads from the same goroutine are always safe (no concurrent mutations).
-	// When we mutate the cache, we hold the exclusive (write) lock to avoid concurrent reads.
-	// When we read from the cache from other goroutines, we obtain the read lock.
+	var (
+		toLookupC  chan<- gostatsd.IP
+		toLookupIP gostatsd.IP
+	)
+	infoSource := ch.cachedInstances.InfoSource()
+	ipSink := ch.cachedInstances.IpSink()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case toLookupC <- toLookupIP:
-			toLookupIP = gostatsd.UnknownIP
-			toLookupC = nil // ip has been sent; if there is nothing to send, will block
-		case lr := <-lookupResults:
-			ch.handleLookupResult(ctx, lr)
-		case t := <-refreshTicker.C:
-			ch.doRefresh(ctx, t)
-		case metrics := <-ch.metricSource:
-			ch.handleMetrics(ctx, metrics)
-		case e := <-ch.eventSource:
-			ch.handleEvent(ctx, e)
+			toLookupIP = gostatsd.UnknownIP // Enable GC
+			toLookupC = nil                 // ip has been sent; if there is nothing to send, will block
+		case info := <-infoSource:
+			ch.handleInstanceInfo(ctx, info)
+		case metrics := <-ch.incomingMetrics:
+			// Add metrics to awaitingMetrics, accumulate IPs to lookup
+			ch.handleIncomingMetrics(metrics)
+		case e := <-ch.incomingEvents:
+			// Add event to awaitingEvents, accumulate IPs to lookup
+			ch.handleIncomingEvent(e)
 		case statser := <-ch.emitChan:
 			ch.emit(statser)
 		}
@@ -348,125 +185,50 @@ func (ch *CloudHandler) Run(ctx context.Context) {
 			toLookupIP = ch.toLookupIPs[last]
 			ch.toLookupIPs[last] = gostatsd.UnknownIP // Enable GC
 			ch.toLookupIPs = ch.toLookupIPs[:last]
-			toLookupC = toLookup
+			toLookupC = ipSink
 		}
 	}
 }
 
-func (ch *CloudHandler) doRefresh(ctx context.Context, t time.Time) {
-	var toDelete []gostatsd.IP
-	now := t.UnixNano()
-	idleNano := ch.cacheOpts.CacheEvictAfterIdlePeriod.Nanoseconds()
-
-	for ip, holder := range ch.cache {
-		if now-holder.lastAccess() > idleNano {
-			// Entry was not used recently, remove it.
-			toDelete = append(toDelete, ip)
-			if holder.instance == nil {
-				ch.statsCacheNegative--
-			} else {
-				ch.statsCachePositive--
-			}
-		} else if t.After(holder.expires) {
-			// Entry needs a refresh.
-			ch.toLookupIPs = append(ch.toLookupIPs, ip)
-		}
-	}
-
-	if len(toDelete) > 0 {
-		ch.rw.Lock()
-		defer ch.rw.Unlock()
-		for _, ip := range toDelete {
-			delete(ch.cache, ip)
-		}
-	}
-}
-
-func (ch *CloudHandler) handleLookupResult(ctx context.Context, lr *lookupResult) {
-	var ttl time.Duration
-	if lr.instance == nil {
-		ttl = ch.cacheOpts.CacheNegativeTTL
-	} else {
-		ttl = ch.cacheOpts.CacheTTL
-	}
-	now := time.Now()
-	newHolder := &instanceHolder{
-		expires:  now.Add(ttl),
-		instance: lr.instance,
-	}
-	currentHolder := ch.cache[lr.ip]
-	if currentHolder == nil {
-		// Not in cache, count it
-		if lr.instance == nil {
-			ch.statsCacheNegative++
-		} else {
-			ch.statsCachePositive++
-		}
-		newHolder.lastAccessNano = now.UnixNano()
-	} else {
-		// In cache, don't count it
-		newHolder.lastAccessNano = currentHolder.lastAccess()
-		if lr.instance == nil {
-			// Use the old instance if there was a lookup error.
-			newHolder.instance = currentHolder.instance
-			ch.statsCacheRefreshNegative++
-		} else {
-			if currentHolder.instance == nil && newHolder.instance != nil {
-				// An entry has flipped from invalid to valid
-				ch.statsCacheNegative--
-				ch.statsCachePositive++
-			}
-			ch.statsCacheRefreshPositive++
-		}
-	}
-	func() {
-		ch.rw.Lock()
-		defer ch.rw.Unlock()
-		ch.cache[lr.ip] = newHolder
-	}()
-	metrics := ch.awaitingMetrics[lr.ip]
-	if metrics != nil {
-		delete(ch.awaitingMetrics, lr.ip)
+func (ch *CloudHandler) handleInstanceInfo(ctx context.Context, info gostatsd.InstanceInfo) {
+	metrics := ch.awaitingMetrics[info.IP]
+	if len(metrics) > 0 {
+		delete(ch.awaitingMetrics, info.IP)
 		ch.statsMetricItemsQueued -= uint64(len(metrics))
 		ch.statsMetricHostsQueued--
-		go ch.updateAndDispatchMetrics(ctx, lr.instance, metrics)
+		go ch.updateAndDispatchMetrics(ctx, info.Instance, metrics)
 	}
-	events := ch.awaitingEvents[lr.ip]
-	if events != nil {
-		delete(ch.awaitingEvents, lr.ip)
+	events := ch.awaitingEvents[info.IP]
+	if len(events) > 0 {
+		delete(ch.awaitingEvents, info.IP)
 		ch.statsEventItemsQueued -= uint64(len(events))
 		ch.statsEventHostsQueued--
-		go ch.updateAndDispatchEvents(ctx, lr.instance, events)
+		go ch.updateAndDispatchEvents(ctx, info.Instance, events)
 	}
 }
 
-func (ch *CloudHandler) handleMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
-	var toDispatch []*gostatsd.Metric
+func (ch *CloudHandler) handleIncomingMetrics(metrics []*gostatsd.Metric) {
 	for _, m := range metrics {
-		holder, ok := ch.cache[m.SourceIP]
-		if ok {
-			// While metric was in the queue the cache was primed. Use the value.
-			ch.statsCacheLateHit++
-			holder.updateAccess()
-			updateInplace(&m.Tags, &m.Hostname, holder.instance)
-			toDispatch = append(toDispatch, m)
-		} else {
-			// Still nothing in the cache.
-			queue := ch.awaitingMetrics[m.SourceIP]
-			ch.awaitingMetrics[m.SourceIP] = append(queue, m)
-			if len(queue) == 0 {
-				// This is the first metric in the queue
-				ch.toLookupIPs = append(ch.toLookupIPs, m.SourceIP)
-				ch.statsMetricHostsQueued++
-			}
-			ch.statsMetricItemsQueued++
-			ch.statsCacheMiss++
+		queue := ch.awaitingMetrics[m.SourceIP]
+		ch.awaitingMetrics[m.SourceIP] = append(queue, m)
+		if len(queue) == 0 && len(ch.awaitingEvents[m.SourceIP]) == 0 {
+			// This is the first metric for that IP in the queue. Need to fetch an Instance for this IP.
+			ch.toLookupIPs = append(ch.toLookupIPs, m.SourceIP)
+			ch.statsMetricHostsQueued++
 		}
 	}
+	ch.statsMetricItemsQueued += uint64(len(metrics))
+}
 
-	if len(toDispatch) > 0 {
-		go ch.handler.DispatchMetrics(ctx, toDispatch)
+func (ch *CloudHandler) handleIncomingEvent(e *gostatsd.Event) {
+	queue := ch.awaitingEvents[e.SourceIP]
+	ch.awaitingEvents[e.SourceIP] = append(queue, e)
+	if len(queue) == 0 && len(ch.awaitingMetrics[e.SourceIP]) == 0 {
+		// This is the first event for that IP in the queue. Need to fetch an Instance for this IP.
+		ch.toLookupIPs = append(ch.toLookupIPs, e.SourceIP)
+		ch.statsEventHostsQueued++
 	}
+	ch.statsEventItemsQueued++
 }
 
 func (ch *CloudHandler) updateAndDispatchMetrics(ctx context.Context, instance *gostatsd.Instance, metrics []*gostatsd.Metric) {
@@ -474,27 +236,6 @@ func (ch *CloudHandler) updateAndDispatchMetrics(ctx context.Context, instance *
 		updateInplace(&m.Tags, &m.Hostname, instance)
 	}
 	ch.handler.DispatchMetrics(ctx, metrics)
-}
-
-func (ch *CloudHandler) handleEvent(ctx context.Context, e *gostatsd.Event) {
-	holder, ok := ch.cache[e.SourceIP]
-	if ok {
-		// While event was in the queue the cache was primed. Use the value.
-		holder.updateAccess()
-		ch.statsCacheLateHit++
-		go ch.updateAndDispatchEvents(ctx, holder.instance, []*gostatsd.Event{e})
-	} else {
-		// Still nothing in the cache.
-		queue := ch.awaitingEvents[e.SourceIP]
-		ch.awaitingEvents[e.SourceIP] = append(queue, e)
-		if len(queue) == 0 {
-			// This is the first event in the queue
-			ch.toLookupIPs = append(ch.toLookupIPs, e.SourceIP)
-			ch.statsEventHostsQueued++
-		}
-		ch.statsEventItemsQueued++
-		ch.statsCacheMiss++
-	}
 }
 
 func (ch *CloudHandler) updateAndDispatchEvents(ctx context.Context, instance *gostatsd.Instance, events []*gostatsd.Event) {
@@ -509,26 +250,25 @@ func (ch *CloudHandler) updateAndDispatchEvents(ctx context.Context, instance *g
 	}
 }
 
-func (ch *CloudHandler) updateTagsAndHostname(ip gostatsd.IP, tags *gostatsd.Tags, hostname *string) bool {
-	instance, ok := ch.getInstance(ip)
-	if ok {
+func (ch *CloudHandler) updateTagsAndHostname(ip gostatsd.IP, tags *gostatsd.Tags, hostname *string) bool /*is a cache hit*/ {
+	instance, cacheHit := ch.getInstance(ip)
+	if cacheHit {
 		updateInplace(tags, hostname, instance)
 	}
-	return ok
+	return cacheHit
 }
 
-func (ch *CloudHandler) getInstance(ip gostatsd.IP) (*gostatsd.Instance, bool) {
+func (ch *CloudHandler) getInstance(ip gostatsd.IP) (*gostatsd.Instance, bool /*is a cache hit*/) {
 	if ip == gostatsd.UnknownIP {
 		return nil, true
 	}
-	ch.rw.RLock()
-	holder, ok := ch.cache[ip]
-	ch.rw.RUnlock()
-	if ok {
-		holder.updateAccess()
-		return holder.instance, true
+	instance, cacheHit := ch.cachedInstances.Peek(ip)
+	if !cacheHit {
+		atomic.AddUint64(&ch.statsCacheMiss, 1)
+		return nil, false
 	}
-	return nil, false
+	atomic.AddUint64(&ch.statsCacheHit, 1)
+	return instance, true
 }
 
 func updateInplace(tags *gostatsd.Tags, hostname *string, instance *gostatsd.Instance) {

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -56,6 +56,22 @@ type countingHandler struct {
 	events  gostatsd.Events
 }
 
+func (ch *countingHandler) Metrics() []gostatsd.Metric {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	result := make([]gostatsd.Metric, len(ch.metrics))
+	copy(result, ch.metrics)
+	return result
+}
+
+func (ch *countingHandler) Events() gostatsd.Events {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	result := make(gostatsd.Events, len(ch.events))
+	copy(result, ch.events)
+	return result
+}
+
 func (ch *countingHandler) EstimatedTags() int {
 	return 0
 }

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -64,7 +64,7 @@ func NewHttpForwarderHandlerV2FromViper(logger logrus.FieldLogger, v *viper.Vipe
 	subViper.SetDefault("api-endpoint", defaultApiEndpoint)
 	subViper.SetDefault("max-requests", defaultMaxRequests)
 	subViper.SetDefault("max-request-elapsed-time", defaultMaxRequestElapsedTime)
-	subViper.SetDefault("consolidator-slots", v.GetInt(ParamMaxParsers))
+	subViper.SetDefault("consolidator-slots", v.GetInt(gostatsd.ParamMaxParsers))
 	subViper.SetDefault("flush-interval", defaultConsolidatorFlushInterval)
 
 	return NewHttpForwarderHandlerV2(
@@ -172,7 +172,7 @@ func (hfh *HttpForwarderHandlerV2) DispatchMetricMap(ctx context.Context, mm *go
 	hfh.consolidator.ReceiveMetricMap(mm)
 }
 
-func (hfh *HttpForwarderHandlerV2) RunMetrics(ctx context.Context) {
+func (hfh *HttpForwarderHandlerV2) RunMetricsContext(ctx context.Context) {
 	statser := stats.FromContext(ctx)
 
 	notify, cancel := statser.RegisterFlush()

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -62,7 +62,7 @@ func NewDatagramParser(in <-chan []*Datagram, ns string, ignoreHost bool, estima
 	}
 }
 
-func (dp *DatagramParser) RunMetrics(ctx context.Context) {
+func (dp *DatagramParser) RunMetricsContext(ctx context.Context) {
 	statser := stats.FromContext(ctx)
 	flushed, unregister := statser.RegisterFlush()
 	defer unregister()

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -48,7 +48,7 @@ func NewDatagramReceiver(out chan<- []*Datagram, sf SocketFactory, numReaders, r
 	}
 }
 
-func (dr *DatagramReceiver) RunMetrics(ctx context.Context) {
+func (dr *DatagramReceiver) RunMetricsContext(ctx context.Context) {
 	statser := stats.FromContext(ctx)
 	flushed, unregister := statser.RegisterFlush()
 	defer unregister()

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func BenchmarkReceive(b *testing.B) {
 	//
 	// ... so this is pretty arbitrary.
 	ch := make(chan []*Datagram, 5000)
-	mr := NewDatagramReceiver(ch, nil, 0, DefaultReceiveBatchSize)
+	mr := NewDatagramReceiver(ch, nil, 0, gostatsd.DefaultReceiveBatchSize)
 	c, done := fakesocket.NewCountedFakePacketConn(uint64(b.N))
 
 	var wg sync.WaitGroup

--- a/pkg/web/http_receiver_v2.go
+++ b/pkg/web/http_receiver_v2.go
@@ -37,7 +37,7 @@ func newRawHttpHandlerV2(logger logrus.FieldLogger, serverName string, handler g
 	}
 }
 
-func (rhh *rawHttpHandlerV2) RunMetrics(ctx context.Context) {
+func (rhh *rawHttpHandlerV2) RunMetricsContext(ctx context.Context) {
 	statser := stats.FromContext(ctx).WithTags([]string{"server-name:" + rhh.serverName})
 
 	notify, cancel := statser.RegisterFlush()

--- a/pkg/web/httpservers.go
+++ b/pkg/web/httpservers.go
@@ -192,7 +192,7 @@ func (hs *httpServer) Run(ctx context.Context) {
 	if hs.rawMetricsV2 != nil {
 		var wg wait.Group
 		defer wg.Wait()
-		wg.StartWithContext(ctx, hs.rawMetricsV2.RunMetrics)
+		wg.StartWithContext(ctx, hs.rawMetricsV2.RunMetricsContext)
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
The idea is to split `CloudHandler` into two pieces by introducing an interface in the middle.
Currently `CloudHandler` does these things:
1. maintains a (negative) cache of ip->instance info
1. maintains a map of ip->[]metrics that need to be enriched per ip while the lookup it taking place

I'm introducing `CachedInstances` interface to abstract the caching bit (1 in the list above) and leave only 2 in the `CloudHandler`.

The next step/PR is to refactor the k8s cloud provider into an implementation of `CachedInstances`.

This PR is not ready to review in full (tests don't even compile as I haven't touched them yet) but to give you a preview and collect early feedback on the approach and major impl details. WDYT?