### PR TITLE
[chore] Fix up codeql for dependabot

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [master]
   pull_request:
   schedule:
     - cron: '0 19 * * 0'


### PR DESCRIPTION
## Context

Apparently dependabot doesn't like having to deal with push events for pull requests, so this should limit push events to only master.