### PR TITLE
This cleans up gofmt failures, and makes the build system enforce it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
   - make setup-ci
 
 script:
+  - make check-fmt
   - make build-all
   - make coveralls || true # Failing coveralls check should not break the build
   - make check

--- a/internal/lexer/lexer_fuzz.go
+++ b/internal/lexer/lexer_fuzz.go
@@ -1,4 +1,4 @@
-// +build gofuzz
+//go:build gofuzz
 
 package lexer
 

--- a/metric_consolidator.go
+++ b/metric_consolidator.go
@@ -38,21 +38,21 @@ func NewMetricConsolidator(spots int, flushInterval time.Duration, sink chan<- [
 	return mc
 }
 
-	func (mc *MetricConsolidator) Run(ctx context.Context) {
-		clck := clock.FromContext(ctx)
-		t := clck.NewTicker(mc.flushInterval)
-		defer t.Stop()
+func (mc *MetricConsolidator) Run(ctx context.Context) {
+	clck := clock.FromContext(ctx)
+	t := clck.NewTicker(mc.flushInterval)
+	defer t.Stop()
 
-		for {
-			select {
-			case <-ctx.Done():
-				mc.Flush()
-				return
-			case <-t.C:
-				mc.Flush()
-			}
+	for {
+		select {
+		case <-ctx.Done():
+			mc.Flush()
+			return
+		case <-t.C:
+			mc.Flush()
 		}
 	}
+}
 
 // Drain will collect all the MetricMaps in the MetricConsolidator and return them.
 func (mc *MetricConsolidator) Drain() []*MetricMap {

--- a/tools.go
+++ b/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package gostatsd
 


### PR DESCRIPTION
For some reason we don't run gofmt/goimports in CI, which has let some problems creep in.  This adds enforcement to CI, and a helper Makefile target to perform the cleanup.

It also removes part of the `go install` usage, because:
1. it's a global solution to a local problem (aka, it's rude to install things to peoples path)
2. if we depend on tools in the path, then it defeats pinning the tool version in tools.go