### PR TITLE
Patch: Discard values that can not be represented by JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+28.1.0
+------
+- The Datadog backend will discard values that result in NaN or ±Inf since they can not be used with our JSON processing.
+
 28.0.0
 ------
 - Internal pipeline refactor removes two internal metrics

--- a/pkg/backends/datadog/flush.go
+++ b/pkg/backends/datadog/flush.go
@@ -2,6 +2,7 @@ package datadog
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/atlassian/gostatsd"
 )
@@ -51,6 +52,10 @@ func (f *flush) addMetricf(metricType metricType, value float64, source gostatsd
 
 // addMetric adds a metric to the series.
 func (f *flush) addMetric(metricType metricType, value float64, source gostatsd.Source, tags gostatsd.Tags, name string) {
+	if math.IsInf(value, 1) || math.IsInf(value, -1) || math.IsNaN(value) {
+		// The value can not be represented within the JSON payload so it is to be discarded.
+		return
+	}
 	f.ts.Series = append(f.ts.Series, metric{
 		Host:     string(source),
 		Interval: f.flushIntervalSec,


### PR DESCRIPTION
There has been an issue trying to marshal due to the fact that +- Inf
and NaN break the JSON spec and caused data to be dropped.

The alternative I had in mind was that the aggregators cap values to be the max or min value that is represented by a float64 instead of Inf.