### PR TITLE
Release Candidate 34.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-unreleased
+34.0.0
 ------
-- Forces http metrics forwarder to flush all data queued on shutdown
+- (Breaking Change) Forces http metrics forwarder to flush all data queued on shutdown
 - Upgrade from Alpine 3.14.3 -> 3.15.0
+- Dependancy upgrades
 
 33.0.2
 ------


### PR DESCRIPTION
## Breaking Change

There is a behavioural change to how the flush system works, it will now hold up any `context.Done` events until it has finished all of the required work. This should not impact statistically aggregation negatively but rather enough that there is data for those time intervals that would have been missed during a system's shutdown event.

## Minor Change

There is some additional changes for the dependancies and fixes to some CVEs found in the docker image.

# Change List

Please see https://github.com/atlassian/gostatsd/compare/33.0.2...master for the list of changes being made between versions.