### PR TITLE
New relic statsd source

### DIFF
--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -285,3 +285,18 @@ Additional options are available to rename attributes if required.
 	timer-sum = "samples_sum"
 	timer-sumsquare = "samples_sum_squares"
 ```
+
+### Host Tag
+When `--ignore-host` is not set, the New Relic backend will add the tag `statsdSource` to
+all metrics. The value of this tag will be the `gostatsd.Source` string recorded
+with each metric. So as not to collide with the existing `host` attribute that
+is added to many infrastructure samples, the name `statsdSource` was chosen
+instead of `host`.
+
+*NOTE:* The addition of the `statsdSource` tag can potentially cause an
+explosion in [cardinality](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/).
+To avoid hitting cardinality limits, the `--ignore-host` option is the default
+when using the New Relic backend. To enable this functionality, supply
+`--ignore-host false` and be sure to watch your cardinality closely with a query
+like `SELECT cardinality() FROM Metric WHERE integration.name='GoStatsD'` or
+`SELECT cardinality() FROM Metric WHERE integration.name='GoStatsD' FACET metricName`.

--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -287,8 +287,8 @@ Additional options are available to rename attributes if required.
 ```
 
 ### Host Tag
-When `--ignore-host` is not set, the New Relic backend will add the tag `statsdSource` to
-all metrics. The value of this tag will be the `gostatsd.Source` string recorded
+When `--ignore-host` is not set, the New Relic backend will add the tag `statsdSource`
+to all metrics. The value of this tag will be the `gostatsd.Source` string recorded
 with each metric. So as not to collide with the existing `host` attribute that
 is added to many infrastructure samples, the name `statsdSource` was chosen
 instead of `host`.

--- a/pkg/backends/newrelic/flush.go
+++ b/pkg/backends/newrelic/flush.go
@@ -44,7 +44,7 @@ func (f *flush) addMetric(n *Client, metricType string, value float64, persecond
 // addMetric adds a timer metric to the series.
 func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Timer, tagsKey, name string) {
 	if n.flushType == flushTypeMetrics {
-		newTags := maybeAddHost(timer.Source, timer.Tags)
+		newTags := maybeAddSource(timer.Source, timer.Tags)
 
 		timerMetric := newDimensionalMetricSet(n, f, name, metricType, float64(timer.Count), newTags)
 
@@ -93,7 +93,7 @@ func (f *flush) addTimerMetric(n *Client, metricType string, timer gostatsd.Time
 		}
 		f.ts.Metrics = append(f.ts.Metrics, timerMetric)
 	} else {
-		newTags := maybeAddHost(timer.Source, timer.Tags)
+		newTags := maybeAddSource(timer.Source, timer.Tags)
 
 		timerMetric := newMetricSet(n, f, name, metricType, float64(timer.Count), newTags)
 

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -32,7 +32,7 @@ const (
 	// BackendName is the name of this backend.
 	BackendName                  = "newrelic"
 	integrationName              = "com.newrelic.gostatsd"
-	integrationVersion           = "2.3.1"
+	integrationVersion           = "2.4.0"
 	protocolVersion              = "2"
 	defaultUserAgent             = "gostatsd"
 	defaultMaxRequestElapsedTime = 15 * time.Second
@@ -496,6 +496,7 @@ func NewClientFromViper(v *viper.Viper, logger logrus.FieldLogger, pool *transpo
 	// New Relic Config Defaults & Recommendations
 	v.SetDefault("statser-type", "null")
 	v.SetDefault("flush-interval", "10s")
+	v.SetDefault("ignore-host", "true")
 	if v.GetString("statser-type") == "null" {
 		logger.Info("internal metrics OFF, to enable set 'statser-type' to 'logging' or 'internal'")
 	}

--- a/pkg/backends/newrelic/newrelic.go
+++ b/pkg/backends/newrelic/newrelic.go
@@ -210,19 +210,19 @@ func (n *Client) processMetrics(now float64, metrics *gostatsd.MetricMap, cb fun
 	}
 
 	metrics.Gauges.Each(func(key, tagsKey string, g gostatsd.Gauge) {
-		newTags := maybeAddHost(g.Source, g.Tags)
+		newTags := maybeAddSource(g.Source, g.Tags)
 		fl.addMetric(n, "gauge", g.Value, 0, newTags, key)
 		fl.maybeFlush()
 	})
 
 	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
-		newTags := maybeAddHost(counter.Source, counter.Tags)
+		newTags := maybeAddSource(counter.Source, counter.Tags)
 		fl.addMetric(n, "counter", float64(counter.Value), counter.PerSecond, newTags, key)
 		fl.maybeFlush()
 	})
 
 	metrics.Sets.Each(func(key, tagsKey string, set gostatsd.Set) {
-		newTags := maybeAddHost(set.Source, set.Tags)
+		newTags := maybeAddSource(set.Source, set.Tags)
 		fl.addMetric(n, "set", float64(len(set.Values)), 0, newTags, key)
 		fl.maybeFlush()
 	})
@@ -234,7 +234,7 @@ func (n *Client) processMetrics(now float64, metrics *gostatsd.MetricMap, cb fun
 				if !math.IsInf(float64(histogramThreshold), 1) {
 					bucketTag = "le:" + strconv.FormatFloat(float64(histogramThreshold), 'f', -1, 64)
 				}
-				newTags := maybeAddHost(timer.Source, timer.Tags.Concat(gostatsd.Tags{bucketTag}))
+				newTags := maybeAddSource(timer.Source, timer.Tags.Concat(gostatsd.Tags{bucketTag}))
 				fl.addMetric(n, "counter", float64(count), 0, newTags, key+".histogram")
 			}
 		} else {
@@ -666,7 +666,7 @@ func contains(s []string, e string) bool {
 
 // If source is not empty and tags does not already have a host tag,
 // add a statsdSource tag.
-func maybeAddHost(source gostatsd.Source, tags gostatsd.Tags) gostatsd.Tags {
+func maybeAddSource(source gostatsd.Source, tags gostatsd.Tags) gostatsd.Tags {
 	if source == "" {
 		return tags
 	}


### PR DESCRIPTION
## Change summary

The purpose of this change is to allow NRQL queries to `FACET` by the source of a given `Metric` coming from a host through `gostatsd`.

* Added `maybeAddSource` to add the `statsdSource` tag to metrics in the New Relic backend.