### PR TITLE
Unify tracking of metrics and events in CloudHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Next
+----
+- Refactor the cloud handler to use the modern pipeline.  This removes the `cloudprovider.items_queued` metric, and now
+  tracks the absolute number of hosts to look up, regardless of type.
+
 29.0.0
 ------
 - Support for ARM64 docker image

--- a/METRICS.md
+++ b/METRICS.md
@@ -53,8 +53,7 @@ Metrics:
 | cloudprovider.cache_refresh_negative        | gauge (cumulative)  |                              | The cumulative number of refreshes which had an error refreshing and used old data
 | cloudprovider.cache_hit                     | gauge (cumulative)  |                              | The cumulative number of cache hits (host was in the cache)
 | cloudprovider.cache_miss                    | gauge (cumulative)  |                              | The cumulative number of cache misses
-| cloudprovider.hosts_queued                  | gauge (flush)       | type                         | The absolute number of hosts waiting to be looked up
-| cloudprovider.items_queued                  | gauge (flush)       | type                         | The absolute number of metrics or events waiting for a host lookup to complete
+| cloudprovider.hosts_queued                  | gauge (flush)       |                              | The absolute number of hosts waiting to be looked up
 | http.forwarder.invalid                      | counter             |                              | The number of failures to prepare a batch of metrics to forward
 | http.forwarder.created                      | counter             |                              | The number of batches prepared for forwarding
 | http.forwarder.sent                         | counter             |                              | The number of batches successfully forwarded
@@ -70,7 +69,6 @@ Metrics:
 | version       | The git tag of the build
 | commit        | The short git commit of the build
 | backend       | The backend sending a particular metric
-| type          | Either metric or event for cloudprovider.hosts_queued, or event for cloudprovider.items_queued
 | result        | Success to indicate a batch of metrics was successfully processed, failure to indicate a batch of metrics was not processed, with additional failure tag for why)
 | failure       | The reason a batch of metrics was not processed
 | server-name   | The name of an http-server as specified in the config file

--- a/pkg/statsd/handler_backend.go
+++ b/pkg/statsd/handler_backend.go
@@ -167,7 +167,7 @@ func (bh *BackendHandler) DispatchEvent(ctx context.Context, e *gostatsd.Event) 
 	for _, backend := range bh.backends {
 		select {
 		case <-ctx.Done():
-			// Not all backends got the event, should decrement the wg counter
+			// Not all backends got the event, should decrement the wg counter to account for it
 			bh.eventWg.Add(eventsDispatched - len(bh.backends))
 			return
 		case bh.concurrentEvents <- struct{}{}:


### PR DESCRIPTION
Instead of having a per source for metrics queue and a per source for events queue, this unifies it in to a single per host for anything queue.

This simplifies the logic, and removes what appears to be a logic bug: https://github.com/atlassian/gostatsd/pull/341#discussion_r469824228