### PR TITLE
[chore] Removing alpine installations

### DIFF
--- a/build/Dockerfile-multiarch
+++ b/build/Dockerfile-multiarch
@@ -14,8 +14,6 @@ ARG MAIN_PKG
 
 ADD . /build
 
-RUN apk update && apk add git
-
 RUN ldFlags="-s -X main.Version=$(git describe --abbrev=0 --tags) -X main.GitCommit=$(git rev-parse --short HEAD) -X main.BuildDate=$(date +%Y-%m-%d-%H:%M)"; \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o bin/linux/${TARGETARCH}/${BINARY_NAME} -ldflags "${ldFlags}" ${MAIN_PKG}
 

--- a/build/Dockerfile-multiarch-glibc
+++ b/build/Dockerfile-multiarch-glibc
@@ -14,9 +14,6 @@ ARG MAIN_PKG
 
 ADD . /build
 
-# We need git, gcc, libc-dev
-RUN apk update && apk add --update git gcc libc-dev
-
 # Race needs CGO
 # https://github.com/golang/go/issues/51235
 RUN ldFlags="-s -X main.Version=$(git describe --abbrev=0 --tags) -X main.GitCommit=$(git rev-parse --short HEAD) -X main.BuildDate=$(date +%Y-%m-%d-%H:%M)"; \


### PR DESCRIPTION
Removing the need to install git and gcc in the default docker images since they come with it.