### PR TITLE
Add Lambda extension telemetry server

### DIFF
--- a/internal/awslambda/extension/manager.go
+++ b/internal/awslambda/extension/manager.go
@@ -66,7 +66,7 @@ func NewManager(lambdaDomain string, lambdaFileName string, log logrus.FieldLogg
 		name:   lambdaFileName,
 	}
 
-	m.telemetryServer = telemetry.NewServer(log, telemetry.NoopHook())
+	m.telemetryServer = telemetry.NewServer(telemetry.LambdaRuntimeAvailableAddr, log, telemetry.NoopHook())
 
 	return m
 }

--- a/internal/awslambda/extension/manager.go
+++ b/internal/awslambda/extension/manager.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
+	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
 )
 
 const (
@@ -26,9 +27,10 @@ const (
 )
 
 var (
-	ErrFailedRegistration = errors.New("extension failed to register with lambda")
-	ErrIssueProgress      = errors.New("unable to continue execution")
-	ErrServerEarlyExit    = errors.New("server has shutdown early without cause")
+	ErrFailedRegistration          = errors.New("extension failed to register with lambda")
+	ErrIssueProgress               = errors.New("unable continue execution")
+	ErrServerEarlyExit             = errors.New("server has shutdown early without cause")
+	ErrFailedTelemetrySubscription = errors.New("extension failed to subscribe to lambda telemetry API")
 )
 
 // Manager ensures that the lifetime management of the lambda
@@ -50,6 +52,8 @@ type manager struct {
 	domain       string
 	name         string
 	registeredID string
+
+	telemetryServer *telemetry.Server
 }
 
 var _ Manager = (*manager)(nil)
@@ -62,21 +66,33 @@ func NewManager(lambdaDomain string, lambdaFileName string, log logrus.FieldLogg
 		name:   lambdaFileName,
 	}
 
+	m.telemetryServer = telemetry.NewServer(log, func() {})
+
 	return m
 }
 
 func (m *manager) Run(parent context.Context, server Server) error {
+	var wg wait.Group
+	var chErrs = make(chan error, 3)
+
 	// Init Phase of the lambda
 	if err := m.register(parent); err != nil {
 		return err
 	}
 
+	// Start telemetry server
 	ctx, cancel := context.WithCancel(parent)
-	// Start gostatsd server
-	var wg wait.Group
-	var chErrs = make(chan error, 2)
 	defer cancel()
+	wg.StartWithContext(ctx, func(c context.Context) {
+		chErrs <- m.telemetryServer.Start(c)
+	})
 
+	if err := m.subscribeToTelemetry(ctx); err != nil {
+		m.log.WithError(err).Error("error subscribing to lambda telemetry endpoint")
+		return err
+	}
+
+	// Start gostatsd server
 	wg.StartWithContext(ctx, func(c context.Context) {
 		err := server.Run(c)
 		// Shutting down due to context is an acceptable
@@ -214,6 +230,41 @@ func (m *manager) register(ctx context.Context) error {
 	return nil
 }
 
+func (m *manager) subscribeToTelemetry(ctx context.Context) error {
+	b, err := jsoniter.Marshal(telemetry.SubscriptionRequest{
+		SchemaVersion: telemetry.ApiVersion,
+		Types:         []string{telemetry.PlatformSubscriptionType},
+		Destination:   &telemetry.SubscriptionDestination{URI: m.telemetryServer.Endpoint(), Protocol: telemetry.ProtocolHTTP},
+		// we buffer for the minimum time on the lambda side to avoid adding additional billedDuration to the lambda
+		Buffering: &telemetry.SubscriptionBufferingConfig{TimeoutMs: telemetry.MinBufferingTimeoutMs},
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, telemetry.SubscribeEndpoint.GetUrl(m.domain), bytes.NewReader(b))
+	req.Header.Set(api.LambdaExtensionIdentifierHeaderKey, m.registeredID)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		m.log.WithError(err).Errorf("received %d response code from telemetry subscription with body %s", resp.StatusCode, string(body))
+		return ErrFailedTelemetrySubscription
+	}
+
+	m.log.Info("successfully subscribed to telemetry API")
+
+	return nil
+}
+
 func (m *manager) nextEvent(ctx context.Context) (*api.EventNextPayload, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, api.EventEndpoint.GetUrl(m.domain), http.NoBody)
 	if err != nil {
@@ -226,10 +277,7 @@ func (m *manager) nextEvent(ctx context.Context) (*api.EventNextPayload, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/awslambda/extension/manager_test.go
+++ b/internal/awslambda/extension/manager_test.go
@@ -335,7 +335,7 @@ func TestManagerDo(t *testing.T) {
 				domain:          u.Hostname() + ":" + u.Port(),
 				name:            t.Name(),
 				registeredID:    t.Name(),
-				telemetryServer: telemetry.NewServer(log, telemetry.NoopHook(), telemetry.WithCustomAddr(availableAddr())),
+				telemetryServer: telemetry.NewServer(availableAddr(), log, telemetry.NoopHook()),
 			}
 
 			start := make(chan struct{}, 1)
@@ -404,7 +404,7 @@ func TestManagerTelemetrySubscription(t *testing.T) {
 				domain:          u.Hostname() + ":" + u.Port(),
 				name:            t.Name(),
 				registeredID:    t.Name(),
-				telemetryServer: telemetry.NewServer(log, telemetry.NoopHook(), telemetry.WithCustomAddr(availableAddr())),
+				telemetryServer: telemetry.NewServer(availableAddr(), log, telemetry.NoopHook()),
 			}
 
 			assert.ErrorIs(t, tc.expectedError, m.subscribeToTelemetry(context.Background()))

--- a/internal/awslambda/extension/manager_test.go
+++ b/internal/awslambda/extension/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,7 +18,7 @@ import (
 	"github.com/tilinna/clock"
 
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
-	"github.com/atlassian/gostatsd/internal/fixtures"
+	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 )
 
@@ -126,7 +127,7 @@ func ExitErrorHandler(tb testing.TB, statusCode int) http.Handler {
 	})
 }
 
-func EventNextHandler(tb testing.TB, ctx context.Context, statusCode, shutdownAfter int) http.Handler {
+func EventNextHandler(tb testing.TB, statusCode, shutdownAfter int) http.Handler {
 	count := 0
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		// Enforcing the correct method is used
@@ -138,7 +139,6 @@ func EventNextHandler(tb testing.TB, ctx context.Context, statusCode, shutdownAf
 		case http.StatusOK:
 			payload := &api.EventNextPayload{
 				EventType:          api.Invoke,
-				Deadline:           clock.FromContext(ctx).Now().UTC().Add(100 * time.Millisecond).UnixMilli(),
 				RequestID:          fmt.Sprint(count),
 				InvokedFunctionARN: "local:dev:gostatsd-extension-manager",
 			}
@@ -160,6 +160,21 @@ func EventNextHandler(tb testing.TB, ctx context.Context, statusCode, shutdownAf
 
 		count++
 	})
+}
+
+func TelemetryHandler(tb testing.TB, statusCode int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(tb, http.MethodPut, r.Method)
+		require.Contains(tb, r.Header, api.LambdaExtensionIdentifierHeaderKey)
+		require.Equal(tb, tb.Name(), r.Header.Get(api.LambdaExtensionIdentifierHeaderKey))
+		w.WriteHeader(statusCode)
+	})
+}
+
+func availableAddr() string {
+	l, _ := net.Listen("tcp", ":0")
+	defer l.Close()
+	return l.Addr().String()
 }
 
 func TestManagerRegister(t *testing.T) {
@@ -227,53 +242,68 @@ func TestManagerDo(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		Scenario      string
-		EventStatus   int
-		ShutdownAfter int
-		MockDelay     time.Duration
-		MockError     error
+		Scenario        string
+		EventStatus     int
+		TelemetryStatus int
+		ShutdownAfter   int
+		MockDelay       time.Duration
+		MockError       error
 
 		ExpectError error
 	}{
 		{
-			Scenario:      "Normal operation",
-			EventStatus:   http.StatusOK,
-			ShutdownAfter: 3,
-			MockDelay:     time.Second,
-			MockError:     nil,
-			ExpectError:   nil,
+			Scenario:        "Normal operation",
+			EventStatus:     http.StatusOK,
+			TelemetryStatus: http.StatusOK,
+			ShutdownAfter:   3,
+			MockDelay:       time.Second,
+			MockError:       nil,
+			ExpectError:     nil,
 		},
 		{
-			Scenario:      "Operational failure sending heartbeart",
-			EventStatus:   http.StatusInternalServerError,
-			ShutdownAfter: 2,
-			MockDelay:     time.Second,
-			MockError:     nil,
-			ExpectError:   ErrIssueProgress,
+			Scenario:        "Operational failure sending heartbeart",
+			EventStatus:     http.StatusInternalServerError,
+			TelemetryStatus: http.StatusOK,
+			ShutdownAfter:   2,
+			MockDelay:       time.Second,
+			MockError:       nil,
+			ExpectError:     ErrIssueProgress,
 		},
 		{
-			Scenario:      "Server has shutdown early without cause",
-			EventStatus:   http.StatusOK,
-			ShutdownAfter: 3,
-			MockDelay:     0,
-			MockError:     nil,
-			ExpectError:   ErrServerEarlyExit,
+			Scenario:        "Server has shutdown early without cause",
+			EventStatus:     http.StatusOK,
+			TelemetryStatus: http.StatusOK,
+			ShutdownAfter:   3,
+			MockDelay:       0,
+			MockError:       nil,
+			ExpectError:     ErrServerEarlyExit,
 		},
 		{
-			Scenario:      "Server configuration was wrong resulting in during init",
-			EventStatus:   http.StatusOK,
-			ShutdownAfter: 0,
-			MockDelay:     0,
-			MockError:     fakesocket.ErrClosedConnection,
-			ExpectError:   fakesocket.ErrClosedConnection,
+			Scenario:        "Server configuration was wrong resulting in during init",
+			EventStatus:     http.StatusOK,
+			TelemetryStatus: http.StatusOK,
+			ShutdownAfter:   0,
+			MockDelay:       0,
+			MockError:       fakesocket.ErrClosedConnection,
+			ExpectError:     fakesocket.ErrClosedConnection,
 		},
 		{
-			Scenario:      "Server failed throughout runtime and successfully committed to lambda",
-			EventStatus:   http.StatusOK,
-			ShutdownAfter: 0,
-			MockDelay:     300 * time.Millisecond,
-			MockError:     fakesocket.ErrClosedConnection,
-			ExpectError:   fakesocket.ErrClosedConnection,
+			Scenario:        "Server failed throughout runtime and successfully committed to lambda",
+			EventStatus:     http.StatusOK,
+			TelemetryStatus: http.StatusOK,
+			ShutdownAfter:   0,
+			MockDelay:       300 * time.Millisecond,
+			MockError:       fakesocket.ErrClosedConnection,
+			ExpectError:     fakesocket.ErrClosedConnection,
+		},
+		{
+			Scenario:        "Server failed to subscribe to telemetry",
+			EventStatus:     http.StatusOK,
+			TelemetryStatus: http.StatusInternalServerError,
+			ShutdownAfter:   0,
+			MockDelay:       300 * time.Millisecond,
+			MockError:       nil,
+			ExpectError:     ErrFailedTelemetrySubscription,
 		},
 	}
 
@@ -281,18 +311,13 @@ func TestManagerDo(t *testing.T) {
 		tc := tc
 		t.Run(tc.Scenario, func(t *testing.T) {
 			t.Parallel()
-			clck := clock.NewMock(time.Unix(1, 0))
-
-			ctx, cancel := context.WithCancel(
-				clock.Context(context.Background(), clck),
-			)
-			t.Cleanup(cancel)
 
 			r := mux.NewRouter()
 			r.Handle(api.RegisterEndpoint.String(), InitHandler(t, http.StatusOK))
 			r.Handle(api.InitErrorEndpoint.String(), InitErrorHandler(t, http.StatusAccepted))
 			r.Handle(api.ExitErrorEndpoint.String(), ExitErrorHandler(t, http.StatusAccepted))
-			r.Handle(api.EventEndpoint.String(), EventNextHandler(t, ctx, tc.EventStatus, tc.ShutdownAfter))
+			r.Handle(telemetry.SubscribeEndpoint.String(), TelemetryHandler(t, tc.TelemetryStatus))
+			r.Handle(api.EventEndpoint.String(), EventNextHandler(t, tc.EventStatus, tc.ShutdownAfter))
 			r.PathPrefix("/").HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 				assert.Fail(t, "Trying to access wrong path", r.RequestURI)
 			})
@@ -302,19 +327,22 @@ func TestManagerDo(t *testing.T) {
 
 			u, err := url.Parse(s.URL)
 			require.NoError(t, err, "Must be able to parse URL from httptest server")
+			log := logrus.New()
 
 			m := &manager{
-				log:    logrus.New(),
-				client: s.Client(),
-				domain: u.Hostname() + ":" + u.Port(),
-				name:   t.Name(),
+				log:             log,
+				client:          s.Client(),
+				domain:          u.Hostname() + ":" + u.Port(),
+				name:            t.Name(),
+				registeredID:    t.Name(),
+				telemetryServer: telemetry.NewServer(log, func() {}, telemetry.WithCustomAddr(availableAddr())),
 			}
 
 			start := make(chan struct{}, 1)
 			done := make(chan struct{}, 1)
 
 			server := &mocked{delay: tc.MockDelay, erred: tc.MockError, start: start, done: done}
-
+			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				<-start
 				close(start)
@@ -322,16 +350,64 @@ func TestManagerDo(t *testing.T) {
 					select {
 					case <-done:
 						close(done)
-						fixtures.NextStep(ctx, clck)
 						cancel()
 						return
-					default:
-						fixtures.NextStep(ctx, clck)
 					}
 				}
 			}()
 			assert.ErrorIs(t, m.Run(ctx, server), tc.ExpectError)
-			assert.Zero(t, clck.Len(), "Must have stopped all timers")
+		})
+	}
+}
+
+func TestManagerTelemetrySubscription(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		serverStatus  int
+		expectedError error
+	}{
+		{
+			name:          "Successful subscription",
+			serverStatus:  http.StatusOK,
+			expectedError: nil,
+		},
+		{
+			name:          "Bad subscription request",
+			serverStatus:  http.StatusBadRequest,
+			expectedError: ErrFailedTelemetrySubscription,
+		},
+		{
+			name:          "Container error",
+			serverStatus:  http.StatusInternalServerError,
+			expectedError: ErrFailedTelemetrySubscription,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := mux.NewRouter()
+			r.Handle(telemetry.SubscribeEndpoint.String(), TelemetryHandler(t, tc.serverStatus))
+			s := httptest.NewServer(r)
+			t.Cleanup(s.Close)
+
+			u, err := url.Parse(s.URL)
+			require.NoError(t, err, "Must be able to parse URL from httptest server")
+			log := logrus.New()
+
+			m := &manager{
+				log:             log,
+				client:          s.Client(),
+				domain:          u.Hostname() + ":" + u.Port(),
+				name:            t.Name(),
+				registeredID:    t.Name(),
+				telemetryServer: telemetry.NewServer(log, func() {}, telemetry.WithCustomAddr(availableAddr())),
+			}
+
+			assert.ErrorIs(t, tc.expectedError, m.subscribeToTelemetry(context.Background()))
 		})
 	}
 }

--- a/internal/awslambda/extension/manager_test.go
+++ b/internal/awslambda/extension/manager_test.go
@@ -335,7 +335,7 @@ func TestManagerDo(t *testing.T) {
 				domain:          u.Hostname() + ":" + u.Port(),
 				name:            t.Name(),
 				registeredID:    t.Name(),
-				telemetryServer: telemetry.NewServer(log, func() {}, telemetry.WithCustomAddr(availableAddr())),
+				telemetryServer: telemetry.NewServer(log, telemetry.NoopHook(), telemetry.WithCustomAddr(availableAddr())),
 			}
 
 			start := make(chan struct{}, 1)
@@ -404,7 +404,7 @@ func TestManagerTelemetrySubscription(t *testing.T) {
 				domain:          u.Hostname() + ":" + u.Port(),
 				name:            t.Name(),
 				registeredID:    t.Name(),
-				telemetryServer: telemetry.NewServer(log, func() {}, telemetry.WithCustomAddr(availableAddr())),
+				telemetryServer: telemetry.NewServer(log, telemetry.NoopHook(), telemetry.WithCustomAddr(availableAddr())),
 			}
 
 			assert.ErrorIs(t, tc.expectedError, m.subscribeToTelemetry(context.Background()))

--- a/internal/awslambda/extension/telemetry/api.go
+++ b/internal/awslambda/extension/telemetry/api.go
@@ -1,0 +1,39 @@
+package telemetry
+
+import "github.com/atlassian/gostatsd/internal/awslambda/extension/api"
+
+const (
+	ApiVersion                              = "2022-07-01"
+	SubscribeEndpoint        api.LambdaPath = "/" + ApiVersion + "/telemetry"
+	ProtocolHTTP             string         = "HTTP"
+	PlatformSubscriptionType string         = "platform"
+	MinBufferingTimeoutMs    int            = 25
+
+	RuntimeDone                EventType = "platform.runtimeDone"
+	LambdaRuntimeAvailableAddr           = "sandbox:8083"
+)
+
+type EventType string
+
+type Event struct {
+	// type is the only field we deserialise as it is used for flushing metrics
+	Type EventType `json:"type"`
+}
+
+type SubscriptionRequest struct {
+	SchemaVersion string                       `json:"schemaVersion"`
+	Types         []string                     `json:"types"`
+	Buffering     *SubscriptionBufferingConfig `json:"buffering,omitempty"`
+	Destination   *SubscriptionDestination     `json:"destination,omitempty"`
+}
+
+type SubscriptionDestination struct {
+	Protocol string `json:"protocol,omitempty"`
+	URI      string `json:"URI"`
+}
+
+type SubscriptionBufferingConfig struct {
+	MaxItems  int         `json:"maxItems,omitempty"`
+	MaxBytes  interface{} `json:"maxBytes,omitempty"`
+	TimeoutMs int         `json:"timeoutMs,omitempty"`
+}

--- a/internal/awslambda/extension/telemetry/api.go
+++ b/internal/awslambda/extension/telemetry/api.go
@@ -9,8 +9,9 @@ const (
 	PlatformSubscriptionType string         = "platform"
 	MinBufferingTimeoutMs    int            = 25
 
-	RuntimeDone                EventType = "platform.runtimeDone"
-	LambdaRuntimeAvailableAddr           = "sandbox:8083"
+	RuntimeDone EventType = "platform.runtimeDone"
+	// the sandbox hostname must be used in the lambda runtime, the port however can be configured if required
+	LambdaRuntimeAvailableAddr = "sandbox:8083"
 )
 
 type EventType string

--- a/internal/awslambda/extension/telemetry/api.go
+++ b/internal/awslambda/extension/telemetry/api.go
@@ -10,14 +10,18 @@ const (
 	MinBufferingTimeoutMs    int            = 25
 
 	RuntimeDone EventType = "platform.runtimeDone"
-	// the sandbox hostname must be used in the lambda runtime, the port however can be configured if required
+	// LambdaRuntimeAvailableAddr uses the sandbox hostname must be used in the lambda runtime
+	// note the port component can be configured
 	LambdaRuntimeAvailableAddr = "sandbox:8083"
 )
 
 type EventType string
 
+// Event is the telemetry event that the lambda server pushes.
+//
+// Full schema can be found here: https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html
 type Event struct {
-	// type is the only field we deserialise as it is used for flushing metrics
+	// Type is the only field we deserialise as it is used for flushing metrics
 	Type EventType `json:"type"`
 }
 

--- a/internal/awslambda/extension/telemetry/doc.go
+++ b/internal/awslambda/extension/telemetry/doc.go
@@ -1,0 +1,8 @@
+// Package telemetry defines the apis and server required
+// to interact with the subscribe to the Telemetry API for AWS lambdas.
+// This is to enable the trigger of specific actions such as metric flushes on
+// certain runtime events.
+//
+// More information on the Telemetry API can be found at :
+// https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html
+package telemetry

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -15,6 +15,10 @@ import (
 
 type RuntimeDoneHook func()
 
+func NoopHook() RuntimeDoneHook {
+	return func() {}
+}
+
 type Server struct {
 	addr string
 	log  logrus.FieldLogger

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -59,12 +59,12 @@ func (s *Server) Start(ctx context.Context) error {
 		defer cancel()
 		err := server.Shutdown(c)
 		if err != nil {
-			s.log.WithError(err).Info("did not shutdown gracefully")
+			s.log.WithError(err).Info("Did not shutdown gracefully")
 		}
 	}()
 
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		s.log.WithError(err).Error("server error")
+		s.log.WithError(err).Error("Server error")
 		return err
 	}
 
@@ -76,13 +76,13 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) eventHandler(_ http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
-		s.log.WithError(err).Error("error reading body")
+		s.log.WithError(err).Error("Error reading body")
 	}
 
 	var telePayload []Event
 	err = jsoniter.Unmarshal(b, &telePayload)
 	if err != nil {
-		s.log.WithError(err).Error("error unmarshaling telemetry request")
+		s.log.WithError(err).Error("Error unmarshaling telemetry request")
 	}
 
 	for _, p := range telePayload {

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -26,8 +26,6 @@ type Server struct {
 	httpServer *http.Server
 }
 
-type ServerOpt func(*Server)
-
 func NewServer(addr string, log logrus.FieldLogger, hook RuntimeDoneHook) *Server {
 	ts := &Server{
 		log: log,
@@ -40,12 +38,6 @@ func NewServer(addr string, log logrus.FieldLogger, hook RuntimeDoneHook) *Serve
 	ts.httpServer = &http.Server{Addr: addr, Handler: mx}
 
 	return ts
-}
-
-func WithCustomAddr(addr string) ServerOpt {
-	return func(s *Server) {
-		s.addr = addr
-	}
 }
 
 func (s *Server) Start(ctx context.Context) error {

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+)
+
+type RuntimeDoneHook func()
+
+type Server struct {
+	addr string
+	log  logrus.FieldLogger
+	f    RuntimeDoneHook
+}
+
+type ServerOpt func(*Server)
+
+func NewServer(log logrus.FieldLogger, hook RuntimeDoneHook, opts ...ServerOpt) *Server {
+	s := &Server{
+		log:  log,
+		f:    hook,
+		addr: LambdaRuntimeAvailableAddr,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+func WithCustomAddr(addr string) ServerOpt {
+	return func(s *Server) {
+		s.addr = addr
+	}
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	mx := mux.NewRouter()
+	mx.HandleFunc("/telemetry", s.eventHandler).Methods(http.MethodPost)
+
+	server := &http.Server{Addr: s.addr, Handler: mx}
+
+	go func() {
+		<-ctx.Done()
+		c, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err := server.Shutdown(c)
+		if err != nil {
+			s.log.WithError(err).Info("did not shutdown gracefully")
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.log.WithError(err).Error("server error")
+		return err
+	}
+
+	s.log.Info("Shutdown telemetry server")
+
+	return nil
+}
+
+func (s *Server) eventHandler(_ http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.log.WithError(err).Error("error reading body")
+	}
+
+	var telePayload []Event
+	err = jsoniter.Unmarshal(b, &telePayload)
+	if err != nil {
+		s.log.WithError(err).Error("error unmarshaling telemetry request")
+	}
+
+	for _, p := range telePayload {
+		if p.Type == RuntimeDone {
+			s.f()
+		}
+	}
+}
+
+func (s *Server) Endpoint() string {
+	return fmt.Sprintf("http://%s/telemetry", s.addr)
+}

--- a/internal/awslambda/extension/telemetry/server_test.go
+++ b/internal/awslambda/extension/telemetry/server_test.go
@@ -23,10 +23,13 @@ func TestNewServer(t *testing.T) {
 func TestServerStart(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(logrus.New(), NoopHook(), WithCustomAddr("127.0.0.1:8083"))
+	l, _ := net.Listen("tcp", ":0")
+	l.Close()
+
+	s := NewServer(logrus.New(), NoopHook(), WithCustomAddr(l.Addr().String()))
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		<-time.NewTimer(1 * time.Second).C
+		<-time.After(1 * time.Second)
 		cancel()
 	}()
 	err := s.Start(ctx)
@@ -96,8 +99,8 @@ func TestServerReturnsCorrectEndpoint(t *testing.T) {
 		},
 		{
 			name:             "custom server address returns correct endpoint",
-			server:           NewServer(logrus.New(), NoopHook(), WithCustomAddr("127.0.0.1:8081")),
-			expectedEndpoint: "http://127.0.0.1:8081/telemetry",
+			server:           NewServer(logrus.New(), NoopHook(), WithCustomAddr("test:8081")),
+			expectedEndpoint: "http://test:8081/telemetry",
 		},
 	}
 

--- a/internal/awslambda/extension/telemetry/server_test.go
+++ b/internal/awslambda/extension/telemetry/server_test.go
@@ -17,13 +17,13 @@ import (
 func TestNewServer(t *testing.T) {
 	t.Parallel()
 
-	assert.NotNil(t, NewServer(logrus.New(), func() {}))
+	assert.NotNil(t, NewServer(logrus.New(), NoopHook()))
 }
 
 func TestServerStart(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(logrus.New(), func() {}, WithCustomAddr("127.0.0.1:8083"))
+	s := NewServer(logrus.New(), NoopHook(), WithCustomAddr("127.0.0.1:8083"))
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-time.NewTimer(1 * time.Second).C
@@ -91,12 +91,12 @@ func TestServerReturnsCorrectEndpoint(t *testing.T) {
 	}{
 		{
 			name:             "default server uses sandbox endpoint",
-			server:           NewServer(logrus.New(), func() {}),
+			server:           NewServer(logrus.New(), NoopHook()),
 			expectedEndpoint: "http://sandbox:8083/telemetry",
 		},
 		{
 			name:             "custom server address returns correct endpoint",
-			server:           NewServer(logrus.New(), func() {}, WithCustomAddr("127.0.0.1:8081")),
+			server:           NewServer(logrus.New(), NoopHook(), WithCustomAddr("127.0.0.1:8081")),
 			expectedEndpoint: "http://127.0.0.1:8081/telemetry",
 		},
 	}

--- a/internal/awslambda/extension/telemetry/server_test.go
+++ b/internal/awslambda/extension/telemetry/server_test.go
@@ -1,0 +1,111 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, NewServer(logrus.New(), func() {}))
+}
+
+func TestServerStart(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer(logrus.New(), func() {}, WithCustomAddr("127.0.0.1:8083"))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-time.NewTimer(1 * time.Second).C
+		cancel()
+	}()
+	err := s.Start(ctx)
+	assert.NoError(t, err)
+}
+
+func TestRuntimeDoneHook(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		name       string
+		payload    []Event
+		hookCalled bool
+	}{
+		{
+			name:       "should invoke hook on runtimeDoneEvent",
+			payload:    []Event{{RuntimeDone}},
+			hookCalled: true,
+		},
+		{
+			name:       "should not invoke hook",
+			payload:    []Event{{"platform.init"}, {"platform.start"}},
+			hookCalled: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			callbackInvoked := false
+			f := func() { callbackInvoked = true }
+
+			p, err := jsoniter.Marshal(tc.payload)
+			require.NoError(t, err)
+
+			l, _ := net.Listen("tcp", ":0")
+			l.Close()
+
+			s := NewServer(logrus.New(), f, WithCustomAddr(l.Addr().String()))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go s.Start(ctx)
+
+			res, err := http.Post(s.Endpoint(), "application/json", bytes.NewReader(p))
+			defer res.Body.Close()
+
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Equal(t, tc.hookCalled, callbackInvoked)
+		})
+	}
+}
+
+func TestServerReturnsCorrectEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		name             string
+		server           *Server
+		expectedEndpoint string
+	}{
+		{
+			name:             "default server uses sandbox endpoint",
+			server:           NewServer(logrus.New(), func() {}),
+			expectedEndpoint: "http://sandbox:8083/telemetry",
+		},
+		{
+			name:             "custom server address returns correct endpoint",
+			server:           NewServer(logrus.New(), func() {}, WithCustomAddr("127.0.0.1:8081")),
+			expectedEndpoint: "http://127.0.0.1:8081/telemetry",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expectedEndpoint, tc.server.Endpoint())
+		})
+	}
+}


### PR DESCRIPTION
Currently the lambda extension binary will flush periodically based on the flush interval. Because the gostatsd runtime is suspended once the invocation is finished, the metric may:
- Not flush at all
- Flush at the next invocation

To address the flakiness of the flush when the lambda is not constantly invoked, we can subscribe to the telemetry API that AWS provides and listen for the `platform.runtimeDone` event to flush on within the extension.

This PR sets up the initial step to start a server and listen to lambda telemetry events, with a hook function defined on the above event.

A subsequent PR will add the logic to trigger a flush using the hook function.