### PR TITLE
Fix the usage of a virtual clock in backoff handler

### DIFF
--- a/pkg/backends/datadog/datadog.go
+++ b/pkg/backends/datadog/datadog.go
@@ -279,6 +279,7 @@ func (d *Client) post(ctx context.Context, buffer *bytes.Buffer, path, typeOfPos
 	b := backoff.NewExponentialBackOff()
 	clck := clock.FromContext(ctx)
 	b.Clock = clck
+	b.Reset()
 	b.MaxElapsedTime = d.maxRequestElapsedTime
 	for {
 		if err = post(); err == nil {

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -302,6 +302,7 @@ func (n *Client) post(ctx context.Context, buffer *bytes.Buffer, data interface{
 	b := backoff.NewExponentialBackOff()
 	clck := clock.FromContext(ctx)
 	b.Clock = clck
+	b.Reset()
 	b.MaxElapsedTime = n.maxRequestElapsedTime
 	for {
 		if err = post(); err == nil {


### PR DESCRIPTION
`backoff.NewExponentialBackOff()` initializes an `ExponentialBackOff`, including grabbing
the current time from the system clock.  During tests when we override the clock, this
effectively puts us back in time to 1970.

Eventually all this adhoc retry logic will be centralized when the Transport system
is completed (which handles it properly already)