### PR TITLE
Add pprof wildcard match to enable the remaining pprof endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+24.0.1
+------
+- Add pprof catch-all route to match the rest of pprof's available endpoints
+
 24.0.0
 ------
 - Update to aggregator channel metrics. see [METRICS.md](METRICS.md) for details.

--- a/pkg/web/httpservers.go
+++ b/pkg/web/httpservers.go
@@ -90,11 +90,11 @@ func NewHttpServer(
 
 	if enableProf {
 		routes = append(routes,
-			route{path: "/debug/pprof/", handler: pprof.Index, methods: []string{"GET"}, name: "pprof_index"},
 			route{path: "/debug/pprof/cmdline", handler: pprof.Cmdline, methods: []string{"GET"}, name: "pprof_cmdline"},
 			route{path: "/debug/pprof/profile", handler: pprof.Profile, methods: []string{"GET"}, name: "pprof_profile"},
 			route{path: "/debug/pprof/symbol", handler: pprof.Symbol, methods: []string{"GET"}, name: "pprof_symbol"},
 			route{path: "/debug/pprof/trace", handler: pprof.Trace, methods: []string{"GET", "POST"}, name: "pprof_trace"},
+			route{path: "/debug/pprof/{any:.*}", handler: pprof.Index, methods: []string{"GET"}, name: "pprof_index"},
 		)
 	}
 


### PR DESCRIPTION
The current implementation doesn't forward catchall routes to the pprof.Index handler. This means we can't make requests like `/debug/pprof/{heap,goroutine}`etc.

This change binds the `/debug/pprof/.*` route after all of our specific routes to ensure the Index handler is used for any other endpoint.