### PR TITLE
Make `transport.ResponseHeaderTimeout` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+20.2.0
+------
+- Support for `response-header-timeout` for `transport` section
+
 20.1.2
 ------
 - Fixes a bug where `aggregator.metricmaps_received` are the same for for every worker

--- a/TRANSPORT.md
+++ b/TRANSPORT.md
@@ -56,3 +56,7 @@ tls-handshake-timeout = '3m'
 - `tls-handshake-timeout`: The maximum amount of time waiting for a TLS handshake.  Set to `0` to disable timeout, must
   not be negative.
   Corresponds to `http.Transport#TLSHandshakeTimeout`.
+- `response-header-timeout`: If non-zero, specifies the amount of time to wait for a server's response headers after
+  fully writing the request (including its body, if any). It time does not include the time to read the response body.
+  Defaults to zero.
+  Corresponds to `http.Transport#ResponseHeaderTimeout`.

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -75,7 +75,7 @@ func (th *TagHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.M
 func (th *TagHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
 	mmNew := gostatsd.NewMetricMap()
 
-	mm.Counters.Each(func(metricName, x string, cOriginal gostatsd.Counter) {
+	mm.Counters.Each(func(metricName, _ string, cOriginal gostatsd.Counter) {
 		if th.uniqueFilterAndAddTags(metricName, &cOriginal.Hostname, &cOriginal.Tags) {
 			newTagsKey := gostatsd.FormatTagsKey(cOriginal.Hostname, cOriginal.Tags)
 			if cs, ok := mmNew.Counters[metricName]; ok {


### PR DESCRIPTION
When the backend connects to an AWS ELB and one or more instances behind the LB go offline, the total flush delay would hit ~20s, some of the batches might got dropped, and may last for a few minutes (depends on how you configure the ELB) before the LB kicks off the dead node.

Since the TCP connect timeout (10s) is not configurable on AWS side and it is a 7 layer proxy which means the client side has no knowledge of the LB backend side. We need a way in gostatsd to be more sensitive to the backend failure so that the backoff-retry could take effect to avoid data loss.

The `http.transport.ResponseHeaderTimeout` seems a good fit and we've tested it works under normal loads.