### PR TITLE
Update CloudHandler.DispatchMetricMap to use MetricMap all the way through

### DIFF
--- a/CLOUDPROVIDERS.md
+++ b/CLOUDPROVIDERS.md
@@ -12,9 +12,6 @@ There are currently two supported cloud providers:
 
 All configuration is in a stanza named after the backend, and takes simple key value pairs.
 
-**Cloud providers should be disabled on the aggregation server when using http forwarding, as the source IP isn't
-propagated, and that information should be collected on the ingestion server.**
-
 aws
 ---
 ### TODO

--- a/METRICS.md
+++ b/METRICS.md
@@ -70,7 +70,7 @@ Metrics:
 | version       | The git tag of the build
 | commit        | The short git commit of the build
 | backend       | The backend sending a particular metric
-| type          | Either metric or event
+| type          | Either metric or event for cloudprovider.hosts_queued, or event for cloudprovider.items_queued
 | result        | Success to indicate a batch of metrics was successfully processed, failure to indicate a batch of metrics was not processed, with additional failure tag for why)
 | failure       | The reason a batch of metrics was not processed
 | server-name   | The name of an http-server as specified in the config file

--- a/README.md
+++ b/README.md
@@ -216,9 +216,6 @@ Cloud providers are a way to automatically enrich metrics with metadata from a c
 
 Refer to [cloud providers](CLOUDPROVIDERS.md) for configuration options for the cloud providers.
 
-They should be disabled on the aggregation server when using http forwarding, as the source IP isn't propagated, and
-that information should be collected on the ingestion server.
-
 
 Configuring timer sub-metrics
 -----------------------------

--- a/counters.go
+++ b/counters.go
@@ -14,6 +14,11 @@ func NewCounter(timestamp Nanotime, value int64, source Source, tags Tags) Count
 	return Counter{Value: value, Timestamp: timestamp, Source: source, Tags: tags.Copy()}
 }
 
+func (c *Counter) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	c.Tags = c.Tags.Concat(additionalTags)
+	c.Source = newSource
+}
+
 // Counters stores a map of counters by tags.
 type Counters map[string]map[string]Counter
 

--- a/gauges.go
+++ b/gauges.go
@@ -13,6 +13,11 @@ func NewGauge(timestamp Nanotime, value float64, source Source, tags Tags) Gauge
 	return Gauge{Value: value, Timestamp: timestamp, Source: source, Tags: tags.Copy()}
 }
 
+func (g *Gauge) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	g.Tags = g.Tags.Concat(additionalTags)
+	g.Source = newSource
+}
+
 // Gauges stores a map of gauges by tags.
 type Gauges map[string]map[string]Gauge
 

--- a/metric_map.go
+++ b/metric_map.go
@@ -373,6 +373,7 @@ func (mm *MetricMap) String() string {
 }
 
 // AsMetrics will synthesize Metrics from the MetricMap and return them as a slice
+// TODO: Remove this function, it only supports tests now
 func (mm *MetricMap) AsMetrics() []*Metric {
 	var metrics []*Metric
 

--- a/metric_map.go
+++ b/metric_map.go
@@ -373,7 +373,8 @@ func (mm *MetricMap) String() string {
 }
 
 // AsMetrics will synthesize Metrics from the MetricMap and return them as a slice
-// TODO: Remove this function, it only supports tests now
+// TODO: Remove this function.
+// Deprecated: It only supports tests now
 func (mm *MetricMap) AsMetrics() []*Metric {
 	var metrics []*Metric
 

--- a/metrics.go
+++ b/metrics.go
@@ -53,17 +53,6 @@ type Metric struct {
 	DoneFunc  func()     // Returns the metric to the pool. May be nil. Call Metric.Done(), not this.
 }
 
-func (m *Metric) AddTagsSetSource(additionalTags Tags, newSource Source) {
-	if len(additionalTags) > 0 {
-		m.Tags = m.Tags.Concat(additionalTags)
-		m.TagsKey = ""
-	}
-	if newSource != m.Source {
-		m.Source = newSource
-		m.TagsKey = ""
-	}
-}
-
 // Reset is used to reset a metric to as clean state, called on re-use from the pool.
 func (m *Metric) Reset() {
 	m.Name = ""

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -36,20 +36,20 @@ func TestMetricString(t *testing.T) {
 	}
 }
 
-func TestUpdateTags(t *testing.T) {
-	m := &Metric{}
-	m.FormatTagsKey()
-	require.EqualValues(t, "", m.TagsKey)
-	m.AddTagsSetSource(Tags{"foo"}, "source")
-	require.EqualValues(t, Tags{"foo"}, m.Tags)
-	require.EqualValues(t, "source", m.Source)
-	require.EqualValues(t, "", m.TagsKey)
-	m.FormatTagsKey()
-	require.EqualValues(t, "foo,s:source", m.TagsKey) // It's set
-	m.AddTagsSetSource(Tags{"foo2"}, "source2")
-	require.EqualValues(t, Tags{"foo", "foo2"}, m.Tags)
-	require.EqualValues(t, "source2", m.Source)
-	require.EqualValues(t, "", m.TagsKey) // It's cleared
-	m.FormatTagsKey()
-	require.EqualValues(t, "foo,foo2,s:source2", m.TagsKey)
+func TestAddTagsSetSource(t *testing.T) {
+	mCounter := Counter{}
+	mCounter.AddTagsSetSource(Tags{"foo"}, "source")
+	require.Equal(t, Tags{"foo"}, mCounter.Tags)
+
+	mGauge := Gauge{}
+	mGauge.AddTagsSetSource(Tags{"foo"}, "source")
+	require.Equal(t, Tags{"foo"}, mGauge.Tags)
+
+	mSet := Set{}
+	mSet.AddTagsSetSource(Tags{"foo"}, "source")
+	require.Equal(t, Tags{"foo"}, mSet.Tags)
+
+	mTimer := Timer{}
+	mTimer.AddTagsSetSource(Tags{"foo"}, "source")
+	require.Equal(t, Tags{"foo"}, mTimer.Tags)
 }

--- a/sets.go
+++ b/sets.go
@@ -13,6 +13,11 @@ func NewSet(timestamp Nanotime, values map[string]struct{}, source Source, tags 
 	return Set{Values: values, Timestamp: timestamp, Source: source, Tags: tags.Copy()}
 }
 
+func (s *Set) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	s.Tags = s.Tags.Concat(additionalTags)
+	s.Source = newSource
+}
+
 // Sets stores a map of sets by tags.
 type Sets map[string]map[string]Set
 

--- a/timers.go
+++ b/timers.go
@@ -1,6 +1,8 @@
 package gostatsd
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+)
 
 // Timer is used for storing aggregated values for timers.
 type Timer struct {
@@ -35,6 +37,11 @@ func NewTimer(timestamp Nanotime, values []float64, source Source, tags Tags) Ti
 // NewTimerValues initialises a new timer only from Values array
 func NewTimerValues(values []float64) Timer {
 	return NewTimer(Nanotime(0), values, "", nil)
+}
+
+func (t *Timer) AddTagsSetSource(additionalTags Tags, newSource Source) {
+	t.Tags = t.Tags.Concat(additionalTags)
+	t.Source = newSource
 }
 
 // Timers stores a map of timers by tags.
@@ -108,5 +115,4 @@ func DisabledSubMetrics(viper *viper.Viper) TimerSubtypes {
 		SumSquares:     subViper.GetBool("sum-squares"),
 		SumSquaresPct:  subViper.GetBool("sum-squares-pct"),
 	}
-
 }


### PR DESCRIPTION
This is the current "big" thing that I'm aware of blocking clustering, 'cause it interferes with loop detection.

As usual, commits are relatively stand-alone.

@mwhittington21 - if you could get a chance to test this at some point (I'll release it as 28.3.0-rc1), that would be much appreciated.  I generally soak changes locally, but I can only validate this one with tests.