### PR TITLE
Remove dispatch metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-PENDING
--------
+28.0.0
+------
 - Internal pipeline refactor removes two internal metrics
 
 27.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+PENDING
+-------
+- Internal pipeline refactor removes two internal metrics
+
 27.0.0
 ------
 - Simplify internal tracking of the source address of a metric.  The current rules are:

--- a/METRICS.md
+++ b/METRICS.md
@@ -16,7 +16,6 @@ Metrics:
 
 | Name                                        | type                | tags                         | description
 | ------------------------------------------- | ------------------- | ---------------------------- | -----------
-| aggregator.metrics_received                 | gauge (flush)       | aggregator_id                | The number of datapoints received during the flush interval
 | aggregator.metricmaps_received              | gauge (flush)       | aggregator_id                | The number of datapoint batches received during the flush interval
 | aggregator.aggregation_time                 | gauge (time)        | aggregator_id                | The time taken (in ms) to aggregate all counter and timer
 |                                             |                     |                              | datapoints in this flush interval
@@ -84,7 +83,6 @@ the samples are reset.
 
 | Channel name              | Additional tags | Description
 | ------------------------- | --------------- | -----------
-| dispatch_aggregator_batch | aggregator_id   | Channel to dispatch metrics to a specific aggregator.
 | dispatch_aggregator_map   | aggregator_id   | Channel to dispatch metric maps to a given aggregator.
 | backend_events_sem        |                 | Semaphore limiting the number of events in flight at once.  Corresponds to
 |                           |                 | the `--max-concurrent-events` flag.

--- a/events.go
+++ b/events.go
@@ -92,5 +92,10 @@ type Event struct {
 	AlertType AlertType
 }
 
+func (e *Event) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	e.Tags = e.Tags.Concat(additionalTags)
+	e.Source = newSource
+}
+
 // Events represents a list of events.
 type Events []*Event

--- a/events.go
+++ b/events.go
@@ -93,4 +93,4 @@ type Event struct {
 }
 
 // Events represents a list of events.
-type Events []Event
+type Events []*Event

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -35,7 +35,7 @@ func (ch *capturingHandler) EstimatedTags() int {
 	return 0
 }
 
-func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*Metric) {
+func (ch *capturingHandler) dispatchMetrics(ctx context.Context, metrics []*Metric) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	for _, m := range metrics {
@@ -44,9 +44,14 @@ func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*Metr
 	}
 }
 
+// Wrapper until we can remove it
+func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*Metric) {
+	ch.dispatchMetrics(ctx, metrics)
+}
+
 // DispatchMetricMap re-dispatches a metric map through capturingHandler.DispatchMetrics
 func (ch *capturingHandler) DispatchMetricMap(ctx context.Context, mm *MetricMap) {
-	mm.DispatchMetrics(ctx, ch)
+	ch.dispatchMetrics(ctx, mm.AsMetrics())
 }
 
 func (ch *capturingHandler) DispatchEvent(ctx context.Context, e *Event) {

--- a/internal/fixtures/metrics.go
+++ b/internal/fixtures/metrics.go
@@ -1,0 +1,80 @@
+package fixtures
+
+import (
+	"fmt"
+
+	"github.com/atlassian/gostatsd"
+)
+
+type MetricOpt func(m *gostatsd.Metric)
+
+// MakeMetric provides a way to build a metric for tests.  Hopefully over
+// time this will be used more, bringing more consistency to tests.
+func MakeMetric(opts ...MetricOpt) *gostatsd.Metric {
+	m := &gostatsd.Metric{
+		Type: gostatsd.COUNTER,
+		Name: "name",
+		Rate: 1,
+		Tags: gostatsd.Tags{
+			"foo:bar",
+			"host:baz",
+		},
+		Source: "baz",
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+func Name(n string) MetricOpt {
+	return func(m *gostatsd.Metric) {
+		m.Name = n
+	}
+}
+
+func AddTag(t ...string) MetricOpt {
+	return func(m *gostatsd.Metric) {
+		m.Tags = append(m.Tags, t...)
+	}
+}
+
+func DropSource(m *gostatsd.Metric) {
+	m.Source = gostatsd.UnknownSource
+}
+
+func DropTag(t string) MetricOpt {
+	return func(m *gostatsd.Metric) {
+		next := 0
+		found := false
+		for _, tag := range m.Tags {
+			if t == tag {
+				found = true
+				m.Tags[next] = tag
+				next++
+			}
+		}
+		if !found {
+			panic(fmt.Sprintf("failed to find tag %s while building metric", t))
+		}
+		m.Tags = m.Tags[:next]
+	}
+}
+
+// SortCompare func for metrics so they can be compared with require.EqualValues
+// Invoke with sort.Slice(x, SortCompare(x))
+func SortCompare(ms []*gostatsd.Metric) func(i, j int) bool {
+	return func(i, j int) bool {
+		if ms[i].Name == ms[j].Name {
+			if len(ms[i].Tags) == len(ms[j].Tags) { // This is not exactly accurate, but close enough with our data
+				if ms[i].Type == gostatsd.SET {
+					return ms[i].StringValue < ms[j].StringValue
+				} else {
+					return ms[i].Value < ms[j].Value
+				}
+			}
+			return len(ms[i].Tags) < len(ms[j].Tags)
+		}
+		return ms[i].Name < ms[j].Name
+	}
+}

--- a/metric_consolidator.go
+++ b/metric_consolidator.go
@@ -7,8 +7,9 @@ import (
 	"github.com/tilinna/clock"
 )
 
-// MetricConsolidator will consolidate metrics randomly in to a slice of MetricMaps, and send the slice to the provided
-// channel.  Run can be started in a long running goroutine to perform flushing, or Flush can be called externally.
+// MetricConsolidator will consolidate metrics randomly in to a slice of MetricMaps, and either send the slice to
+// the provided channel, or make them available synchronously through Drain/Fill. Run can also be started in a long
+// running goroutine to perform flushing, or Flush can be called externally to trigger the channel send.
 //
 // Used to consolidate metrics such as:
 // - counter[name=x, value=1]
@@ -30,9 +31,7 @@ type MetricConsolidator struct {
 func NewMetricConsolidator(spots int, flushInterval time.Duration, sink chan<- []*MetricMap) *MetricConsolidator {
 	mc := &MetricConsolidator{}
 	mc.maps = make(chan *MetricMap, spots)
-	for i := 0; i < spots; i++ {
-		mc.maps <- NewMetricMap()
-	}
+	mc.Fill()
 	mc.flushInterval = flushInterval
 	mc.sink = sink
 	return mc
@@ -52,10 +51,11 @@ func (mc *MetricConsolidator) Run(ctx context.Context) {
 	}
 }
 
-// Flush will collect all the MetricMaps in to a slice, send them to the channel provided, then
-// create new MetricMaps for new metrics to land in.  Not thread-safe.
-func (mc *MetricConsolidator) Flush(ctx context.Context) {
-	var mms []*MetricMap
+// Drain will collect all the MetricMaps in the MetricConsolidator and return them.  If the
+// context.Context is canceled before everything can be collected, they are returned to the
+// MetricConsolidator and nil is returned.
+func (mc *MetricConsolidator) Drain(ctx context.Context) []*MetricMap {
+	mms := make([]*MetricMap, 0, cap(mc.maps))
 	for i := 0; i < cap(mc.maps); i++ {
 		select {
 		case mm := <-mc.maps:
@@ -66,8 +66,18 @@ func (mc *MetricConsolidator) Flush(ctx context.Context) {
 			for _, mm := range mms {
 				mc.maps <- mm
 			}
-			return
+			return nil
 		}
+	}
+	return mms
+}
+
+// Flush will collect all the MetricMaps in to a slice, send them to the channel provided, then
+// create new MetricMaps for new metrics to land in.  Not thread-safe.
+func (mc *MetricConsolidator) Flush(ctx context.Context) {
+	mms := mc.Drain(ctx)
+	if mms == nil {
+		return
 	}
 
 	// Send the collected data to the sink before putting new maps in place.  This allows back-pressure
@@ -77,6 +87,12 @@ func (mc *MetricConsolidator) Flush(ctx context.Context) {
 	case <-ctx.Done():
 	}
 
+	mc.Fill()
+}
+
+// Fill re-populates the MetricConsolidator with empty MetricMaps, it is the pair to Drain and
+// must be called after a successful Drain, must not be called after a failed Drain.
+func (mc *MetricConsolidator) Fill() {
 	for i := 0; i < cap(mc.maps); i++ {
 		mc.maps <- NewMetricMap()
 	}

--- a/metric_map.go
+++ b/metric_map.go
@@ -46,6 +46,14 @@ func (mm *MetricMap) Receive(m *Metric) {
 	m.Done()
 }
 
+func MergeMaps(mms []*MetricMap) *MetricMap {
+	mm := NewMetricMap()
+	for _, mmFrom := range mms {
+		mm.Merge(mmFrom)
+	}
+	return mm
+}
+
 func (mm *MetricMap) Merge(mmFrom *MetricMap) {
 	mmFrom.Counters.Each(func(metricName string, tagsKey string, counterFrom Counter) {
 		v, ok := mm.Counters[metricName]

--- a/metric_map.go
+++ b/metric_map.go
@@ -2,7 +2,6 @@ package gostatsd
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 
@@ -367,8 +366,8 @@ func (mm *MetricMap) String() string {
 	return buf.String()
 }
 
-// DispatchMetrics will synthesize Metrics from the MetricMap and push them to the supplied PipelineHandler
-func (mm *MetricMap) DispatchMetrics(ctx context.Context, handler RawMetricHandler) {
+// AsMetrics will synthesize Metrics from the MetricMap and return them as a slice
+func (mm *MetricMap) AsMetrics() []*Metric {
 	var metrics []*Metric
 
 	mm.Counters.Each(func(metricName string, tagsKey string, c Counter) {
@@ -434,5 +433,5 @@ func (mm *MetricMap) DispatchMetrics(ctx context.Context, handler RawMetricHandl
 		}
 	})
 
-	handler.DispatchMetrics(ctx, metrics)
+	return metrics
 }

--- a/metric_map_test.go
+++ b/metric_map_test.go
@@ -153,7 +153,7 @@ func TestMetricMapDispatch(t *testing.T) {
 	}
 	ch := &capturingHandler{}
 
-	mm.DispatchMetrics(ctx, ch)
+	ch.dispatchMetrics(ctx, mm.AsMetrics())
 
 	expected := []*Metric{
 		{Name: "abc.def.g", Value: 3, Rate: 1, Type: GAUGE, Timestamp: 10},

--- a/metric_map_test.go
+++ b/metric_map_test.go
@@ -143,17 +143,13 @@ func BenchmarkReceives(b *testing.B) {
 }
 
 func TestMetricMapDispatch(t *testing.T) {
-	ctx, done := testContext(t)
-	defer done()
-
 	mm := NewMetricMap()
 	metrics := metricsFixtures()
 	for _, metric := range metrics {
 		mm.Receive(metric)
 	}
-	ch := &capturingHandler{}
 
-	ch.dispatchMetrics(ctx, mm.AsMetrics())
+	actual := mm.AsMetrics()
 
 	expected := []*Metric{
 		{Name: "abc.def.g", Value: 3, Rate: 1, Type: GAUGE, Timestamp: 10},
@@ -172,8 +168,6 @@ func TestMetricMapDispatch(t *testing.T) {
 		{Name: "uniq.usr", StringValue: "john", Rate: 1, Type: SET, Timestamp: 10},
 		{Name: "uniq.usr", StringValue: "john", Rate: 1, TagsKey: "baz,foo:bar", Tags: Tags{"baz", "foo:bar"}, Type: SET, Timestamp: 10},
 	}
-
-	actual := ch.GetMetrics()
 
 	sort.Slice(actual, SortCompare(actual))
 	sort.Slice(expected, SortCompare(expected))

--- a/metric_map_test.go
+++ b/metric_map_test.go
@@ -173,28 +173,29 @@ func TestMetricMapDispatch(t *testing.T) {
 		{Name: "uniq.usr", StringValue: "john", Rate: 1, TagsKey: "baz,foo:bar", Tags: Tags{"baz", "foo:bar"}, Type: SET, Timestamp: 10},
 	}
 
-	cmpSort := func(slice []*Metric) func(i, j int) bool {
-		return func(i, j int) bool {
-			if slice[i].Name == slice[j].Name {
-				if len(slice[i].Tags) == len(slice[j].Tags) { // This is not exactly accurate, but close enough with our data
-					if slice[i].Type == SET {
-						return slice[i].StringValue < slice[j].StringValue
-					} else {
-						return slice[i].Value < slice[j].Value
-					}
-				}
-				return len(slice[i].Tags) < len(slice[j].Tags)
-			}
-			return slice[i].Name < slice[j].Name
-		}
-	}
-
 	actual := ch.GetMetrics()
 
-	sort.Slice(actual, cmpSort(actual))
-	sort.Slice(expected, cmpSort(expected))
+	sort.Slice(actual, SortCompare(actual))
+	sort.Slice(expected, SortCompare(expected))
 
 	require.EqualValues(t, expected, actual)
+}
+
+// Copied from internal/fixtures because dependency loops
+func SortCompare(ms []*Metric) func(i, j int) bool {
+	return func(i, j int) bool {
+		if ms[i].Name == ms[j].Name {
+			if len(ms[i].Tags) == len(ms[j].Tags) { // This is not exactly accurate, but close enough with our data
+				if ms[i].Type == SET {
+					return ms[i].StringValue < ms[j].StringValue
+				} else {
+					return ms[i].Value < ms[j].Value
+				}
+			}
+			return len(ms[i].Tags) < len(ms[j].Tags)
+		}
+		return ms[i].Name < ms[j].Name
+	}
 }
 
 func TestMetricMapMerge(t *testing.T) {

--- a/metrics.go
+++ b/metrics.go
@@ -53,6 +53,17 @@ type Metric struct {
 	DoneFunc  func()     // Returns the metric to the pool. May be nil. Call Metric.Done(), not this.
 }
 
+func (m *Metric) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	if len(additionalTags) > 0 {
+		m.Tags = m.Tags.Concat(additionalTags)
+		m.TagsKey = ""
+	}
+	if newSource != m.Source {
+		m.Source = newSource
+		m.TagsKey = ""
+	}
+}
+
 // Reset is used to reset a metric to as clean state, called on re-use from the pool.
 func (m *Metric) Reset() {
 	m.Name = ""

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,55 @@
+package gostatsd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricReset(t *testing.T) {
+	// this is deliberately constructed without using named fields,
+	// so that if the fields change it will cause a compiler error.
+	m := &Metric{
+		"metric",
+		10,
+		1,
+		Tags{"tag"},
+		"something",
+		"somethingelse",
+		"source",
+		123,
+		COUNTER,
+		nil,
+	}
+	m.Reset()
+	// Tags needs to be an empty slice, not a nil slice, because half the reason
+	// behind having the MetricPool and Reset is to re-use the Tags slice. Therefore
+	// we don't nil it.
+	require.EqualValues(t, &Metric{Tags: Tags{}, Rate: 1}, m)
+}
+
+func TestMetricString(t *testing.T) {
+	types := []MetricType{COUNTER, TIMER, SET, GAUGE, 42}
+	names := []string{"counter", "timer", "set", "gauge", "unknown"}
+	for idx, name := range names {
+		require.Equal(t, name, types[idx].String())
+	}
+}
+
+func TestUpdateTags(t *testing.T) {
+	m := &Metric{}
+	m.FormatTagsKey()
+	require.EqualValues(t, "", m.TagsKey)
+	m.AddTagsSetSource(Tags{"foo"}, "source")
+	require.EqualValues(t, Tags{"foo"}, m.Tags)
+	require.EqualValues(t, "source", m.Source)
+	require.EqualValues(t, "", m.TagsKey)
+	m.FormatTagsKey()
+	require.EqualValues(t, "foo,s:source", m.TagsKey) // It's set
+	m.AddTagsSetSource(Tags{"foo2"}, "source2")
+	require.EqualValues(t, Tags{"foo", "foo2"}, m.Tags)
+	require.EqualValues(t, "source2", m.Source)
+	require.EqualValues(t, "", m.TagsKey) // It's cleared
+	m.FormatTagsKey()
+	require.EqualValues(t, "foo,foo2,s:source2", m.TagsKey)
+}

--- a/pkg/stats/flush_notifier.go
+++ b/pkg/stats/flush_notifier.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -35,7 +36,7 @@ func (fn *flushNotifier) RegisterFlush() (ch <-chan time.Duration, unregister fu
 
 // NotifyFlush will notify any registered channels that a flush has completed.
 // Non-blocking, thread-safe.
-func (fn *flushNotifier) NotifyFlush(d time.Duration) {
+func (fn *flushNotifier) NotifyFlush(ctx context.Context, d time.Duration) {
 	fn.lock.RLock()
 	defer fn.lock.RUnlock()
 	for _, hook := range fn.flushTargets {

--- a/pkg/stats/flush_notifier_test.go
+++ b/pkg/stats/flush_notifier_test.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func TestFlushNotifierFires(t *testing.T) {
 	go func() {
 		// Just enough to be certain that the select below is ready.
 		time.Sleep(10 * time.Millisecond)
-		fn.NotifyFlush(0)
+		fn.NotifyFlush(context.Background(), 0)
 	}()
 
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -91,7 +92,7 @@ func TestFlushNotifierDoesNotBlock(t *testing.T) {
 	_, unregister := fn.RegisterFlush()
 
 	deadline := time.Now().Add(10 * time.Millisecond)
-	fn.NotifyFlush(0)
+	fn.NotifyFlush(context.Background(), 0)
 	assert.Truef(t, time.Now().Before(deadline), "NotifyFlush ran too long")
 
 	unregister()

--- a/pkg/stats/statser.go
+++ b/pkg/stats/statser.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -9,7 +10,7 @@ import (
 // Statser is the interface for sending metrics
 type Statser interface {
 	// NotifyFlush is called when a flush occurs.  It signals all known subscribers.
-	NotifyFlush(d time.Duration)
+	NotifyFlush(ctx context.Context, d time.Duration)
 	// RegisterFlush returns a channel which will receive a notification after every flush, and a cleanup
 	// function which should be called to signal the channel is no longer being monitored.  If the channel
 	// blocks, the notification will be silently dropped.

--- a/pkg/stats/statser_tagged.go
+++ b/pkg/stats/statser_tagged.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	"time"
 
 	"github.com/atlassian/gostatsd"
@@ -25,8 +26,8 @@ func NewTaggedStatser(statser Statser, tags gostatsd.Tags) Statser {
 	}
 }
 
-func (ts *TaggedStatser) NotifyFlush(d time.Duration) {
-	ts.statser.NotifyFlush(d)
+func (ts *TaggedStatser) NotifyFlush(ctx context.Context, d time.Duration) {
+	ts.statser.NotifyFlush(ctx, d)
 }
 
 func (ts *TaggedStatser) RegisterFlush() (<-chan time.Duration, func()) {

--- a/pkg/statsd/aggregator.go
+++ b/pkg/statsd/aggregator.go
@@ -23,7 +23,6 @@ type percentStruct struct {
 
 // MetricAggregator aggregates metrics.
 type MetricAggregator struct {
-	metricsReceived       uint64
 	metricMapsReceived    uint64
 	expiryIntervalCounter time.Duration // How often to expire counters
 	expiryIntervalGauge   time.Duration // How often to expire gauges
@@ -82,7 +81,6 @@ func round(v float64) float64 {
 
 // Flush prepares the contents of a MetricAggregator for sending via the Sender.
 func (a *MetricAggregator) Flush(flushInterval time.Duration) {
-	a.statser.Gauge("aggregator.metrics_received", float64(a.metricsReceived), nil)
 	a.statser.Gauge("aggregator.metricmaps_received", float64(a.metricMapsReceived), nil)
 
 	flushInSeconds := float64(flushInterval) / float64(time.Second)
@@ -215,7 +213,6 @@ func deleteMetric(key, tagsKey string, metrics gostatsd.AggregatedMetrics) {
 
 // Reset clears the contents of a MetricAggregator.
 func (a *MetricAggregator) Reset() {
-	a.metricsReceived = 0
 	a.metricMapsReceived = 0
 	nowNano := gostatsd.Nanotime(a.now().UnixNano())
 
@@ -273,15 +270,6 @@ func (a *MetricAggregator) Reset() {
 			}
 		}
 	})
-}
-
-// Receive takes a batched metrics and will put them on the internal aggregator
-// queue to be processed
-func (a *MetricAggregator) Receive(ms ...*gostatsd.Metric) {
-	a.metricsReceived += uint64(len(ms))
-	for _, m := range ms {
-		a.metricMap.Receive(m)
-	}
 }
 
 // ReceiveMap takes a single metric map and will aggregate the values

--- a/pkg/statsd/flusher.go
+++ b/pkg/statsd/flusher.go
@@ -66,10 +66,10 @@ func (f *MetricFlusher) Run(ctx context.Context) {
 			return
 		case thisFlush := <-ch: // Time to flush to the backends
 			flushDelta := thisFlush.Sub(lastFlush)
+			statser.NotifyFlush(ctx, flushDelta)
 			if f.aggregateProcesser != AggregateProcesser(nil) {
 				f.flushData(ctx, flushDelta, statser)
 			}
-			statser.NotifyFlush(flushDelta)
 			lastFlush = thisFlush
 		}
 	}

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -45,7 +45,6 @@ func NewBackendHandler(backends []gostatsd.Backend, maxConcurrentEvents uint, nu
 		workers[i] = &worker{
 			aggr: af.Create(),
 			// TODO: Reassess the defaults
-			metricsQueue:   make(chan []*gostatsd.Metric, perWorkerBufferSize),
 			metricMapQueue: make(chan *gostatsd.MetricMap, perWorkerBufferSize),
 			processChan:    make(chan *processCommand),
 			id:             i,
@@ -66,7 +65,6 @@ func (bh *BackendHandler) Run(ctx context.Context) {
 	var wg wait.Group
 	defer func() {
 		for _, worker := range bh.workers {
-			close(worker.metricsQueue)   // Close channel to terminate worker
 			close(worker.metricMapQueue) // Close channel to terminate worker
 		}
 		wg.Wait() // Wait for all workers to finish
@@ -121,25 +119,6 @@ func (bh *BackendHandler) RunMetrics(ctx context.Context, statser stats.Statser)
 // EstimatedTags returns a guess for how many tags to pre-allocate
 func (bh *BackendHandler) EstimatedTags() int {
 	return 0
-}
-
-// DispatchMetrics dispatches metric to a corresponding Aggregator.
-func (bh *BackendHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
-	metricsByAggr := make([][]*gostatsd.Metric, bh.numWorkers)
-
-	for _, m := range metrics {
-		m.TagsKey = m.FormatTagsKey() // this is expensive, so do it with no aggregator affinity
-		bucket := m.Bucket(bh.numWorkers)
-		metricsByAggr[bucket] = append(metricsByAggr[bucket], m)
-	}
-
-	for aggrIdx, bucketedMetrics := range metricsByAggr {
-		w := bh.workers[aggrIdx]
-		select {
-		case <-ctx.Done():
-		case w.metricsQueue <- bucketedMetrics:
-		}
-	}
 }
 
 // DispatchMetricMap re-dispatches a metric map through BackendHandler.DispatchMetrics

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -121,7 +121,7 @@ func (bh *BackendHandler) EstimatedTags() int {
 	return 0
 }
 
-// DispatchMetricMap re-dispatches a metric map through BackendHandler.DispatchMetrics
+// DispatchMetricMap splits a MetricMap in to per-aggregator buckets and distributes it.
 func (bh *BackendHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
 	maps := mm.Split(bh.numWorkers)
 

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -57,19 +57,11 @@ func (ch *CloudHandler) EstimatedTags() int {
 	return ch.estimatedTags
 }
 
-// Wrapper until we can remove it
-func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
-	ch.dispatchMetrics(ctx, metrics)
-}
-
-func (ch *CloudHandler) dispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
+func (ch *CloudHandler) processMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
 	mmToDispatch := gostatsd.NewMetricMap()
 	var toHandle []*gostatsd.Metric
 	for _, m := range metrics {
-		if ch.updateTagsAndHostname(&m.Tags, &m.Source) {
-			// Changing the tags requires invalidating the TagsKey.
-			// TODO: Reassess this when we get rid of DispatchMetrics properly.
-			m.TagsKey = ""
+		if ch.updateTagsAndHostname(m, m.Source) {
 			mmToDispatch.Receive(m)
 		} else {
 			toHandle = append(toHandle, m)
@@ -88,17 +80,16 @@ func (ch *CloudHandler) dispatchMetrics(ctx context.Context, metrics []*gostatsd
 	}
 }
 
-// DispatchMetricMap re-dispatches a metric map through CloudHandler.DispatchMetrics
+// DispatchMetricMap re-dispatches a MetricMap through CloudHandler.processMetrics
 // TODO: This is inefficient, and should be handled first class, however that is a major re-factor of
 //  the CloudHandler.  It is also recommended to not use a CloudHandler in an http receiver based
 //  service, as the IP is not propagated.
 func (ch *CloudHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
-	ms := mm.AsMetrics()
-	ch.dispatchMetrics(ctx, ms)
+	ch.processMetrics(ctx, mm.AsMetrics())
 }
 
 func (ch *CloudHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
-	if ch.updateTagsAndHostname(&e.Tags, &e.Source) {
+	if ch.updateTagsAndHostname(e, e.Source) {
 		ch.handler.DispatchEvent(ctx, e)
 		return
 	}
@@ -244,9 +235,7 @@ func (ch *CloudHandler) handleIncomingEvent(e *gostatsd.Event) {
 func (ch *CloudHandler) updateAndDispatchMetrics(ctx context.Context, instance *gostatsd.Instance, metrics []*gostatsd.Metric) {
 	mm := gostatsd.NewMetricMap()
 	for _, m := range metrics {
-		updateInplace(&m.Tags, &m.Source, instance)
-		// Updating the tags requires invaliding the TagsKey
-		m.TagsKey = ""
+		updateInplace(m, instance)
 		mm.Receive(m)
 	}
 	ch.handler.DispatchMetricMap(ctx, mm)
@@ -258,16 +247,16 @@ func (ch *CloudHandler) updateAndDispatchEvents(ctx context.Context, instance *g
 		ch.wg.Add(-dispatched)
 	}()
 	for _, e := range events {
-		updateInplace(&e.Tags, &e.Source, instance)
+		updateInplace(e, instance)
 		dispatched++
 		ch.handler.DispatchEvent(ctx, e)
 	}
 }
 
-func (ch *CloudHandler) updateTagsAndHostname(tags *gostatsd.Tags, source *gostatsd.Source) bool /*is a cache hit*/ {
-	instance, cacheHit := ch.getInstance(*source)
+func (ch *CloudHandler) updateTagsAndHostname(obj TagChanger, source gostatsd.Source) bool /*is a cache hit*/ {
+	instance, cacheHit := ch.getInstance(source)
 	if cacheHit {
-		updateInplace(tags, source, instance)
+		updateInplace(obj, instance)
 	}
 	return cacheHit
 }
@@ -285,11 +274,8 @@ func (ch *CloudHandler) getInstance(ip gostatsd.Source) (*gostatsd.Instance, boo
 	return instance, true
 }
 
-func updateInplace(tags *gostatsd.Tags, source *gostatsd.Source, instance *gostatsd.Instance) {
+func updateInplace(obj TagChanger, instance *gostatsd.Instance) {
 	if instance != nil { // It was a positive cache hit (successful lookup cache, not failed lookup cache)
-		// Update hostname inplace
-		*source = instance.ID
-		// Update tag list inplace
-		*tags = append(*tags, instance.Tags...)
+		obj.AddTagsSetSource(instance.Tags, instance.ID)
 	}
 }

--- a/pkg/statsd/handler_cloud.go
+++ b/pkg/statsd/handler_cloud.go
@@ -57,7 +57,12 @@ func (ch *CloudHandler) EstimatedTags() int {
 	return ch.estimatedTags
 }
 
+// Wrapper until we can remove it
 func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
+	ch.dispatchMetrics(ctx, metrics)
+}
+
+func (ch *CloudHandler) dispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
 	var toDispatch []*gostatsd.Metric
 	var toHandle []*gostatsd.Metric
 	for _, m := range metrics {
@@ -85,7 +90,8 @@ func (ch *CloudHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd
 //  the CloudHandler.  It is also recommended to not use a CloudHandler in an http receiver based
 //  service, as the IP is not propagated.
 func (ch *CloudHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
-	mm.DispatchMetrics(ctx, ch)
+	ms := mm.AsMetrics()
+	ch.dispatchMetrics(ctx, ms)
 }
 
 func (ch *CloudHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {

--- a/pkg/statsd/handler_cloud_test.go
+++ b/pkg/statsd/handler_cloud_test.go
@@ -88,7 +88,7 @@ func TestTransientInstanceFailure(t *testing.T) {
 	}
 
 	// t+0: prime the cache
-	expecting.Expect(0, 1, 0)
+	expecting.Expect(1, 0)
 	ch.DispatchMetrics(ctx, []*gostatsd.Metric{m1})
 	expecting.WaitAll()
 
@@ -97,7 +97,7 @@ func TestTransientInstanceFailure(t *testing.T) {
 	clck.Add(50 * time.Millisecond)
 
 	// t+100ms: read from cache, must still be valid
-	expecting.Expect(0, 1, 0)
+	expecting.Expect(1, 0)
 	ch.DispatchMetrics(ctx, []*gostatsd.Metric{m2})
 	expecting.WaitAll()
 
@@ -222,14 +222,14 @@ func doCheck(
 	wg.StartWithContext(ctx, ch.Run)
 	wg.StartWithContext(ctx, ci.Run)
 
-	expecting.Expect(0, 1, 1)
+	expecting.Expect(1, 1)
 	mm := gostatsd.NewMetricMap()
 	mm.Receive(m1)
 	ch.DispatchMetricMap(ctx, mm)
 	ch.DispatchEvent(ctx, e1)
 	expecting.WaitAll()
 
-	expecting.Expect(0, 1, 1)
+	expecting.Expect(1, 1)
 	mm = gostatsd.NewMetricMap()
 	mm.Receive(m2)
 	ch.DispatchMetricMap(ctx, mm)

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -87,14 +87,14 @@ func (e *expectingHandler) WaitAll() {
 
 type countingHandler struct {
 	mu      sync.Mutex
-	metrics []gostatsd.Metric
+	metrics []*gostatsd.Metric
 	events  gostatsd.Events
 }
 
-func (ch *countingHandler) Metrics() []gostatsd.Metric {
+func (ch *countingHandler) Metrics() []*gostatsd.Metric {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
-	result := make([]gostatsd.Metric, len(ch.metrics))
+	result := make([]*gostatsd.Metric, len(ch.metrics))
 	copy(result, ch.metrics)
 	return result
 }
@@ -121,7 +121,7 @@ func (ch *countingHandler) dispatchMetrics(ctx context.Context, metrics []*gosta
 	defer ch.mu.Unlock()
 	for _, m := range metrics {
 		m.DoneFunc = nil // Clear DoneFunc because it contains non-predictable variable data which interferes with the tests
-		ch.metrics = append(ch.metrics, *m)
+		ch.metrics = append(ch.metrics, m)
 	}
 }
 
@@ -133,7 +133,7 @@ func (ch *countingHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.M
 func (ch *countingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
-	ch.events = append(ch.events, *e)
+	ch.events = append(ch.events, e)
 }
 
 func (ch *countingHandler) WaitForEvents() {

--- a/pkg/statsd/handler_fixtures_test.go
+++ b/pkg/statsd/handler_fixtures_test.go
@@ -111,7 +111,12 @@ func (ch *countingHandler) EstimatedTags() int {
 	return 0
 }
 
+// Wrapper until we can remove it
 func (ch *countingHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
+	ch.dispatchMetrics(ctx, metrics)
+}
+
+func (ch *countingHandler) dispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	for _, m := range metrics {
@@ -122,7 +127,7 @@ func (ch *countingHandler) DispatchMetrics(ctx context.Context, metrics []*gosta
 
 // DispatchMetricMap re-dispatches a metric map through BackendHandler.DispatchMetrics
 func (ch *countingHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
-	mm.DispatchMetrics(ctx, ch)
+	ch.dispatchMetrics(ctx, mm.AsMetrics())
 }
 
 func (ch *countingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {

--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -180,11 +180,7 @@ func (hfh *HttpForwarderHandlerV2) EstimatedTags() int {
 	return 0
 }
 
-func (hfh *HttpForwarderHandlerV2) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
-	hfh.consolidator.ReceiveMetrics(metrics)
-}
-
-// DispatchMetricMap re-dispatches a metric map through HttpForwarderHandlerV2.DispatchMetrics
+// DispatchMetricMap dispatches a metric map to the MetricConsolidator
 func (hfh *HttpForwarderHandlerV2) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
 	hfh.consolidator.ReceiveMetricMap(mm)
 }

--- a/pkg/statsd/handler_tags.go
+++ b/pkg/statsd/handler_tags.go
@@ -50,20 +50,6 @@ func (th *TagHandler) EstimatedTags() int {
 	return th.estimatedTags
 }
 
-// DispatchMetrics adds the unique tags from the TagHandler to the metric and passes it to the next stage in the
-// pipeline as a MetricMap.
-//
-// TODO: Remove this after all dependencies are gone.
-func (th *TagHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
-	mm := gostatsd.NewMetricMap()
-	for _, m := range metrics {
-		mm.Receive(m)
-	}
-	if !mm.IsEmpty() {
-		th.DispatchMetricMap(ctx, mm)
-	}
-}
-
 // DispatchMetricMap adds the unique tags from the TagHandler to each consolidated metric in the map and passes it to
 // the next stage in the pipeline
 //

--- a/pkg/statsd/parser.go
+++ b/pkg/statsd/parser.go
@@ -110,9 +110,13 @@ func (dp *DatagramParser) Run(ctx context.Context) {
 				accumE += eventCount
 				accumB += badLineCount
 			}
+			// TODO: Refactor this to use a MetricConsolidator
+			mm := gostatsd.NewMetricMap()
+			for _, m := range metrics {
+				mm.Receive(m)
+			}
 			if len(metrics) > 0 {
-				dp.handler.DispatchMetrics(ctx, metrics)
-
+				dp.handler.DispatchMetricMap(ctx, mm)
 				dp.doLogRawMetric(metrics)
 			}
 			atomic.AddUint64(&dp.metricsReceived, uint64(len(metrics)))

--- a/pkg/statsd/parser_test.go
+++ b/pkg/statsd/parser_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type metricAndEvent struct {
-	metrics []gostatsd.Metric
+	metrics []*gostatsd.Metric
 	events  gostatsd.Events
 }
 
@@ -47,43 +47,43 @@ func TestParseDatagram(t *testing.T) {
 	t.Parallel()
 	input := map[string]metricAndEvent{
 		"f:2|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\n": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#t": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"host:h"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 				{Name: "x", Value: 3, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\nx:3|c\n": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 				{Name: "x", Value: 3, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"_e{1,1}:a|b\nf:6|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 6, Source: "127.0.0.1", Type: gostatsd.COUNTER, Rate: 1},
 			},
 			events: gostatsd.Events{
-				gostatsd.Event{Title: "a", Text: "b", Source: "127.0.0.1"},
+				{Title: "a", Text: "b", Source: "127.0.0.1"},
 			},
 		},
 	}
@@ -111,48 +111,48 @@ func TestParseDatagramIgnoreHost(t *testing.T) {
 	t.Parallel()
 	input := map[string]metricAndEvent{
 		"f:2|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\n": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#t": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"t"}},
 			},
 		},
 		"f:2|c|#host:h": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "h", Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c|#host:h1,host:h2": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Source: "h1", Type: gostatsd.COUNTER, Rate: 1, Tags: gostatsd.Tags{"host:h2"}},
 			},
 		},
 		"f:2|c\nx:3|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 				{Name: "x", Value: 3, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"f:2|c\nx:3|c\n": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 2, Type: gostatsd.COUNTER, Rate: 1},
 				{Name: "x", Value: 3, Type: gostatsd.COUNTER, Rate: 1},
 			},
 		},
 		"_e{1,1}:a|b\nf:6|c": {
-			metrics: []gostatsd.Metric{
+			metrics: []*gostatsd.Metric{
 				{Name: "f", Value: 6, Type: gostatsd.COUNTER, Rate: 1},
 			},
 			events: gostatsd.Events{
-				gostatsd.Event{Title: "a", Text: "b", Source: "127.0.0.1"},
+				{Title: "a", Text: "b", Source: "127.0.0.1"},
 			},
 		},
 	}

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -23,9 +23,8 @@ type ProcessFunc func(*gostatsd.MetricMap)
 // Aggregator is an object that aggregates statsd metrics.
 // The function NewAggregator should be used to create the objects.
 //
-// Incoming metrics should be passed via Receive function.
+// Incoming metrics should be passed via ReceiveMap function.
 type Aggregator interface {
-	Receive(metrics ...*gostatsd.Metric)
 	ReceiveMap(mm *gostatsd.MetricMap)
 	Flush(interval time.Duration)
 	Process(ProcessFunc)

--- a/pkg/statsd/types.go
+++ b/pkg/statsd/types.go
@@ -44,3 +44,10 @@ type Datagram struct {
 type MetricEmitter interface {
 	RunMetrics(ctx context.Context, statser stats.Statser)
 }
+
+// TagChanger is an interface that Metric/Event can implement to update their tags
+// and source.  It is so the CloudHandler can change the tags without worrying about
+// the TagsKey cache.
+type TagChanger interface {
+	AddTagsSetSource(additionalTags gostatsd.Tags, newSource gostatsd.Source)
+}

--- a/pkg/web/fixtures_test.go
+++ b/pkg/web/fixtures_test.go
@@ -21,7 +21,12 @@ func (ch *capturingHandler) EstimatedTags() int {
 	return 0
 }
 
+// Wrapper until we can remove it
 func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
+	ch.dispatchMetrics(ctx, metrics)
+}
+
+func (ch *capturingHandler) dispatchMetrics(ctx context.Context, metrics []*gostatsd.Metric) {
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 	for _, m := range metrics {
@@ -30,8 +35,8 @@ func (ch *capturingHandler) DispatchMetrics(ctx context.Context, metrics []*gost
 	}
 }
 
-func (ch *capturingHandler) DispatchMetricMap(ctx context.Context, metrics *gostatsd.MetricMap) {
-	metrics.DispatchMetrics(ctx, ch)
+func (ch *capturingHandler) DispatchMetricMap(ctx context.Context, mm *gostatsd.MetricMap) {
+	ch.dispatchMetrics(ctx, mm.AsMetrics())
 }
 
 func (ch *capturingHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) {

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -144,7 +144,12 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		{Name: "set", Type: gostatsd.SET, StringValue: "def", Rate: 1},
 	}
 
-	actual := ch.GetMetrics()
+	actual := gostatsd.MergeMaps(ch.MetricMaps()).AsMetrics()
+
+	for _, m := range expected {
+		m.FormatTagsKey()
+	}
+
 	for _, metric := range actual {
 		metric.Timestamp = 0 // This isn't propagated through v2, and is set to the time of receive
 	}

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tilinna/clock"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/internal/fixtures"
 	"github.com/atlassian/gostatsd/pkg/statsd"
 	"github.com/atlassian/gostatsd/pkg/transport"
 	"github.com/atlassian/gostatsd/pkg/web"
@@ -111,17 +112,24 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		Rate:        0.1,
 	}
 
+	mm := gostatsd.NewMetricMap()
+
 	for i := 0; i < 100; i++ {
-		hfh.DispatchMetrics(ctxTest, []*gostatsd.Metric{m1, m2, m5, m6, m7, m8})
+		mm.Receive(m1)
+		mm.Receive(m2)
+		mm.Receive(m5)
+		mm.Receive(m6)
+		mm.Receive(m7)
+		mm.Receive(m8)
 	}
 	// only do timers once, because they're very noisy in the output.
-	hfh.DispatchMetrics(ctxTest, []*gostatsd.Metric{m3, m4})
+	mm.Receive(m3)
+	mm.Receive(m4)
+	hfh.DispatchMetricMap(ctxTest, mm)
 
-	// There's no good way to tell when the Ticker has been created, so we use a hard loop
-	for _, d := mockClock.AddNext(); d == 0 && ctxTest.Err() == nil; _, d = mockClock.AddNext() {
-		time.Sleep(time.Millisecond) // Allows the system to actually idle, runtime.Gosched() does not.
-	}
-	mockClock.Add(1 * time.Second)    // Make sure everything gets scheduled
+	fixtures.NextStep(ctxTest, mockClock)
+	mockClock.Add(1 * time.Second) // Make sure everything gets scheduled
+
 	time.Sleep(50 * time.Millisecond) // Give the http call time to actually occur
 
 	expected := []*gostatsd.Metric{
@@ -141,24 +149,8 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		metric.Timestamp = 0 // This isn't propagated through v2, and is set to the time of receive
 	}
 
-	cmpSort := func(slice []*gostatsd.Metric) func(i, j int) bool {
-		return func(i, j int) bool {
-			if slice[i].Name == slice[j].Name {
-				if len(slice[i].Tags) == len(slice[j].Tags) { // This is not exactly accurate, but close enough with our data
-					if slice[i].Type == gostatsd.SET {
-						return slice[i].StringValue < slice[j].StringValue
-					} else {
-						return slice[i].Value < slice[j].Value
-					}
-				}
-				return len(slice[i].Tags) < len(slice[j].Tags)
-			}
-			return slice[i].Name < slice[j].Name
-		}
-	}
-
-	sort.Slice(actual, cmpSort(actual))
-	sort.Slice(expected, cmpSort(expected))
+	sort.Slice(actual, fixtures.SortCompare(actual))
+	sort.Slice(expected, fixtures.SortCompare(expected))
 
 	require.EqualValues(t, expected, actual)
 	testDone()

--- a/types.go
+++ b/types.go
@@ -72,7 +72,6 @@ func MaybeAppendRunnable(runnables []Runnable, maybeRunner interface{}) []Runnab
 // RawMetricHandler is an interface that accepts a Metric for processing.  Raw refers to pre-aggregation, not
 // pre-consolidation.
 type RawMetricHandler interface {
-	DispatchMetrics(ctx context.Context, m []*Metric)
 	DispatchMetricMap(ctx context.Context, mm *MetricMap)
 }
 


### PR DESCRIPTION
There's some juggling with the benchmarks, which is primarily because they're now creating a MetricMap in the loop, which is not really valid.  But they're in there so they're staying.

As always, commits are generally isolated.