### PR TITLE
Fixes a race in the coverage of sender.Sender

### DIFF
--- a/pkg/backends/sender/sender_test.go
+++ b/pkg/backends/sender/sender_test.go
@@ -67,7 +67,7 @@ func TestSendCallsCallbacksOnMainCtxDone(t *testing.T) {
 		ConnFactory: func() (net.Conn, error) {
 			return nil, errors.New("(donotwant)")
 		},
-		Sink: make(chan Stream, 1),
+		Sink: make(chan Stream),
 		BufPool: sync.Pool{
 			New: func() interface{} {
 				return new(bytes.Buffer)


### PR DESCRIPTION
When this channel is buffered, the following sequence occurs:

- `Sender.Run` enters the [select](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender.go#L57) loop and goes to sleep
- `TestSendCallsCallbacksOnMainCtxDone` [sends](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender_test.go#L84) a `Stream` to the buffered channel
- `TestSendCallsCallbacksOnMainCtxDone` [cancels](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender_test.go#L94) the context
- `Sender.Run` wakes up

At this point, `Sender.Run` will randomly receive from one of the channels:
1. [ctx.Done](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender.go#L58) will result in the function exiting with a nil stream (and thus not invoking the [callback](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender.go#L40).)
2. [sink](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender.go#L62) will result in `stream` being set, then the next time through the loop, the cancelled context will be picked up, and the function will exit and invoke the callback.

By making this an unbuffered channel, the following will happen:
- `Sender.Run` enters the [select](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender.go#L57) loop
- TestSendCallsCallbacksOnMainCtxDone [sends](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/sender/sender_test.go#L84) a `Stream` to the channel
- `TestSendCallsCallbacksOnMainCtxDone` does **not** cancel the context, because the `Stream` must be received before the send will return
- `Sender.Run` wakes up and picks up the `Stream`
- `TestSendCallsCallbacksOnMainCtxDone` cancels the context
- `Sender.Run` re-enters the select, and picks up the canceled context

Fixes #345