### PR TITLE
fix: use correct timestamps for newrelic backend

### DIFF
--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -147,7 +147,7 @@ func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, t
 
 	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
-	metricSet["timestamp"] = n.now().Unix()
+	metricSet["timestamp"] = f.timestamp
 	metricSet["interval"] = f.flushIntervalSec
 	metricSet["integration_version"] = integrationVersion
 
@@ -171,11 +171,10 @@ func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, t
 
 // create a new metric set for the dimensional metrics api
 func newDimensionalMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags) NRMetric {
-	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
-	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
+	// https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/report-metrics-metric-api#new-relic-guidelines
 	metricSet := NRMetric{
 		Name:      metricName,
-		Timestamp: n.now().Unix(),
+		Timestamp: int64(f.timestamp),
 		Attributes: map[string]interface{}{
 			"statsdType": Type,
 		},

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -23,17 +23,17 @@ type timeSeries struct {
 }
 
 // addMetric adds a metric to the series.
-func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string, timestamp gostatsd.Nanotime) {
+func (f *flush) addMetric(n *Client, metricType string, value float64, persecond float64, hostname string, tags gostatsd.Tags, name string) {
 	if n.flushType == flushTypeMetrics {
 		metricName := name
 		if metricType == "counter" {
-			perSecondMetric := newDimensionalMetricSet(n, f, metricName+".per_second", "gauge", persecond, tags, timestamp)
+			perSecondMetric := newDimensionalMetricSet(n, f, metricName+".per_second", "gauge", persecond, tags)
 			f.ts.Metrics = append(f.ts.Metrics, perSecondMetric)
 		}
-		standardMetric := newDimensionalMetricSet(n, f, name, metricType, value, tags, timestamp)
+		standardMetric := newDimensionalMetricSet(n, f, name, metricType, value, tags)
 		f.ts.Metrics = append(f.ts.Metrics, standardMetric)
 	} else {
-		standardMetric := newMetricSet(n, f, name, metricType, value, tags, timestamp)
+		standardMetric := newMetricSet(n, f, name, metricType, value, tags)
 		if metricType == "counter" {
 			standardMetric[n.metricPerSecond] = persecond
 		}
@@ -44,7 +44,7 @@ func (f *flush) addMetric(n *Client, metricType string, value float64, persecond
 // addMetric adds a timer metric to the series.
 func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Timer, tagsKey, name string) {
 	if n.flushType == flushTypeMetrics {
-		timerMetric := newDimensionalMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags, timer.Timestamp)
+		timerMetric := newDimensionalMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags)
 
 		timerMetric.Value = map[string]float64{
 			"count": float64(timer.Count),
@@ -54,23 +54,23 @@ func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Time
 		}
 
 		if !n.disabledSubtypes.CountPerSecond {
-			gaugeMetric := newDimensionalMetricSet(n, f, name+".per_second", "gauge", timer.PerSecond, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, name+".per_second", "gauge", timer.PerSecond, timer.Tags)
 			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
 		}
 		if !n.disabledSubtypes.Mean {
-			gaugeMetric := newDimensionalMetricSet(n, f, name+".mean", "gauge", timer.Mean, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, name+".mean", "gauge", timer.Mean, timer.Tags)
 			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
 		}
 		if !n.disabledSubtypes.Median {
-			gaugeMetric := newDimensionalMetricSet(n, f, name+".median", "gauge", timer.Median, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, name+".median", "gauge", timer.Median, timer.Tags)
 			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
 		}
 		if !n.disabledSubtypes.StdDev {
-			gaugeMetric := newDimensionalMetricSet(n, f, name+".std_dev", "gauge", timer.StdDev, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, name+".std_dev", "gauge", timer.StdDev, timer.Tags)
 			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
 		}
 		if !n.disabledSubtypes.SumSquares {
-			gaugeMetric := newDimensionalMetricSet(n, f, name+".sum_squares", "gauge", timer.SumSquares, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, name+".sum_squares", "gauge", timer.SumSquares, timer.Tags)
 			f.ts.Metrics = append(f.ts.Metrics, gaugeMetric)
 		}
 
@@ -82,7 +82,7 @@ func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Time
 		// Each metric name MUST have a ".percentiles" suffix.
 		for _, pct := range timer.Percentiles {
 			lastUnderscore := strings.LastIndex(pct.Str, "_")
-			gaugeMetric := newDimensionalMetricSet(n, f, fmt.Sprintf("%v.%v.percentiles", name, pct.Str[:lastUnderscore]), "gauge", pct.Float, timer.Tags, timer.Timestamp)
+			gaugeMetric := newDimensionalMetricSet(n, f, fmt.Sprintf("%v.%v.percentiles", name, pct.Str[:lastUnderscore]), "gauge", pct.Float, timer.Tags)
 			percentileResult, err := strconv.ParseFloat(pct.Str[lastUnderscore+1:], 64) // eg. for sum_squares_90 will return 90
 			if err == nil {
 				gaugeMetric.Attributes["percentile"] = percentileResult
@@ -91,7 +91,7 @@ func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Time
 		}
 		f.ts.Metrics = append(f.ts.Metrics, timerMetric)
 	} else {
-		timerMetric := newMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags, timer.Timestamp)
+		timerMetric := newMetricSet(n, f, name, metricType, float64(timer.Count), timer.Tags)
 
 		if !n.disabledSubtypes.Lower {
 			timerMetric[n.timerMin] = timer.Min
@@ -142,12 +142,12 @@ func (f *flush) finish() {
 	}
 }
 
-func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags, timestamp gostatsd.Nanotime) map[string]interface{} {
+func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags) map[string]interface{} {
 	metricSet := map[string]interface{}{}
 
 	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
-	metricSet["timestamp"] = timestamp / 1e9
+	metricSet["timestamp"] = n.now().Unix()
 	metricSet["interval"] = f.flushIntervalSec
 	metricSet["integration_version"] = integrationVersion
 
@@ -170,12 +170,12 @@ func newMetricSet(n *Client, f *flush, metricName, Type string, Value float64, t
 }
 
 // create a new metric set for the dimensional metrics api
-func newDimensionalMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags, timestamp gostatsd.Nanotime) NRMetric {
+func newDimensionalMetricSet(n *Client, f *flush, metricName, Type string, Value float64, tags gostatsd.Tags) NRMetric {
 	// GoStatsD provides the timestamp in Nanotime, New Relic requires seconds or milliseconds, see under "Limits and restricted characters"
 	// https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#instrument
 	metricSet := NRMetric{
 		Name:      metricName,
-		Timestamp: int64(timestamp) / 1e9,
+		Timestamp: n.now().Unix(),
 		Attributes: map[string]interface{}{
 			"statsdType": Type,
 		},

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -30,7 +30,7 @@ const (
 	// BackendName is the name of this backend.
 	BackendName                  = "newrelic"
 	integrationName              = "com.newrelic.gostatsd"
-	integrationVersion           = "2.3.0"
+	integrationVersion           = "2.3.1"
 	protocolVersion              = "2"
 	defaultUserAgent             = "gostatsd"
 	defaultMaxRequestElapsedTime = 15 * time.Second
@@ -205,17 +205,17 @@ func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 	}
 
 	metrics.Gauges.Each(func(key, tagsKey string, g gostatsd.Gauge) {
-		fl.addMetric(n, "gauge", g.Value, 0, g.Hostname, g.Tags, key, g.Timestamp)
+		fl.addMetric(n, "gauge", g.Value, 0, g.Hostname, g.Tags, key)
 		fl.maybeFlush()
 	})
 
 	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
-		fl.addMetric(n, "counter", float64(counter.Value), counter.PerSecond, counter.Hostname, counter.Tags, key, counter.Timestamp)
+		fl.addMetric(n, "counter", float64(counter.Value), counter.PerSecond, counter.Hostname, counter.Tags, key)
 		fl.maybeFlush()
 	})
 
 	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
-		fl.addMetric(n, "set", float64(len(set.Values)), 0, set.Hostname, set.Tags, key, set.Timestamp)
+		fl.addMetric(n, "set", float64(len(set.Values)), 0, set.Hostname, set.Tags, key)
 		fl.maybeFlush()
 	})
 
@@ -227,7 +227,7 @@ func (n *Client) processMetrics(metrics *gostatsd.MetricMap, cb func(*timeSeries
 					bucketTag = "le:" + strconv.FormatFloat(float64(histogramThreshold), 'f', -1, 64)
 				}
 				newTags := timer.Tags.Concat(gostatsd.Tags{bucketTag})
-				fl.addMetric(n, "counter", float64(count), 0, timer.Hostname, newTags, key+".histogram", timer.Timestamp)
+				fl.addMetric(n, "counter", float64(count), 0, timer.Hostname, newTags, key+".histogram")
 			}
 		} else {
 			fl.addTimerMetric(n, "timer", timer, tagsKey, key)

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -112,38 +112,38 @@ func TestSendMetrics(t *testing.T) {
 			name:      "infra",
 			flushType: "infra",
 			apiKey:    "",
-			expected: `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.0","data":[{"metrics":` +
-				`[{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
-				`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
-				`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
-				`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
-				`"samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":0}]}]}`,
+			expected: `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.1","data":[{"metrics":` +
+				`[{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":100},` +
+				`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":100},` +
+				`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":100},` +
+				`{"count_90":0.1,"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,` +
+				`"samples_count":1,"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":100}]}]}`,
 		},
 		{
 			name:      "insights",
 			flushType: "insights",
 			apiKey:    "some-api-key",
-			expected: `[{"eventType":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":0},` +
-				`{"eventType":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":0},` +
-				`{"eventType":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":0},` +
-				`{"count_90":0.1,"eventType":"GoStatsD","integration_version":"2.3.0","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,"samples_count":1,` +
-				`"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":0}]`,
+			expected: `[{"eventType":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"g1","metric_type":"gauge","metric_value":3,"tag3":"true","timestamp":100},` +
+				`{"eventType":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"c1","metric_per_second":1.1,"metric_type":"counter","metric_value":5,"tag1":"true","timestamp":100},` +
+				`{"eventType":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"users","metric_type":"set","metric_value":3,"tag4":"true","timestamp":100},` +
+				`{"count_90":0.1,"eventType":"GoStatsD","integration_version":"2.3.1","interval":1,"metric_name":"t1","metric_per_second":1.1,"metric_type":"timer","metric_value":1,"samples_count":1,` +
+				`"samples_max":1,"samples_mean":0.5,"samples_median":0.5,"samples_min":0,"samples_std_dev":0.1,"samples_sum":1,"samples_sum_squares":1,"tag2":"true","timestamp":100}]`,
 		},
 		{
 			name:      "metrics",
 			flushType: "metrics",
 			apiKey:    "some-api-key",
-			expected: `[{"common":{"attributes":{"integration.name":"GoStatsD","integration.version":"2.3.0"},"interval.ms":1000},` +
-				`"metrics":[{"name":"g1","value":3,"type":"gauge","attributes":{"statsdType":"gauge","tag3":"true"}},` +
-				`{"name":"c1.per_second","value":1.1,"type":"gauge","attributes":{"statsdType":"gauge","tag1":"true"}},` +
-				`{"name":"c1","value":5,"type":"count","attributes":{"statsdType":"counter","tag1":"true"}},` +
-				`{"name":"users","attributes":{"statsdType":"set","tag4":"true"}},{"name":"t1.per_second","value":1.1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.mean","value":0.5,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.median","value":0.5,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.std_dev","value":0.1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.sum_squares","value":1,"type":"gauge","attributes":{"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.count.percentiles","value":0.1,"type":"gauge","attributes":{"percentile":90,"statsdType":"gauge","tag2":"true"}},` +
-				`{"name":"t1.summary","value":{"count":1,"max":1,"min":0,"sum":1},"type":"summary","attributes":{"statsdType":"timer","tag2":"true"}}]}]`,
+			expected: `[{"common":{"attributes":{"integration.name":"GoStatsD","integration.version":"2.3.1"},"interval.ms":1000},` +
+				`"metrics":[{"name":"g1","value":3,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag3":"true"}},` +
+				`{"name":"c1.per_second","value":1.1,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag1":"true"}},` +
+				`{"name":"c1","value":5,"type":"count","timestamp":100,"attributes":{"statsdType":"counter","tag1":"true"}},` +
+				`{"name":"users","timestamp":100,"attributes":{"statsdType":"set","tag4":"true"}},{"name":"t1.per_second","value":1.1,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.mean","value":0.5,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.median","value":0.5,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.std_dev","value":0.1,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.sum_squares","value":1,"type":"gauge","timestamp":100,"attributes":{"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.count.percentiles","value":0.1,"type":"gauge","timestamp":100,"attributes":{"percentile":90,"statsdType":"gauge","tag2":"true"}},` +
+				`{"name":"t1.summary","value":{"count":1,"max":1,"min":0,"sum":1},"type":"summary","timestamp":100,"attributes":{"statsdType":"timer","tag2":"true"}}]}]`,
 		},
 	}
 
@@ -227,12 +227,12 @@ func TestSendMetricsWithHistogram(t *testing.T) {
 		}
 
 		expected := []string{
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":20,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":5,"timestamp":0}`,
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":30,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":0}`,
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":40,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":0}`,
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":50,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":0}`,
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":60,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":19,"timestamp":0}`,
-			`{"event_type":"GoStatsD","integration_version":"2.3.0","interval":1,"le":"infinity","metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":19,"timestamp":0}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":20,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":5,"timestamp":100}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":30,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":100}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":40,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":100}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":50,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":10,"timestamp":100}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":60,"metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":19,"timestamp":100}`,
+			`{"event_type":"GoStatsD","integration_version":"2.3.1","interval":1,"le":"infinity","metric_name":"t1.histogram","metric_per_second":0,"metric_type":"counter","metric_value":19,"timestamp":100}`,
 		}
 
 		for _, e := range expected {
@@ -356,7 +356,7 @@ func TestEventFormatter(t *testing.T) {
 	}{
 		{
 			name: "infra",
-			expected: `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.0","data":` +
+			expected: `{"name":"com.newrelic.gostatsd","protocol_version":"2","integration_version":"2.3.1","data":` +
 				`[{"metrics":[{"AggregationKey":"","AlertType":"","DateHappened":0,"Hostname":"blah","Priority":"low","SourceTypeName":"","Text":"hi","Title":"EventTitle","event_type":"GoStatsD","name":"event"}]}]}`,
 		},
 		{


### PR DESCRIPTION
The incorrect timestamp is currently being used in the payload, so when this is sent to New Relic, viewing each metric / event does not show the timestamp on flush, but from the individual metric itself. 

For example when a gauge may have not been sent for awhile, it will reuse the last gauges timestamp as the default which will throw off graphing when it should be using the the timestamp during flush.

PR uses the correct timestamp, and supplies the individual metrics attribute as a custom attribute instead.