### PR TITLE
fix `metricMapsReceived` of aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+20.1.2
+------
+- Fixes a bug where `aggregator.metricmaps_received` are the same for for every worker
+
 20.1.1
 ------
 - Fixes a bug where no cloud provider would crash on startup

--- a/METRICS.md
+++ b/METRICS.md
@@ -17,6 +17,7 @@ Metrics:
 | Name                                        | type                | tags                         | description
 | ------------------------------------------- | ------------------- | ---------------------------- | -----------
 | aggregator.metrics_received                 | gauge (flush)       | aggregator_id                | The number of datapoints received during the flush interval
+| aggregator.metricmaps_received              | gauge (flush)       | aggregator_id                | The number of datapoint batches received during the flush interval
 | aggregator.aggregation_time                 | gauge (time)        | aggregator_id                | The time taken (in ms) to aggregate all counter and timer
 |                                             |                     |                              | datapoints in this flush interval
 | aggregator.process_time                     | gauge (time)        | aggregator_id                | The time taken to process all synchronous flush actions

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -194,6 +194,7 @@ func deleteMetric(key, tagsKey string, metrics gostatsd.AggregatedMetrics) {
 // Reset clears the contents of a MetricAggregator.
 func (a *MetricAggregator) Reset() {
 	a.metricsReceived = 0
+	a.metricMapsReceived = 0
 	nowNano := gostatsd.Nanotime(a.now().UnixNano())
 
 	a.metricMap.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -147,7 +147,7 @@ func (bh *BackendHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.Me
 	maps := mm.Split(bh.numWorkers)
 
 	for aggrIdx, mmSplit := range maps {
-		if !mm.IsEmpty() {
+		if !mmSplit.IsEmpty() {
 			w := bh.workers[aggrIdx]
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
**Problem**

The `aggregator.metricmaps_received` values of different workers are always the same due to a typo in the codes. 

**Fix**

- Correct the variable typo.
- Reset `aggregator.metricmaps_received`  in the same way with `metricsReceived `.
