### PR TITLE
bump alpine to 3.15.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.5
 
 RUN apk --no-cache add \
     ca-certificates


### PR DESCRIPTION
bump alpine to [3.15.5](https://alpinelinux.org/posts/Alpine-3.13.11-3.14.7-3.15.5-released.html) which fixed [CVE-2022-2097](https://security.alpinelinux.org/vuln/CVE-2022-2097)

