### PR TITLE
Cleanup imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-all: fmt test test-race bench bench-race check cover
 
 fmt:
 	gofmt -w=true -s $$(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pb/*")
-	goimports -w=true -d $$(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pb/*")
+	goimports -w=true -d -local github.com/atlassian/gostatsd $$(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pb/*")
 
 test: pb/gostatsd.pb.go
 	go test ./...

--- a/cmd/gostatsd/main.go
+++ b/cmd/gostatsd/main.go
@@ -13,6 +13,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"golang.org/x/time/rate"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends"
 	"github.com/atlassian/gostatsd/pkg/cachedinstances"
@@ -20,10 +25,6 @@ import (
 	"github.com/atlassian/gostatsd/pkg/statsd"
 	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/atlassian/gostatsd/pkg/util"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"golang.org/x/time/rate"
 )
 
 const (

--- a/cmd/tester/sender.go
+++ b/cmd/tester/sender.go
@@ -8,9 +8,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd"
 )
 
 // Metrics store the metrics to send.

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -3,6 +3,9 @@ package backends
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/cloudwatch"
 	"github.com/atlassian/gostatsd/pkg/backends/datadog"
@@ -12,9 +15,6 @@ import (
 	"github.com/atlassian/gostatsd/pkg/backends/statsdaemon"
 	"github.com/atlassian/gostatsd/pkg/backends/stdout"
 	"github.com/atlassian/gostatsd/pkg/transport"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // All known backends.

--- a/pkg/backends/cloudwatch/cloudwatch.go
+++ b/pkg/backends/cloudwatch/cloudwatch.go
@@ -7,17 +7,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/transport"
-	"github.com/atlassian/gostatsd/pkg/util"
-
-	log "github.com/sirupsen/logrus"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/transport"
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
 // Maximum number of dimensions per metric

--- a/pkg/backends/cloudwatch/cloudwatch_test.go
+++ b/pkg/backends/cloudwatch/cloudwatch_test.go
@@ -5,17 +5,15 @@ import (
 	"math"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/transport"
-
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type mockedCloudwatch struct {

--- a/pkg/backends/datadog/datadog_test.go
+++ b/pkg/backends/datadog/datadog_test.go
@@ -26,7 +26,7 @@ import (
 func advanceTime(c *clock.Mock, ch <-chan struct{}) {
 	for {
 		select {
-		case <- ch:
+		case <-ch:
 			return
 		default:
 			c.AddNext()

--- a/pkg/backends/graphite/graphite.go
+++ b/pkg/backends/graphite/graphite.go
@@ -12,13 +12,13 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
 	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/atlassian/gostatsd/pkg/util"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 const (

--- a/pkg/backends/graphite/graphite_test.go
+++ b/pkg/backends/graphite/graphite_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/ash2k/stager/wait"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
 )
 
 func TestPreparePayloadLegacy(t *testing.T) {

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -25,7 +25,6 @@ import (
 	"github.com/atlassian/gostatsd/pkg/stats"
 	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/atlassian/gostatsd/pkg/util"
-
 )
 
 const (

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -26,7 +26,7 @@ import (
 func advanceTime(c *clock.Mock, ch <-chan struct{}) {
 	for {
 		select {
-		case <- ch:
+		case <-ch:
 			return
 		default:
 			c.AddNext()

--- a/pkg/backends/null/null.go
+++ b/pkg/backends/null/null.go
@@ -3,10 +3,10 @@ package null
 import (
 	"context"
 
+	"github.com/spf13/viper"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/transport"
-
-	"github.com/spf13/viper"
 )
 
 // BackendName is the name of this backend.

--- a/pkg/backends/sender/sender.go
+++ b/pkg/backends/sender/sender.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd"
 )
 
 const maxStreamsPerConnection = 100

--- a/pkg/backends/statsdaemon/statsdaemon.go
+++ b/pkg/backends/statsdaemon/statsdaemon.go
@@ -11,13 +11,13 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/sender"
 	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/atlassian/gostatsd/pkg/util"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 const (

--- a/pkg/backends/statsdaemon/statsdaemon_test.go
+++ b/pkg/backends/statsdaemon/statsdaemon_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
 )
 
 var longName = strings.Repeat("t", maxUDPPacketSize-5)

--- a/pkg/backends/stdout/stdout.go
+++ b/pkg/backends/stdout/stdout.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/transport"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/transport"
 )
 
 // BackendName is the name of this backend.

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/ash2k/stager/wait"
+	"github.com/sirupsen/logrus"
+	"github.com/tilinna/clock"
+	"golang.org/x/time/rate"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/stats"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
-	"github.com/tilinna/clock"
 )
 
 func NewCachedCloudProvider(logger logrus.FieldLogger, limiter *rate.Limiter, cloudProvider gostatsd.CloudProvider, cacheOpts gostatsd.CacheOptions) *CachedCloudProvider {

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider_lookup.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider_lookup.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/atlassian/gostatsd"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
+
+	"github.com/atlassian/gostatsd"
 )
 
 const (

--- a/pkg/cachedinstances/cloudprovider/cached_cloud_provider_test.go
+++ b/pkg/cachedinstances/cloudprovider/cached_cloud_provider_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/ash2k/stager/wait"
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/cloudproviders/fakeprovider"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/cloudproviders/fakeprovider"
 )
 
 func TestCachedCloudProviderExpirationAndRefresh(t *testing.T) {

--- a/pkg/cachedinstances/factory.go
+++ b/pkg/cachedinstances/factory.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"golang.org/x/time/rate"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cachedinstances/cloudprovider"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/k8s"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"golang.org/x/time/rate"
 )
 
 var (

--- a/pkg/cloudproviders/aws/aws.go
+++ b/pkg/cloudproviders/aws/aws.go
@@ -10,19 +10,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/spf13/viper"
-
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/stats"
-	"github.com/atlassian/gostatsd/pkg/util"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"golang.org/x/net/http2"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/stats"
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
 const (

--- a/pkg/cloudproviders/cloudproviders.go
+++ b/pkg/cloudproviders/cloudproviders.go
@@ -3,11 +3,12 @@ package cloudproviders
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/aws"
 	"github.com/atlassian/gostatsd/pkg/cloudproviders/k8s"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // All registered cloud providers.

--- a/pkg/cloudproviders/k8s/k8s.go
+++ b/pkg/cloudproviders/k8s/k8s.go
@@ -6,9 +6,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/util"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	core_v1 "k8s.io/api/core/v1"
@@ -18,6 +15,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
 var (

--- a/pkg/cloudproviders/k8s/k8s_test.go
+++ b/pkg/cloudproviders/k8s/k8s_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	mainFake "k8s.io/client-go/kubernetes/fake"
 	kube_testing "k8s.io/client-go/testing"
+
+	"github.com/atlassian/gostatsd"
 )
 
 const (

--- a/pkg/stats/statser_logging.go
+++ b/pkg/stats/statser_logging.go
@@ -3,9 +3,9 @@ package stats
 import (
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	log "github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd"
 )
 
 // LoggingStatser is a Statser which emits logs

--- a/pkg/statsd/filtering.go
+++ b/pkg/statsd/filtering.go
@@ -1,9 +1,9 @@
 package statsd
 
 import (
-	"github.com/atlassian/gostatsd"
-
 	"github.com/spf13/viper"
+
+	"github.com/atlassian/gostatsd"
 )
 
 type Filter struct {

--- a/pkg/statsd/flusher.go
+++ b/pkg/statsd/flusher.go
@@ -7,10 +7,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/stats"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // MetricFlusher periodically flushes metrics from all Aggregators to Senders.

--- a/pkg/statsd/handler_backend_test.go
+++ b/pkg/statsd/handler_backend_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/stats"
-
 	"github.com/ash2k/stager/wait"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/stats"
 )
 
 type testAggregator struct {

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ash2k/stager/wait"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/stats"
 )

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/ash2k/stager/wait"
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/cachedinstances/cloudprovider"
-	"github.com/atlassian/gostatsd/pkg/cloudproviders/fakeprovider"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/tilinna/clock"
 	"golang.org/x/time/rate"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/cachedinstances/cloudprovider"
+	"github.com/atlassian/gostatsd/pkg/cloudproviders/fakeprovider"
 )
 
 // BenchmarkCloudHandlerDispatchMetric is a benchmark intended to (manually) test

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -52,7 +52,7 @@ func (nh *nopHandler) WaitForEvents() {
 
 type expectingHandler struct {
 	countingHandler
-	
+
 	wgMetrics    sync.WaitGroup
 	wgMetricMaps sync.WaitGroup
 	wgEvents     sync.WaitGroup

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -13,18 +13,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pb"
-	"github.com/atlassian/gostatsd/pkg/stats"
-	"github.com/atlassian/gostatsd/pkg/transport"
-	"github.com/atlassian/gostatsd/pkg/util"
-
 	"github.com/ash2k/stager/wait"
 	"github.com/cenkalti/backoff"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/tilinna/clock"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pb"
+	"github.com/atlassian/gostatsd/pkg/stats"
+	"github.com/atlassian/gostatsd/pkg/transport"
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
 const (

--- a/pkg/statsd/handler_http_forwarder_v2_test.go
+++ b/pkg/statsd/handler_http_forwarder_v2_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pb"
-	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pb"
+	"github.com/atlassian/gostatsd/pkg/transport"
 )
 
 func TestHttpForwarderV2Translation(t *testing.T) {

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -3,10 +3,10 @@ package statsd
 import (
 	"context"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/atlassian/gostatsd"
 )
 
 type TagHandler struct {

--- a/pkg/statsd/handler_tags_test.go
+++ b/pkg/statsd/handler_tags_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
 )
 
 func TestTagStripMergesCounters(t *testing.T) {

--- a/pkg/statsd/lexer_test.go
+++ b/pkg/statsd/lexer_test.go
@@ -3,11 +3,11 @@ package statsd
 import (
 	"testing"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/pool"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/pool"
 )
 
 func TestMetricsLexer(t *testing.T) {

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -8,12 +8,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/pool"
 	"github.com/atlassian/gostatsd/pkg/stats"
-
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 )
 
 // Default buffer size for debug channel

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
+
+	"github.com/atlassian/gostatsd"
 )
 
 type metricAndEvent struct {

--- a/pkg/statsd/receiver.go
+++ b/pkg/statsd/receiver.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/ash2k/stager/wait"
+	"github.com/sirupsen/logrus"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/atlassian/gostatsd/pkg/pool"
 	"github.com/atlassian/gostatsd/pkg/stats"
-
-	"github.com/ash2k/stager/wait"
-	"github.com/sirupsen/logrus"
 )
 
 // ip packet size is stored in two bytes and that is how big in theory the packet can be.

--- a/pkg/statsd/receiver_test.go
+++ b/pkg/statsd/receiver_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/fakesocket"
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/fakesocket"
 )
 
 func BenchmarkReceive(b *testing.B) {

--- a/pkg/statsd/worker.go
+++ b/pkg/statsd/worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ash2k/stager/wait"
+
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/stats"
 )

--- a/pkg/web/fixtures_test.go
+++ b/pkg/web/fixtures_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/atlassian/gostatsd"
 )
 
 type capturingHandler struct {

--- a/pkg/web/http_receiver_v2.go
+++ b/pkg/web/http_receiver_v2.go
@@ -7,12 +7,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pb"
-
-	"github.com/atlassian/gostatsd/pkg/stats"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pb"
+	"github.com/atlassian/gostatsd/pkg/stats"
 )
 
 type rawHttpHandlerV2 struct {

--- a/pkg/web/httpservers.go
+++ b/pkg/web/httpservers.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atlassian/gostatsd"
-	"github.com/atlassian/gostatsd/pkg/util"
-
 	"github.com/ash2k/stager/wait"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/pkg/util"
 )
 
 type httpServer struct {


### PR DESCRIPTION
This gives us consistent imports across the entire codebase.  No functional changes except the Makefile.  Also cleans up two gofmt changes in newrelic_test.go and datadog_test.go

Still no changelog because it's still not a change as such.