### PR TITLE
bump alpine to 3.15.5 for cmd/tester and update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+35.0.1
+------
+- Update to Alpine 3.15.5
+
 35.0.0
 ------
 - Adds a statsdSource tag to the New Relic backend, see [BACKENDS.md](BACKENDS.md) for details.

--- a/cmd/tester/Dockerfile
+++ b/cmd/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.5
 RUN apk --no-cache add \
     ca-certificates
 ADD statsd-tester-linux /bin/statsd-tester


### PR DESCRIPTION
bump alpine to [3.15.5](https://alpinelinux.org/posts/Alpine-3.13.11-3.14.7-3.15.5-released.html) in cmd/tester which fixed [CVE-2022-2097](https://security.alpinelinux.org/vuln/CVE-2022-2097)

Updated change log