### PR TITLE
Fixed issue in NewRelic backend which prevent to report internal metrics

### DIFF
--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -93,6 +93,8 @@ type Client struct {
 	flushInterval    time.Duration
 }
 
+var _ = gostatsd.Runner((*Client)(nil))
+
 // NRInfraPayload represents New Relic Infrastructure Payload format
 // https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/v2tov3.md#v2-json-full-sample
 type NRInfraPayload struct {

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -402,21 +402,6 @@ func TestEventFormatter(t *testing.T) {
 	}
 }
 
-func TestNewRelicFulfillRunnerInterface(t *testing.T) {
-	v := viper.New()
-	v.SetDefault("transport.default.client-timeout", 1*time.Second)
-	p := transport.NewTransportPool(logrus.New(), v)
-	client, err := NewClient("default", "v1/data", "", "GoStatsD", "insights", "api-key", "", "metric_name", "metric_type",
-		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
-		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
-		defaultMetricsPerBatch, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, logrus.New(), p)
-	require.NoError(t, err)
-
-	runnables := []gostatsd.Runnable{}
-	runnables = gostatsd.MaybeAppendRunnable(runnables, client)
-	require.Len(t, runnables, 1)
-}
-
 func countMatches(s string, m string) int {
 	index := suffixarray.New([]byte(s))
 	return len(index.Lookup([]byte(m), -1))

--- a/pkg/backends/newrelic/newrelic_test.go
+++ b/pkg/backends/newrelic/newrelic_test.go
@@ -402,6 +402,21 @@ func TestEventFormatter(t *testing.T) {
 	}
 }
 
+func TestNewRelicFulfillRunnerInterface(t *testing.T) {
+	v := viper.New()
+	v.SetDefault("transport.default.client-timeout", 1*time.Second)
+	p := transport.NewTransportPool(logrus.New(), v)
+	client, err := NewClient("default", "v1/data", "", "GoStatsD", "insights", "api-key", "", "metric_name", "metric_type",
+		"metric_per_second", "metric_value", "samples_min", "samples_max", "samples_count",
+		"samples_mean", "samples_median", "samples_std_dev", "samples_sum", "samples_sum_squares", "agent",
+		defaultMetricsPerBatch, defaultMaxRequests, 2*time.Second, 1*time.Second, gostatsd.TimerSubtypes{}, logrus.New(), p)
+	require.NoError(t, err)
+
+	runnables := []gostatsd.Runnable{}
+	runnables = gostatsd.MaybeAppendRunnable(runnables, client)
+	require.Len(t, runnables, 1)
+}
+
 func countMatches(s string, m string) int {
 	index := suffixarray.New([]byte(s))
 	return len(index.Lookup([]byte(m), -1))


### PR DESCRIPTION
### Changes
- Fulfill Runner interface in NewRelic backend to report internal metrics.
- Added regression test to show that NewRelic backend was not fulfilling the Runner interface.


## Context
I have been investigating that NewRelic backend has not been sending backend internal metrics when `statser-type = internal` is set.

I have found that the issue is a bug in the Newrelic backend implementation.
The backend has a method [RunMetrics](https://github.com/atlassian/gostatsd/blob/master/pkg/backends/newrelic/newrelic.go#L178) which is intended to receive flush events and update internal metrics. However this method **is not being executed** (yes! it is dead code).

During initialisation, GoStatsD allows components to decide to run specific methods in background.
Internally GoStatsD keeps an array of runnables that would be executed after the initialisation.

This goal is achieved by calling [gostatsd.MaybeAppendRunnable](https://github.com/atlassian/gostatsd/blob/07e3525daa7c9c2c303c9551fa5c726db569029e/types.go#L62). For example after [instanciate a backed](https://github.com/atlassian/gostatsd/blob/master/cmd/gostatsd/main.go#L127).

"gostatsd.MaybeAppendRunnable" checks if the component implements [Runner interface](https://github.com/atlassian/gostatsd/blob/07e3525daa7c9c2c303c9551fa5c726db569029e/types.go#L54) or/and
[MetricsRunner interface](https://github.com/atlassian/gostatsd/blob/07e3525daa7c9c2c303c9551fa5c726db569029e/types.go#L58).
If the component implements the interface a specific method (Run or/and RunMetricsContext) is added to the array of runnables.
Just after the initialisation all the method in the array of runnables [are executed](https://github.com/atlassian/gostatsd/blob/65989af91f9ca3b62aa8b0f8cbe8a110d6b2aac2/pkg/statsd/statsd.go#L201-L203).

Newrelic backend does not implement Runner neither MetricsRunner interfaces. Because of that, the backend does not run any background task and as result backend's metrics are not reported to statser.

Basically, the fix consist in rename `RunMetricsContext` to `Run` to implements the `Runner` interface and add `<NewRelicBackend>.Run` to the array of runnables.

The diagram below shows the call chain when a "flush" occurs.
![application-logging-Page-5](https://user-images.githubusercontent.com/360408/127658857-b8e01aa2-eb32-4915-b7bb-d4cda98ac8ea.jpg)

Explanation:
1. Run is executed in background, it register to receive "flush events"
2. It is time to flush, so MetricsFlusher.NotifyFlush is called
3. SendMetricsAsync is called for all the backend.
4. A tick is emitted to all the registered backend using a channel.
5. SendEvent is executed in the backend and the metrics are sent to they final destination.
5. Backend's Run background task receives the "flush" event and reports the internal metrics back to statser.

### Results
With this patch applied, internal "backend" metrics appeared into newrelic based on the "flush interval" as you can see in the image below 🎉 .

<img width="910" alt="Screenshot 2021-07-30 at 15 24 59" src="https://user-images.githubusercontent.com/360408/127659534-d638ac29-e4e2-42d8-9436-c984e70e7376.png">

I have GoStatsD with this patch running in production environment without issue and reporting the metrics as expected.