### PR TITLE
End the comparison step on an echo

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -29,7 +29,7 @@ jobs:
           # get the latest tag
           TAG=$(git describe --tag --abbrev=0)
           [ "$(git rev-parse master)" != "$(git rev-parse $TAG)" ] && echo "master branch and $TAG are different commits" && exit 1
-          echo "Master branch and $TAG are the same commits. We can continue with the release."
+          echo "Master branch and $TAG are the same commit. We can continue with the release."
       # Get the token we need to publish to packages.atlassian.com
       - name: Get publish token
         id: publish-token

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -29,6 +29,7 @@ jobs:
           # get the latest tag
           TAG=$(git describe --tag --abbrev=0)
           [ "$(git rev-parse master)" != "$(git rev-parse $TAG)" ] && echo "master branch and $TAG are different commits" && exit 1
+          echo "Master branch and $TAG are the same commits. We can continue with the release."
       # Get the token we need to publish to packages.atlassian.com
       - name: Get publish token
         id: publish-token


### PR DESCRIPTION
This is because, if the last command is the bash test which we expect to exit with `1` in the successful case, then the result of the step will be failure.

In this change, we will make the last command an echo, which should exit with `0` and make the step a success...
The test should still handle the case of the master and tag commits being different.