### PR TITLE
Add internal metric for keeping track of the number of individual series flushed to the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+20.3.1
+------
+- Added a new internal metric called `backend.series.sent` which contains the number of flushed timeseries over time.
 
 20.3.0
 ------

--- a/METRICS.md
+++ b/METRICS.md
@@ -41,6 +41,7 @@ Metrics:
 | backend.retried                             | gauge (cumulative)  | backend                      | Lifetime number of metric batches retried by the backend
 | backend.dropped                             | gauge (cumulative)  | backend                      | Lifetime number of metric batches dropped by the backend (DATALOSS!)
 | backend.sent                                | gauge (cumulative)  | backend                      | Lifetime number of metric batches successfully transmitted
+| backend.series.sent                         | gauge (cumulative)  | backend                      | Lifetime number of metric series successfully transmitted
 | cloudprovider.aws.describeinstancecount     | gauge (cumulative)  |                              | The cumulative number of times DescribeInstancesPages has been called
 | cloudprovider.aws.describeinstanceinstances | gauge (cumulative)  |                              | The cumulative number of instances which have been fed in to DescribeInstancesPages
 | cloudprovider.aws.describeinstancepages     | gauge (cumulative)  |                              | The cumulative number of pages from DescribeInstancesPages

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -59,7 +59,7 @@ type Client struct {
 	batchesRetried uint64 // Accumulated number of batches retried (first send is not a retry)
 	batchesDropped uint64 // Accumulated number of batches aborted (data loss)
 	batchesSent    uint64 // Accumulated number of batches successfully sent
-	seriesSent    uint64 // Accumulated number of series successfully sent
+	seriesSent     uint64 // Accumulated number of series successfully sent
 
 	apiKey                string
 	apiEndpoint           string

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -59,6 +59,7 @@ type Client struct {
 	batchesRetried uint64 // Accumulated number of batches retried (first send is not a retry)
 	batchesDropped uint64 // Accumulated number of batches aborted (data loss)
 	batchesSent    uint64 // Accumulated number of batches successfully sent
+	seriesSent    uint64 // Accumulated number of series successfully sent
 
 	apiKey                string
 	apiEndpoint           string
@@ -147,6 +148,7 @@ func (d *Client) Run(ctx context.Context) {
 			statser.Gauge("backend.retried", float64(atomic.LoadUint64(&d.batchesRetried)), nil)
 			statser.Gauge("backend.dropped", float64(atomic.LoadUint64(&d.batchesDropped)), nil)
 			statser.Gauge("backend.sent", float64(atomic.LoadUint64(&d.batchesSent)), nil)
+			statser.Gauge("backend.series.sent", float64(atomic.LoadUint64(&d.seriesSent)), nil)
 		}
 	}
 }
@@ -228,7 +230,11 @@ func (d *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 }
 
 func (d *Client) postMetrics(ctx context.Context, buffer *bytes.Buffer, ts *timeSeries) error {
-	return d.post(ctx, buffer, "/api/v1/series", "metrics", ts)
+	if err := d.post(ctx, buffer, "/api/v1/series", "metrics", ts); err != nil {
+		return err
+	}
+	atomic.AddUint64(&d.seriesSent, uint64(len(ts.Series)))
+	return nil
 }
 
 // SendEvent sends an event to Datadog.

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -79,7 +79,7 @@ type Client struct {
 	batchesRetried uint64 // Accumulated number of batches retried (first send is not a retry)
 	batchesDropped uint64 // Accumulated number of batches aborted (data loss)
 	batchesSent    uint64 // Accumulated number of batches successfully sent
-	seriesSent    uint64 // Accumulated number of series successfully sent
+	seriesSent     uint64 // Accumulated number of series successfully sent
 
 	userAgent             string
 	maxRequestElapsedTime time.Duration

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -79,6 +79,7 @@ type Client struct {
 	batchesRetried uint64 // Accumulated number of batches retried (first send is not a retry)
 	batchesDropped uint64 // Accumulated number of batches aborted (data loss)
 	batchesSent    uint64 // Accumulated number of batches successfully sent
+	seriesSent    uint64 // Accumulated number of series successfully sent
 
 	userAgent             string
 	maxRequestElapsedTime time.Duration
@@ -143,6 +144,9 @@ func (n *Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricM
 					n.metricsBufferSem <- buffer
 				}()
 				err := n.post(ctx, buffer, ts)
+				if err != nil {
+					atomic.AddUint64(&n.seriesSent, uint64(len(ts.Metrics)))
+				}
 
 				select {
 				case <-ctx.Done():
@@ -184,6 +188,7 @@ func (n *Client) RunMetrics(ctx context.Context, statser stats.Statser) {
 			statser.Gauge("backend.retried", float64(atomic.LoadUint64(&n.batchesRetried)), nil)
 			statser.Gauge("backend.dropped", float64(atomic.LoadUint64(&n.batchesDropped)), nil)
 			statser.Gauge("backend.sent", float64(atomic.LoadUint64(&n.batchesSent)), nil)
+			statser.Gauge("backend.series.sent", float64(atomic.LoadUint64(&n.seriesSent)), nil)
 		}
 	}
 }


### PR DESCRIPTION
Let me know if this approach is sane.

This will allow us to calculate the number of metric time series each of our aggregators emit over time.

- [x] Update METRICS.md with new metric name
- [x] Update CHANGELOG with new metrics