### PR TITLE
bump alpine from version 3.10 to 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+29.0.1
+------
+- Update to Alpine 3.13
+
 29.0.0
 ------
 - Support for ARM64 docker image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 
 RUN apk --no-cache add \
     ca-certificates

--- a/cmd/tester/Dockerfile
+++ b/cmd/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 RUN apk --no-cache add \
 	ca-certificates
 ADD statsd-tester-linux /bin/statsd-tester


### PR DESCRIPTION
Hi,

I ran the tests/benchmarking and it all seemed fine. Let me know if there's anything else I need to do.

Bumping the version to fix vulnerabilities including (https://snyk.io/test/docker/alpine%3A3.10.0#SNYK-ALPINE310-OPENSSL-587954).

-cfei