### PR TITLE
Document how the project uses semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+28.2.1
+------
+- Document how semver is used in the codebase.
+
 28.2.0
 ------
 - Changes how `parser.bad_lines_seen` and `backend.retried` metrics are sent.  They are now only sent on change.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,13 @@ Note that this project uses Go modules for dependency management.
 Documentation can be found via `go doc github.com/atlassian/gostatsd/pkg/statsd` or at
 https://godoc.org/github.com/atlassian/gostatsd/pkg/statsd
 
+Versioning
+----------
+Gostatsd uses semver versioning for both API and configuration settings, however it does not use it for packages.
+
+This is due to gostatsd being an application first and a library second.  Breaking API changes occur regularly, and
+the overhead of managing this is too burdensome.
+
 Contributors
 ------------
 


### PR DESCRIPTION
I'm going to skip cutting another release of 28.2.0, because we have the docker tag v28.2.0 already, and I don't want to cause confusion of which one should be consumed.  So 28.2.1 will be the "real" 28.2.0.

Closes #335