### PR TITLE
Fixes a bug in the cloud provider initialization when no cloud provider is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+20.1.1
+------
+- Fixes a bug where no cloud provider would crash on startup
+- Minor documentation fix
+
 20.1.0
 ------
 - Minor internal refactoring

--- a/CLOUDPROVIDERS.md
+++ b/CLOUDPROVIDERS.md
@@ -3,7 +3,7 @@ Configuring cloud providers
 Cloud providers are a way to automatically enrich metrics with metadata from a cloud vendor.
 
 Cloud providers must be configured through the usage of a configuration file (toml, yaml and json are supported), passed via
-`--config-path`.
+`--config-path`.  The cloud provider is specified using the `cloud-provider` configuration option.
 
 There are currently two supported cloud providers:
 
@@ -45,6 +45,8 @@ To fix this it is highly recommended to drop the hostname from incoming metrics.
 #### Example with defaults
 
 ```$toml
+cloud-provider = 'k8s'
+
 [k8s]
 kube-api-qps = 5
 kube-api-burst = 1.5

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -93,8 +93,10 @@ func constructServer(v *viper.Viper) (*statsd.Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := cloud.InitCloudProvider(v); err != nil {
-		return nil, err
+	if cloud != nil {
+		if err := cloud.InitCloudProvider(v); err != nil {
+			return nil, err
+		}
 	}
 	// Backends
 	backendNames := v.GetStringSlice(statsd.ParamBackends)

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -72,18 +72,16 @@ func newCloudHandlerFactory(cloudProviderName string, logger logrus.FieldLogger,
 func NewCloudHandlerFactoryFromViper(v *viper.Viper, logger logrus.FieldLogger, version string) (*CloudHandlerFactory, error) {
 	cloudProviderName := v.GetString(ParamCloudProvider)
 	if cloudProviderName == "" {
-		return newCloudHandlerFactory(cloudProviderName, logger, CacheOptions{}, nil, version), nil
+		return nil, nil
+	}
+
+	if _, ok := DefaultCloudProviderCacheValues[cloudProviderName]; !ok {
+		return nil, fmt.Errorf("unknown cloud provider %q", cloudProviderName)
 	}
 
 	// Cloud provider defaults
-	cpDefaultCacheOpts, ok := DefaultCloudProviderCacheValues[cloudProviderName]
-	if !ok {
-		return nil, fmt.Errorf("could not find default cache values for cloud provider '%s'", cloudProviderName)
-	}
-	cpDefaultLimiterOpts, ok := DefaultCloudProviderLimiterValues[cloudProviderName]
-	if !ok {
-		return nil, fmt.Errorf("could not find default cache values for cloud provider '%s'", cloudProviderName)
-	}
+	cpDefaultCacheOpts := DefaultCloudProviderCacheValues[cloudProviderName]
+	cpDefaultLimiterOpts := DefaultCloudProviderLimiterValues[cloudProviderName]
 
 	// Set the defaults in Viper based on the cloud provider values before we manipulate things
 	v.SetDefault(ParamCacheRefreshPeriod, cpDefaultCacheOpts.CacheRefreshPeriod)

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -249,7 +249,7 @@ func TestConstructCloudHandlerFactoryFromViper(t *testing.T) {
 	// Test no cloud handler
 	factory, err := NewCloudHandlerFactoryFromViper(v, logger, "test")
 	assert.NoError(t, err)
-	assert.Nil(t, factory.cloudProvider)
+	assert.Nil(t, factory)
 
 	// Test unknown cloud handler - unsupported
 	v.Set(ParamCloudProvider, "unknown")
@@ -275,10 +275,7 @@ func TestInitCloudHandlerFactory(t *testing.T) {
 
 	factory, err := NewCloudHandlerFactoryFromViper(v, logger, "test")
 	assert.NoError(t, err)
-	assert.Nil(t, factory.cloudProvider)
-
-	err = factory.InitCloudProvider(v)
-	assert.NoError(t, err)
+	assert.Nil(t, factory)
 
 	// We don't test the path for specific cloud providers as they have logic that isn't easily mockable
 }


### PR DESCRIPTION
Looks like tests missed this one because we now invoke things later on in startup.

Fixes #293.