### PR TITLE
Load buildx image into docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,13 +125,13 @@ build-hash: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH) -f build/Dockerfile-multiarch \
     --build-arg MAIN_PKG=$(MAIN_PKG) \
     --build-arg BINARY_NAME=$(BINARY_NAME) \
-    --platform=linux/$(CPU_ARCH) .
+    --platform=linux/$(CPU_ARCH) . --load
 
 build-hash-race: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH)-race -f build/Dockerfile-multiarch-glibc \
 	--build-arg MAIN_PKG=$(MAIN_PKG) \
 	--build-arg BINARY_NAME=$(BINARY_NAME) \
-	--platform=linux/$(CPU_ARCH) .
+	--platform=linux/$(CPU_ARCH) . --load
 
 release-hash-ci: build-hash
 	docker push $(IMAGE_NAME):$(GIT_HASH)

--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ git-hook:
 
 build-hash: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH) -f build/Dockerfile-multiarch \
-    	--build-arg MAIN_PKG=$(MAIN_PKG) \
-    	--build-arg BINARY_NAME=$(BINARY_NAME) \
-    	--platform=linux/$(CPU_ARCH) . --output=type=image
+		--build-arg MAIN_PKG=$(MAIN_PKG) \
+		--build-arg BINARY_NAME=$(BINARY_NAME) \
+		--platform=linux/$(CPU_ARCH) . --output=type=image
 	docker images
 
 build-hash-race: pb/gostatsd.pb.go

--- a/Makefile
+++ b/Makefile
@@ -123,15 +123,17 @@ git-hook:
 
 build-hash: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH) -f build/Dockerfile-multiarch \
-    --build-arg MAIN_PKG=$(MAIN_PKG) \
-    --build-arg BINARY_NAME=$(BINARY_NAME) \
-    --platform=linux/$(CPU_ARCH) . --load
+    	--build-arg MAIN_PKG=$(MAIN_PKG) \
+    	--build-arg BINARY_NAME=$(BINARY_NAME) \
+    	--platform=linux/$(CPU_ARCH) . --output=type=image
+	docker images
 
 build-hash-race: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH)-race -f build/Dockerfile-multiarch-glibc \
-	--build-arg MAIN_PKG=$(MAIN_PKG) \
-	--build-arg BINARY_NAME=$(BINARY_NAME) \
-	--platform=linux/$(CPU_ARCH) . --load
+		--build-arg MAIN_PKG=$(MAIN_PKG) \
+		--build-arg BINARY_NAME=$(BINARY_NAME) \
+		--platform=linux/$(CPU_ARCH) . --output=type=image
+	docker images
 
 release-hash-ci: build-hash
 	docker push $(IMAGE_NAME):$(GIT_HASH)


### PR DESCRIPTION
After the last failed release I had another look at the docs and the build output:

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

So it seems like the default behavior (at least in CI) is for the build to just be stored in a build cache? And maybe not available as a local image?

From the [docs](https://docs.docker.com/engine/reference/commandline/buildx_build/#output):

>  --load |   | Shorthand for --output=type=docker
> The docker export type writes the single-platform result image as a [Docker image specification](https://github.com/docker/docker/blob/v20.10.2/image/spec/v1.2.md) tarball on the client. Tarballs created by this exporter are also OCI compatible.

> Currently, multi-platform images cannot be exported with the docker export type. The most common usecase for multi-platform images is to directly push to a [registry](https://docs.docker.com/engine/reference/commandline/buildx_build/#registry) (see registry).

But then looking at the `image` output type, this seems like exactly what we want
> The image exporter writes the build result as an image or a manifest list. When using docker driver the image will appear in docker images. Optionally, image can be automatically pushed to a registry by specifying attributes.

So I'm going to try that, and I've added a "debug" step to print out all local images after the buildx step...
