### PR TITLE
Bump Alpine version to 3.13 -> 3.14.1 to fix apk-tools vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+29.0.2
+------
+- Update to Alpine 3.14.1
+
 29.0.1
 ------
 - Update to Alpine 3.13

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14.1
 
 RUN apk --no-cache add \
     ca-certificates

--- a/cmd/tester/Dockerfile
+++ b/cmd/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14.1
 RUN apk --no-cache add \
 	ca-certificates
 ADD statsd-tester-linux /bin/statsd-tester


### PR DESCRIPTION
Bumping version to fix this vulnerability, https://security.alpinelinux.org/vuln/CVE-2021-36159.