### PR TITLE
Maybe this time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,14 +125,16 @@ build-hash: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH) -f build/Dockerfile-multiarch \
 		--build-arg MAIN_PKG=$(MAIN_PKG) \
 		--build-arg BINARY_NAME=$(BINARY_NAME) \
-		--platform=linux/$(CPU_ARCH) . --output=type=image
+		--platform=linux/$(CPU_ARCH) \
+		--load .
 	docker images
 
 build-hash-race: pb/gostatsd.pb.go
 	docker buildx build -t $(IMAGE_NAME):$(GIT_HASH)-race -f build/Dockerfile-multiarch-glibc \
 		--build-arg MAIN_PKG=$(MAIN_PKG) \
 		--build-arg BINARY_NAME=$(BINARY_NAME) \
-		--platform=linux/$(CPU_ARCH) . --output=type=image
+		--platform=linux/$(CPU_ARCH) \
+		--load .
 	docker images
 
 release-hash-ci: build-hash


### PR DESCRIPTION
- [all documentation](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#docker-container-driver) says to use --load for docker-container builder 
- buildx action [says it starts and makes docker-container the default](https://github.com/docker/setup-buildx-action) 
- move the --load option to where it's supposed to be - I don't think this is super important