### PR TITLE
Limit dependabot to 1 PR per group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,14 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  open-pull-requests-limit: 1 # Limit to 1 to reduce travis credit usage
 - package-ecosystem: "docker"
   directory: "/build"
   schedule:
     interval: "weekly"
+  open-pull-requests-limit: 1
 - package-ecosystem: "docker"
   directory: "/cmd/tester"
   schedule:
     interval: "weekly"    
+  open-pull-requests-limit: 1


### PR DESCRIPTION
We ran out of travis credits because every time a dependabot was merged,
we would:

- build master
- rebase the other 4 dependabot PRs and build them
- get a fresh dependabot PR

This was 6 builds, running for both x64 and arm64.

So this will limit us to 1 PR per group, and I'll try to personally keep
a closer eye on the dependabot PRs.