### PR TITLE
Add support for adding http headers extracted from tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+------
+- Added experimental support for adding http headers based on metrics tags
+
 22.0.0
 ------
 - Refactor pprof endpoints to sit under `/debug/pprof`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ following configuration options:
 - `log-raw-metric`: logs raw metrics received from the network.  Defaults to `false`.
 - `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection.
   Not required, default is empty. Example: `--custom-headers='{"region" : "us-east-1", "service" : "event-producer"}'`
+- `dynamic-headers` : similar with `custom-headers`, but the header values are extracted from metric tags matching the
+  provided list of string. Not required, default is empty. Example: `--dynamic-headers='["region", "service"]'`
 
 
 Metric expiry and persistence

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ following configuration options:
 - `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection.
   Not required, default is empty. Example: `--custom-headers='{"region" : "us-east-1", "service" : "event-producer"}'`
 - `dynamic-headers` : similar with `custom-headers`, but the header values are extracted from metric tags matching the
-  provided list of string. Not required, default is empty. Example: `--dynamic-headers='["region", "service"]'`. If a tag is specified in both `custom-header` and `dynamic-header`, the vaule set by `custom-header` takes precedence.
+  provided list of string. Tag names are canonicalized by first replacing underscores with hyphens, then converting
+  first letter and each letter after a hyphen to uppercase, the rest are converted to lower case. If a tag is specified
+  in both `custom-header` and `dynamic-header`, the vaule set by `custom-header` takes precedence. Not required, default
+  is empty. Example: `--dynamic-headers='["region", "service"]'`.
+  This is an experimental feature and it may be removed or changed in future versions.
 
 
 Metric expiry and persistence

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ following configuration options:
 - `custom-headers` : a map of strings that are added to each request sent to allow for additional network routing / request inspection.
   Not required, default is empty. Example: `--custom-headers='{"region" : "us-east-1", "service" : "event-producer"}'`
 - `dynamic-headers` : similar with `custom-headers`, but the header values are extracted from metric tags matching the
-  provided list of string. Not required, default is empty. Example: `--dynamic-headers='["region", "service"]'`
+  provided list of string. Not required, default is empty. Example: `--dynamic-headers='["region", "service"]'`. If a tag is specified in both `custom-header` and `dynamic-header`, the vaule set by `custom-header` takes precedence.
 
 
 Metric expiry and persistence

--- a/examples/cloudproviders/k8s/daemonset.yaml
+++ b/examples/cloudproviders/k8s/daemonset.yaml
@@ -108,7 +108,7 @@ spec:
           image: alpine:latest
           # Send a metric called `metric.namespace` which is a counter with a value of 1, tagged with some dummy tags,
           # to the local gostatsd DaemonSet. Do this once every 10 seconds.
-          command: ['/bin/sh', '-c', 'while 1; echo "metric.namespace:1|c|#tag1:value1,tag2:value2" |  nc -w 1 -u $MY_NODE_IP 8125; sleep 10; done']
+          command: ['/bin/sh', '-c', 'while 1; do echo "metric.namespace:1|c|#tag1:value1,tag2:value2" |  nc -w 1 -u $MY_NODE_IP 8125; sleep 10; done']
           env:
           - name: MY_NODE_IP
             valueFrom:

--- a/metric_map.go
+++ b/metric_map.go
@@ -181,7 +181,10 @@ func tagsMatch(tagNames []string, tagsKey string) string {
 	res := make([]string, 0)
 	for _, tv := range strings.Split(tagsKey, ",") {
 		for _, tagName := range tagNames {
-			if strings.HasPrefix(tv, tagName+":") {
+			if tagName == "" {
+				break
+			}
+			if strings.HasPrefix(tv, tagName) {
 				res = append(res, tv)
 				break
 			}

--- a/metric_map_test.go
+++ b/metric_map_test.go
@@ -389,22 +389,22 @@ func TestMetricMapSplitByTags(t *testing.T) {
 	require.Equal(t, len(mms), 1)
 
 	// non existing tag name doesn't match
-	mms = mmOriginal.SplitByTags([]string{"key"})
+	mms = mmOriginal.SplitByTags([]string{"key:"})
 	require.Equal(t, len(mms), 1)
 
 	// valueless tag doesn't match
-	mms = mmOriginal.SplitByTags([]string{"x"})
+	mms = mmOriginal.SplitByTags([]string{"x:"})
 	require.Equal(t, len(mms), 1)
 
 	// each value of tag s is unique
-	mms = mmOriginal.SplitByTags([]string{"s"})
+	mms = mmOriginal.SplitByTags([]string{"s:"})
 	require.Equal(t, len(mms), 5)
 
 	// two possible values for tag t
-	mms = mmOriginal.SplitByTags([]string{"t"})
+	mms = mmOriginal.SplitByTags([]string{"t:"})
 	require.Equal(t, len(mms), 2)
 
 	// all value combinations of tag t and v
-	mms = mmOriginal.SplitByTags([]string{"t", "v"})
+	mms = mmOriginal.SplitByTags([]string{"t:", "v:"})
 	require.Equal(t, len(mms), 4)
 }

--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -22,7 +22,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/util"
 
 	"github.com/cenkalti/backoff"
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -53,6 +53,7 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		10*time.Second,
 		10*time.Millisecond,
 		nil,
+		nil,
 		p,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Added a new configuration `dynamic-headers` for specifying a list of tags to be matched against for added to headers of http request. Metrics are also regrouped by the matching tags.

Fixes #305.