### PR TITLE
Allow parallel metrics merging with HTTP forwarder mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+35.1.3
+------
+- HTTP forwarder updated with a new option `concurrent-merge` to support parallel processing, the
+  default value is backward-compatible.
+
 35.1.2
 ------
 - Bump all the libraries.  No user visible impact expected.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ following configuration options:
 - `api-endpoint`: configures the endpoint to submit raw metrics to.  This setting should be just a base URL, for example
   `https://statsd-aggregator.private`, with no path.  Required, no default
 - `max-requests`: maximum number of requests in flight.  Defaults to `1000` (which is probably too high)
+- `concurrent-merge`: maximum number of concurrent goroutines allowed to merge metrics before forwarding.  Defaults to `1` for backward-compatibility
 - `max-request-elapsed-time`: duration for the maximum amount of time to try submitting data before giving up.  This
   includes retries.  Defaults to `30s` (which is probably too high). Setting this value to `-1` will disable retries.
 - `consolidator-slots`: number of slots in the metric consolidator.  Memory usage is a function of this.  Lower values

--- a/pkg/statsd/handler_http_forwarder_v2_test.go
+++ b/pkg/statsd/handler_http_forwarder_v2_test.go
@@ -251,6 +251,7 @@ func TestForwardingData(t *testing.T) {
 		s.URL,
 		1,
 		1,
+		1,
 		false,
 		100*time.Millisecond, // maxRequestElapsedTime
 		100*time.Millisecond, // flushInterval
@@ -312,7 +313,7 @@ func TestHttpForwarderV2New(t *testing.T) {
 			expected:   []string{"service:", "deploy:"},
 		},
 	} {
-		h, err := NewHttpForwarderHandlerV2(logger, "default", "endpoint", 1, 1, false, time.Second, time.Second,
+		h, err := NewHttpForwarderHandlerV2(logger, "default", "endpoint", 1, 1, 1, false, time.Second, time.Second,
 			cusHeaders, testcase.dynHeaders, pool)
 		require.Nil(t, err)
 		require.Equal(t, h.dynHeaderNames, testcase.expected)

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -54,6 +54,7 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		c.URL,
 		5, // deliberately prime, so the loop below doesn't send the same thing to the same MetricMap every time.
 		10,
+		1,
 		false,
 		10*time.Second,
 		10*time.Millisecond,


### PR DESCRIPTION
In the forwarder mode, metrics merging is a blocking operation which may introduce significant back pressure to the UDP consumption if there is large load. This patch adds a configuration `concurrent-merge` to allow for parallel processing of the merging operation. The default value is set to 1 to maintain backward-compatibility since it aggravates the out-of-orderness of the forwarding metrics.