### PR TITLE
Update alpine base image to 3.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+34.2.1
+------
+- Upgrade from Alpine 3.15.0 -> 3.15.3
+
 34.2.0
 ------
 - Support for Unix Domain Sockets added by rubenruizdegauna

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.4
 
 RUN apk --no-cache add \
     ca-certificates


### PR DESCRIPTION
This upgrade fixes to a number of CVEs, see https://git.alpinelinux.org/aports/log/?h=v3.15.3