### PR TITLE
Lambda extension - support manual flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ The following settings from the previous section are also supported:
 - `hostname`
 - `log-raw-metric`
 
+Running as a Lambda Extension
+-----------------------------
+Gostatsd can be run as a lambda extension in forwarder mode. The metrics are flushed at the end of each lambda invocation
+by default. The flush interval is ignored for your custom metrics, internal metrics are still flushed on a best effort
+basis using the configured flush interval.
+
+To support flushes based on the runtime function, a lambda telemetry server is started at the reserved lambda hostname
+`sandbox` on port 8083. This can be configured by setting the `lambda-extension-telemetry-address` configuration parameter.
+This will need to be done if port 8083 is not available within the lambda runtime.
+
+The flush per invocation setting can be disabled by setting `lambda-extension-manual-flush` to `false`, however this
+is not recommended unless the lambda is constantly invoked. Since the extensions are suspended once the user lambda
+functions return, this may lead to metric loss (for inflight requests) or metric delay until the next invocation in
+lambdas that are sparsely invoked.
+
+Configurable options:
+- `lambda-extension-telemetry-address`: address that the extension telemetry server should listen on
+- `lambda-extension-manual-flush`: boolean indicating whether the lambda should flush per invocation and disregard the
+   the flush interval
+
+All options for specified in the previous section for the forwarder are also configurable with the following caveats:
+- `dynamic-headers` are not supported
+- `flush-interval` will not be respected when `lambda-extension-manual-flush` is set to true
 
 Metric expiry and persistence
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The following settings from the previous section are also supported:
 - `hostname`
 - `log-raw-metric`
 
-Running as a Lambda Extension
+Running as a Lambda Extension (experimental feature)
 -----------------------------
 Gostatsd can be run as a lambda extension in forwarder mode. The metrics are flushed at the end of each lambda invocation
 by default. The flush interval is ignored for your custom metrics, internal metrics are still flushed on a best effort

--- a/cmd/lambda-extension/main.go
+++ b/cmd/lambda-extension/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -16,6 +14,7 @@ import (
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/internal/awslambda/extension"
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
+	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
 	"github.com/atlassian/gostatsd/internal/flush"
 	"github.com/atlassian/gostatsd/internal/util"
 	"github.com/atlassian/gostatsd/pkg/statsd"

--- a/cmd/lambda-extension/main.go
+++ b/cmd/lambda-extension/main.go
@@ -70,7 +70,7 @@ func GetConfiguration() (*viper.Viper, error) {
 	return v, nil
 }
 
-func CreateServer(v *viper.Viper, logger logrus.FieldLogger) *statsd.Server {
+func NewServer(v *viper.Viper, logger logrus.FieldLogger) *statsd.Server {
 	// create server in forwarder mode
 	s := &statsd.Server{
 		InternalTags:      v.GetStringSlice(gostatsd.ParamInternalTags),
@@ -135,11 +135,12 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	server := CreateServer(conf, log)
+	server := NewServer(conf, log)
 
 	var opts = make([]extension.ManagerOpt, 0)
 	telemetryServerAddr := conf.GetString(gostatsd.ParamLambdaExtensionTelemetryAddress)
 	if conf.GetBool(gostatsd.ParamLambdaExtensionManualFlush) {
+		log.Info("Starting extension with manual flush")
 		opts = append(opts, extension.WithManualFlushEnabled(server.ForwarderFlushCoordinator, telemetryServerAddr))
 	}
 

--- a/defaults_and_params.go
+++ b/defaults_and_params.go
@@ -176,8 +176,10 @@ const (
 	ParamLogRawMetric = "log-raw-metric"
 	// ParamDisableInternalEvents enables sending internal events from gostatsd
 	ParamDisableInternalEvents = "disable-internal-events"
-	// ParamEnableForwarderManualFlush enables the manual flushing of metrics in forwarder mode, the flush interval is ignored
-	ParamEnableForwarderManualFlush = "enable-forwarder-manual-flush"
+	// ParamLambdaExtensionManualFlush enables the manual flushing of metrics in forwarder mode, the flush interval is ignored
+	ParamLambdaExtensionManualFlush = "lambda-extension-manual-flush"
+	// ParamLambdaExtensionTelemetryAddress enables the manual flushing of metrics in forwarder mode, the flush interval is ignored
+	ParamLambdaExtensionTelemetryAddress = "lambda-extension-telemetry-address"
 )
 
 // AddFlags adds flags to the specified FlagSet.

--- a/defaults_and_params.go
+++ b/defaults_and_params.go
@@ -176,6 +176,8 @@ const (
 	ParamLogRawMetric = "log-raw-metric"
 	// ParamDisableInternalEvents enables sending internal events from gostatsd
 	ParamDisableInternalEvents = "disable-internal-events"
+	// ParamEnableForwarderManualFlush enables the manual flushing of metrics in forwarder mode, the flush interval is ignored
+	ParamEnableForwarderManualFlush = "enable-forwarder-manual-flush"
 )
 
 // AddFlags adds flags to the specified FlagSet.

--- a/internal/awslambda/extension/manager.go
+++ b/internal/awslambda/extension/manager.go
@@ -78,17 +78,17 @@ func NewManager(lambdaDomain string, lambdaFileName string, log logrus.FieldLogg
 	return m
 }
 
-func WithManualFlushEnabled(fc flush.Coordinator) ManagerOpt {
+// WithManualFlushEnabled enables a flush per invocation, it requires a flush.Coordinator to trigger the flush
+// and will register it as a telemetry server callback. A server address will also need to be provided
+// for the server to run on.
+func WithManualFlushEnabled(fc flush.Coordinator, telemetryServerAddr string) ManagerOpt {
 	return func(m *manager) {
 		if fc == nil {
 			return
 		}
 
-		if m.telemetryServer == nil {
-			m.telemetryServer = telemetry.NewServer(telemetry.LambdaRuntimeAvailableAddr, m.log, fc.Flush)
-		}
-
 		m.fc = fc
+		m.telemetryServer = telemetry.NewServer(telemetryServerAddr, m.log, fc.Flush)
 	}
 }
 

--- a/internal/awslambda/extension/manager.go
+++ b/internal/awslambda/extension/manager.go
@@ -92,12 +92,6 @@ func WithManualFlushEnabled(fc flush.Coordinator, telemetryServerAddr string) Ma
 	}
 }
 
-func WithCustomTelemetryServerAddr(addr string) ManagerOpt {
-	return func(m *manager) {
-		m.telemetryServer = telemetry.NewServer(addr, m.log, m.fc.Flush)
-	}
-}
-
 func (m *manager) Run(parent context.Context, server Server) error {
 	var wg wait.Group
 	var chErrs = make(chan error, 3)

--- a/internal/awslambda/extension/manager.go
+++ b/internal/awslambda/extension/manager.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
+	"github.com/atlassian/gostatsd/internal/flush"
 )
 
 const (
@@ -46,29 +47,55 @@ type Server interface {
 }
 
 type manager struct {
-	log    logrus.FieldLogger
-	client *http.Client
-
+	log          logrus.FieldLogger
 	domain       string
 	name         string
 	registeredID string
 
-	telemetryServer *telemetry.Server
+	client              *http.Client
+	telemetryServerAddr string
+	telemetryServer     *telemetry.Server
+	fc                  flush.Coordinator
 }
+
+type ManagerOpt func(*manager)
 
 var _ Manager = (*manager)(nil)
 
-func NewManager(lambdaDomain string, lambdaFileName string, log logrus.FieldLogger) Manager {
+func NewManager(lambdaDomain string, lambdaFileName string, log logrus.FieldLogger, opts ...ManagerOpt) Manager {
 	m := &manager{
 		log:    log,
 		client: &http.Client{},
 		domain: lambdaDomain,
 		name:   lambdaFileName,
+		fc:     flush.NewNoopFlushCoordinator(),
 	}
 
-	m.telemetryServer = telemetry.NewServer(telemetry.LambdaRuntimeAvailableAddr, log, telemetry.NoopHook())
+	for _, opt := range opts {
+		opt(m)
+	}
 
 	return m
+}
+
+func WithManualFlushEnabled(fc flush.Coordinator) ManagerOpt {
+	return func(m *manager) {
+		if fc == nil {
+			return
+		}
+
+		if m.telemetryServer == nil {
+			m.telemetryServer = telemetry.NewServer(telemetry.LambdaRuntimeAvailableAddr, m.log, fc.Flush)
+		}
+
+		m.fc = fc
+	}
+}
+
+func WithCustomTelemetryServerAddr(addr string) ManagerOpt {
+	return func(m *manager) {
+		m.telemetryServer = telemetry.NewServer(addr, m.log, m.fc.Flush)
+	}
 }
 
 func (m *manager) Run(parent context.Context, server Server) error {
@@ -83,13 +110,16 @@ func (m *manager) Run(parent context.Context, server Server) error {
 	// Start telemetry server
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
-	wg.StartWithContext(ctx, func(c context.Context) {
-		chErrs <- m.telemetryServer.Start(c)
-	})
 
-	if err := m.subscribeToTelemetry(ctx); err != nil {
-		m.log.WithError(err).Error("error subscribing to lambda telemetry endpoint")
-		return err
+	if m.telemetryEnabled() {
+		wg.StartWithContext(ctx, func(c context.Context) {
+			chErrs <- m.telemetryServer.Start(c)
+		})
+
+		if err := m.subscribeToTelemetry(ctx); err != nil {
+			m.log.WithError(err).Error("error subscribing to lambda telemetry endpoint")
+			return err
+		}
 	}
 
 	// Start gostatsd server
@@ -148,7 +178,10 @@ func (m *manager) Run(parent context.Context, server Server) error {
 }
 
 func (m *manager) heartbeat(ctx context.Context) error {
+	// call flush on init so we don't block the first /next call
+	m.fc.Flush()
 	for ctx.Err() == nil {
+		m.fc.WaitForFlush()
 		resp, err := m.nextEvent(ctx)
 		if err != nil {
 			return err
@@ -376,4 +409,8 @@ func (m *manager) reportExitError(ctx context.Context, problem error) {
 	if resp.StatusCode != http.StatusAccepted {
 		m.log.WithField("status code", resp.StatusCode).Error("issue with sending exit error to lambda")
 	}
+}
+
+func (m *manager) telemetryEnabled() bool {
+	return m.telemetryServer != nil
 }

--- a/internal/awslambda/extension/manager_integration_test.go
+++ b/internal/awslambda/extension/manager_integration_test.go
@@ -1,0 +1,177 @@
+package extension
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ash2k/stager/wait"
+	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
+	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
+	"github.com/atlassian/gostatsd/internal/flush"
+	"github.com/atlassian/gostatsd/pb"
+	"github.com/atlassian/gostatsd/pkg/statsd"
+	"github.com/atlassian/gostatsd/pkg/transport"
+)
+
+func TestManagerGostatsDIntegrationTest(t *testing.T) {
+	t.Parallel()
+
+	var forwarderCallReceived uint64
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	readyCh := make(chan struct{}, 1)
+
+	apiMux := mux.NewRouter()
+	apiMux.Handle("/v2/raw", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddUint64(&forwarderCallReceived, 1)
+		buf, errr := io.ReadAll(r.Body)
+		require.NoError(t, errr, "Must not error when reading request")
+
+		var data pb.RawMessageV2
+		require.NoError(t, proto.Unmarshal(buf, &data))
+
+		if len(data.GetCounters()) == 0 {
+			readyCh <- struct{}{}
+			close(readyCh)
+		}
+		for _, v := range data.GetCounters() {
+			for tag, m := range v.TagMap {
+				assert.EqualValues(t, 42, m.Value)
+				assert.True(t, strings.Contains(tag, "fruit:pineapple"))
+				cancel()
+			}
+		}
+	}))
+	apiMux.Handle("/v2/event", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+	gsdServer := httptest.NewServer(apiMux)
+	t.Cleanup(gsdServer.Close)
+
+	log := logrus.New()
+	fc := flush.NewFlushCoordinator()
+
+	statsDServer, err := createStatsDServer(gsdServer.URL, fc, log)
+
+	// setup lambda server
+	lambdaServer := createLambdaExtensionServer(t)
+	t.Cleanup(lambdaServer.Close)
+
+	teleAddr := availableAddr()
+	u, err := url.Parse(lambdaServer.URL)
+	require.NoError(t, err)
+	m := NewManager(u.Host, "test", log, WithManualFlushEnabled(fc), WithCustomTelemetryServerAddr(teleAddr))
+
+	wg := wait.Group{}
+	wg.StartWithContext(ctx, func(ctx context.Context) {
+		err := m.Run(ctx, statsDServer)
+		assert.ErrorIs(t, err, ctx.Err())
+	})
+
+	<-readyCh
+
+	// send udp metric
+	err = sendUdpMetric(statsDServer.MetricsAddr, []byte("test.metrics:42|c|#fruit:pineapple"))
+	require.NoError(t, err, "failed to send udp metrics to statsDServer")
+
+	// send telemetry done message
+	<-time.After(time.Duration(telemetry.MinBufferingTimeoutMs) * time.Millisecond)
+	res, err := sendRuntimeDoneMsg(teleAddr)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// wait for shutdown
+	wg.Wait()
+	assert.EqualValues(t, forwarderCallReceived, 2)
+}
+
+func createStatsDServer(apiAddr string,
+	fc flush.Coordinator,
+	log logrus.FieldLogger) (s *statsd.Server, err error) {
+
+	// setup statsd server
+	l, err := net.ListenPacket("udp", ":0")
+	if err != nil {
+		return
+	}
+	l.Close()
+
+	v := viper.New()
+	v.Set("http-transport", map[string]interface{}{
+		"api-endpoint":       apiAddr,
+		"consolidator-slots": 1,
+		"compress":           false,
+	})
+	s = &statsd.Server{
+		ForwarderFlushCoordinator: fc,
+		FlushInterval:             5 * time.Minute,
+		FlushOffset:               0,
+		FlushAligned:              false,
+		MaxReaders:                1,
+		MaxParsers:                1,
+		MaxWorkers:                1,
+		ReceiveBatchSize:          50,
+		MetricsAddr:               l.LocalAddr().String(),
+		ServerMode:                "forwarder",
+		Viper:                     v,
+		TransportPool:             transport.NewTransportPool(log, v),
+	}
+	return
+}
+
+func createLambdaExtensionServer(t testing.TB) *httptest.Server {
+	r := mux.NewRouter()
+	r.Handle(api.RegisterEndpoint.String(), InitHandler(t, http.StatusOK))
+	r.Handle(telemetry.SubscribeEndpoint.String(), TelemetryHandler(t, http.StatusOK))
+	r.Handle(api.EventEndpoint.String(), EventNextHandler(t, http.StatusOK, 1))
+
+	return httptest.NewServer(r)
+}
+
+func sendRuntimeDoneMsg(addr string) (*http.Response, error) {
+	platformDoneMsg := []telemetry.Event{{telemetry.RuntimeDone}}
+	b, err := jsoniter.Marshal(platformDoneMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.Post(fmt.Sprintf("http://%s/telemetry", addr), "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	return res, nil
+}
+
+func sendUdpMetric(addr string, msg []byte) error {
+	conn, err := net.Dial("udp", addr)
+	defer conn.Close()
+	if err != nil {
+		return err
+	}
+	_, err = conn.Write(msg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/awslambda/extension/manager_test.go
+++ b/internal/awslambda/extension/manager_test.go
@@ -369,10 +369,10 @@ func TestTelemetryEnabled(t *testing.T) {
 	m := &manager{}
 	assert.False(t, m.telemetryEnabled())
 
-	WithManualFlushEnabled(nil)(m)
+	WithManualFlushEnabled(nil, telemetry.LambdaRuntimeAvailableAddr)(m)
 	assert.False(t, m.telemetryEnabled())
 
-	WithManualFlushEnabled(flush.NewNoopFlushCoordinator())(m)
+	WithManualFlushEnabled(flush.NewNoopFlushCoordinator(), telemetry.LambdaRuntimeAvailableAddr)(m)
 	assert.True(t, m.telemetryEnabled())
 }
 

--- a/internal/awslambda/extension/manager_test.go
+++ b/internal/awslambda/extension/manager_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/api"
 	"github.com/atlassian/gostatsd/internal/awslambda/extension/telemetry"
+	"github.com/atlassian/gostatsd/internal/flush"
 	"github.com/atlassian/gostatsd/pkg/fakesocket"
 )
 
@@ -29,6 +30,23 @@ type mocked struct {
 	start chan<- struct{}
 	done  chan<- struct{}
 }
+
+type countingFlushCoordinator struct {
+	count       int
+	waitedCount int
+}
+
+func (n *countingFlushCoordinator) Flush() {}
+
+func (n *countingFlushCoordinator) NotifyFlush() {}
+
+func (n *countingFlushCoordinator) RegisterFlushable(flush.Flushable) {}
+
+func (n *countingFlushCoordinator) WaitForFlush() {
+	n.waitedCount += 1
+}
+
+var _ flush.Coordinator = (*countingFlushCoordinator)(nil)
 
 func (m *mocked) Run(ctx context.Context) error {
 	m.start <- struct{}{}
@@ -172,7 +190,7 @@ func TelemetryHandler(tb testing.TB, statusCode int) http.Handler {
 }
 
 func availableAddr() string {
-	l, _ := net.Listen("tcp", ":0")
+	l, _ := net.Listen("tcp", "127.0.0.1:0")
 	defer l.Close()
 	return l.Addr().String()
 }
@@ -242,68 +260,53 @@ func TestManagerDo(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		Scenario        string
-		EventStatus     int
-		TelemetryStatus int
-		ShutdownAfter   int
-		MockDelay       time.Duration
-		MockError       error
+		Scenario      string
+		EventStatus   int
+		ShutdownAfter int
+		MockDelay     time.Duration
+		MockError     error
 
 		ExpectError error
 	}{
 		{
-			Scenario:        "Normal operation",
-			EventStatus:     http.StatusOK,
-			TelemetryStatus: http.StatusOK,
-			ShutdownAfter:   3,
-			MockDelay:       time.Second,
-			MockError:       nil,
-			ExpectError:     nil,
+			Scenario:      "Normal operation",
+			EventStatus:   http.StatusOK,
+			ShutdownAfter: 3,
+			MockDelay:     time.Second,
+			MockError:     nil,
+			ExpectError:   nil,
 		},
 		{
-			Scenario:        "Operational failure sending heartbeart",
-			EventStatus:     http.StatusInternalServerError,
-			TelemetryStatus: http.StatusOK,
-			ShutdownAfter:   2,
-			MockDelay:       time.Second,
-			MockError:       nil,
-			ExpectError:     ErrIssueProgress,
+			Scenario:      "Operational failure sending heartbeart",
+			EventStatus:   http.StatusInternalServerError,
+			ShutdownAfter: 2,
+			MockDelay:     time.Second,
+			MockError:     nil,
+			ExpectError:   ErrIssueProgress,
 		},
 		{
-			Scenario:        "Server has shutdown early without cause",
-			EventStatus:     http.StatusOK,
-			TelemetryStatus: http.StatusOK,
-			ShutdownAfter:   3,
-			MockDelay:       0,
-			MockError:       nil,
-			ExpectError:     ErrServerEarlyExit,
+			Scenario:      "Server has shutdown early without cause",
+			EventStatus:   http.StatusOK,
+			ShutdownAfter: 3,
+			MockDelay:     0,
+			MockError:     nil,
+			ExpectError:   ErrServerEarlyExit,
 		},
 		{
-			Scenario:        "Server configuration was wrong resulting in during init",
-			EventStatus:     http.StatusOK,
-			TelemetryStatus: http.StatusOK,
-			ShutdownAfter:   0,
-			MockDelay:       0,
-			MockError:       fakesocket.ErrClosedConnection,
-			ExpectError:     fakesocket.ErrClosedConnection,
+			Scenario:      "Server configuration was wrong resulting in during init",
+			EventStatus:   http.StatusOK,
+			ShutdownAfter: 0,
+			MockDelay:     0,
+			MockError:     fakesocket.ErrClosedConnection,
+			ExpectError:   fakesocket.ErrClosedConnection,
 		},
 		{
-			Scenario:        "Server failed throughout runtime and successfully committed to lambda",
-			EventStatus:     http.StatusOK,
-			TelemetryStatus: http.StatusOK,
-			ShutdownAfter:   0,
-			MockDelay:       300 * time.Millisecond,
-			MockError:       fakesocket.ErrClosedConnection,
-			ExpectError:     fakesocket.ErrClosedConnection,
-		},
-		{
-			Scenario:        "Server failed to subscribe to telemetry",
-			EventStatus:     http.StatusOK,
-			TelemetryStatus: http.StatusInternalServerError,
-			ShutdownAfter:   0,
-			MockDelay:       300 * time.Millisecond,
-			MockError:       nil,
-			ExpectError:     ErrFailedTelemetrySubscription,
+			Scenario:      "Server failed throughout runtime and successfully committed to lambda",
+			EventStatus:   http.StatusOK,
+			ShutdownAfter: 0,
+			MockDelay:     300 * time.Millisecond,
+			MockError:     fakesocket.ErrClosedConnection,
+			ExpectError:   fakesocket.ErrClosedConnection,
 		},
 	}
 
@@ -316,7 +319,6 @@ func TestManagerDo(t *testing.T) {
 			r.Handle(api.RegisterEndpoint.String(), InitHandler(t, http.StatusOK))
 			r.Handle(api.InitErrorEndpoint.String(), InitErrorHandler(t, http.StatusAccepted))
 			r.Handle(api.ExitErrorEndpoint.String(), ExitErrorHandler(t, http.StatusAccepted))
-			r.Handle(telemetry.SubscribeEndpoint.String(), TelemetryHandler(t, tc.TelemetryStatus))
 			r.Handle(api.EventEndpoint.String(), EventNextHandler(t, tc.EventStatus, tc.ShutdownAfter))
 			r.PathPrefix("/").HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 				assert.Fail(t, "Trying to access wrong path", r.RequestURI)
@@ -330,13 +332,15 @@ func TestManagerDo(t *testing.T) {
 			log := logrus.New()
 
 			m := &manager{
-				log:             log,
-				client:          s.Client(),
-				domain:          u.Hostname() + ":" + u.Port(),
-				name:            t.Name(),
-				registeredID:    t.Name(),
-				telemetryServer: telemetry.NewServer(availableAddr(), log, telemetry.NoopHook()),
+				log:          log,
+				client:       s.Client(),
+				domain:       u.Hostname() + ":" + u.Port(),
+				name:         t.Name(),
+				registeredID: t.Name(),
+				fc:           flush.NewNoopFlushCoordinator(),
 			}
+
+			assert.False(t, m.telemetryEnabled())
 
 			start := make(chan struct{}, 1)
 			done := make(chan struct{}, 1)
@@ -358,6 +362,18 @@ func TestManagerDo(t *testing.T) {
 			assert.ErrorIs(t, m.Run(ctx, server), tc.ExpectError)
 		})
 	}
+}
+
+func TestTelemetryEnabled(t *testing.T) {
+	t.Parallel()
+	m := &manager{}
+	assert.False(t, m.telemetryEnabled())
+
+	WithManualFlushEnabled(nil)(m)
+	assert.False(t, m.telemetryEnabled())
+
+	WithManualFlushEnabled(flush.NewNoopFlushCoordinator())(m)
+	assert.True(t, m.telemetryEnabled())
 }
 
 func TestManagerTelemetrySubscription(t *testing.T) {
@@ -408,6 +424,89 @@ func TestManagerTelemetrySubscription(t *testing.T) {
 			}
 
 			assert.ErrorIs(t, tc.expectedError, m.subscribeToTelemetry(context.Background()))
+		})
+	}
+}
+
+func TestManagerManualFlushEnabled(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Scenario        string
+		EventStatus     int
+		TelemetryStatus int
+		ShutdownAfter   int
+
+		ExpectError        error
+		ExpectedFlushWaits int
+	}{
+		{
+			Scenario:           "Normal operation",
+			EventStatus:        http.StatusOK,
+			TelemetryStatus:    http.StatusOK,
+			ShutdownAfter:      3,
+			ExpectError:        nil,
+			ExpectedFlushWaits: 5,
+		},
+		{
+			Scenario:           "Server failed to subscribe to telemetry",
+			EventStatus:        http.StatusOK,
+			TelemetryStatus:    http.StatusInternalServerError,
+			ShutdownAfter:      0,
+			ExpectError:        ErrFailedTelemetrySubscription,
+			ExpectedFlushWaits: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Scenario, func(t *testing.T) {
+			t.Parallel()
+
+			r := mux.NewRouter()
+			r.Handle(api.RegisterEndpoint.String(), InitHandler(t, http.StatusOK))
+			r.Handle(telemetry.SubscribeEndpoint.String(), TelemetryHandler(t, tc.TelemetryStatus))
+			r.Handle(api.EventEndpoint.String(), EventNextHandler(t, tc.EventStatus, tc.ShutdownAfter))
+
+			s := httptest.NewServer(r)
+			t.Cleanup(s.Close)
+
+			u, err := url.Parse(s.URL)
+			require.NoError(t, err, "Must be able to parse URL from httptest server")
+			log := logrus.New()
+
+			fc := &countingFlushCoordinator{}
+			m := &manager{
+				log:             log,
+				client:          s.Client(),
+				domain:          u.Hostname() + ":" + u.Port(),
+				name:            t.Name(),
+				registeredID:    t.Name(),
+				fc:              fc,
+				telemetryServer: telemetry.NewServer(availableAddr(), log, fc.Flush),
+			}
+
+			assert.True(t, m.telemetryEnabled())
+
+			start := make(chan struct{}, 1)
+			done := make(chan struct{}, 1)
+
+			server := &mocked{delay: 1 * time.Second, erred: nil, start: start, done: done}
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				<-start
+				close(start)
+				for {
+					select {
+					case <-done:
+						close(done)
+						cancel()
+						return
+					}
+				}
+			}()
+			assert.ErrorIs(t, tc.ExpectError, m.Run(ctx, server))
+			assert.Equal(t, tc.ExpectedFlushWaits, fc.waitedCount)
 		})
 	}
 }

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -24,6 +25,7 @@ type Server struct {
 	log        logrus.FieldLogger
 	f          RuntimeDoneHook
 	httpServer *http.Server
+	httptest.Server
 }
 
 func NewServer(addr string, log logrus.FieldLogger, hook RuntimeDoneHook) *Server {

--- a/internal/awslambda/extension/telemetry/server.go
+++ b/internal/awslambda/extension/telemetry/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -21,11 +20,9 @@ func NoopHook() RuntimeDoneHook {
 }
 
 type Server struct {
-	addr       string
 	log        logrus.FieldLogger
 	f          RuntimeDoneHook
 	httpServer *http.Server
-	httptest.Server
 }
 
 func NewServer(addr string, log logrus.FieldLogger, hook RuntimeDoneHook) *Server {
@@ -52,6 +49,10 @@ func (s *Server) Start(ctx context.Context) error {
 			s.log.WithError(err).Info("Did not shutdown gracefully")
 		}
 	}()
+
+	s.log.WithFields(map[string]interface{}{
+		"serverAddress": s.httpServer.Addr,
+	}).Info("starting server")
 
 	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.log.WithError(err).Error("Server error")

--- a/internal/awslambda/extension/telemetry/server_test.go
+++ b/internal/awslambda/extension/telemetry/server_test.go
@@ -76,6 +76,7 @@ func TestRuntimeDoneHook(t *testing.T) {
 			go s.Start(ctx)
 
 			res, err := http.Post(s.Endpoint(), "application/json", bytes.NewReader(p))
+			require.NoError(t, err)
 			defer res.Body.Close()
 
 			assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/internal/flush/flush_coordinator.go
+++ b/internal/flush/flush_coordinator.go
@@ -1,0 +1,55 @@
+package flush
+
+type Coordinator interface {
+	Flushable
+	NotifyFlush()
+	RegisterFlushable(f Flushable)
+	WaitForFlush()
+}
+
+type Flushable interface {
+	Flush()
+}
+
+var _ Coordinator = (*coordinator)(nil)
+
+type coordinator struct {
+	t         Flushable
+	flushChan chan struct{}
+}
+
+func NewFlushCoordinator() Coordinator {
+	return &coordinator{
+		flushChan: make(chan struct{}, 1),
+	}
+}
+
+func (fm *coordinator) NotifyFlush() {
+	fm.flushChan <- struct{}{}
+}
+
+func (fm *coordinator) Flush() {
+	fm.t.Flush()
+}
+
+func (fm *coordinator) WaitForFlush() {
+	<-fm.flushChan
+}
+
+func (fm *coordinator) RegisterFlushable(t Flushable) {
+	fm.t = t
+}
+
+func NewNoopFlushCoordinator() Coordinator {
+	return &noopFlushCoordinator{}
+}
+
+type noopFlushCoordinator struct{}
+
+func (n *noopFlushCoordinator) Flush() {}
+
+func (n *noopFlushCoordinator) NotifyFlush() {}
+
+func (n *noopFlushCoordinator) RegisterFlushable(Flushable) {}
+
+func (n *noopFlushCoordinator) WaitForFlush() {}

--- a/internal/flush/flush_coordinator_test.go
+++ b/internal/flush/flush_coordinator_test.go
@@ -1,0 +1,43 @@
+package flush
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockFlushable struct {
+	flushCount int
+	s          Flushable
+}
+
+func (mockFlushable *mockFlushable) Flush() {
+	mockFlushable.flushCount += 1
+}
+
+func TestFlush(t *testing.T) {
+	t.Parallel()
+
+	f := mockFlushable{}
+	fm := NewFlushCoordinator()
+	fm.RegisterFlushable(&f)
+
+	fm.Flush()
+	assert.Equal(t, 1, f.flushCount)
+}
+
+func TestWaitForFlush(t *testing.T) {
+	t.Parallel()
+
+	f := mockFlushable{}
+	fm := NewFlushCoordinator()
+	fm.RegisterFlushable(&f)
+
+	fm.Flush()
+	go func() {
+		<-time.NewTimer(100 * time.Millisecond).C
+		fm.NotifyFlush()
+	}()
+	fm.WaitForFlush()
+}

--- a/pkg/statsd/handler_http_forwarder_v2_test.go
+++ b/pkg/statsd/handler_http_forwarder_v2_test.go
@@ -313,7 +313,7 @@ func TestForwardingData(t *testing.T) {
 	assert.Greater(t, atomic.LoadUint64(&ts.called), uint64(0), "Handler must have been called")
 	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.pineappleCount))
 	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.derpCount))
-	assert.EqualValues(t, 10, ts.derpValue)
+	assert.EqualValues(t, 10, atomic.LoadInt64(&ts.derpValue))
 	assert.Equal(t, 0, mockClock.Len(), "Must have closed all event handlers")
 }
 
@@ -395,10 +395,10 @@ func TestManualFlush(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, uint64(2), ts.called, "Handler must have been called")
-	assert.EqualValues(t, 1, ts.pineappleCount)
-	assert.EqualValues(t, 1, ts.derpCount)
-	assert.EqualValues(t, 10, ts.derpValue)
+	assert.Equal(t, uint64(2), atomic.LoadUint64(&ts.called), "Handler must have been called")
+	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.pineappleCount))
+	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.derpCount))
+	assert.EqualValues(t, 10, atomic.LoadInt64(&ts.derpValue))
 }
 
 type testServer struct {

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/atlassian/gostatsd"
+	"github.com/atlassian/gostatsd/internal/flush"
 	"github.com/atlassian/gostatsd/pkg/healthcheck"
 	"github.com/atlassian/gostatsd/pkg/stats"
 	"github.com/atlassian/gostatsd/pkg/transport"
@@ -33,6 +34,7 @@ type Server struct {
 	ExpiryIntervalGauge       time.Duration
 	ExpiryIntervalSet         time.Duration
 	ExpiryIntervalTimer       time.Duration
+	ForwarderFlushCoordinator flush.Coordinator
 	FlushInterval             time.Duration
 	FlushOffset               time.Duration
 	FlushAligned              bool
@@ -130,6 +132,7 @@ func (s *Server) createForwarderSink(logger logrus.FieldLogger) (gostatsd.Pipeli
 		logger,
 		s.Viper,
 		s.TransportPool,
+		s.ForwarderFlushCoordinator,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/web/http_receiver_v2_test.go
+++ b/pkg/web/http_receiver_v2_test.go
@@ -63,6 +63,7 @@ func TestForwardingEndToEndV2(t *testing.T) {
 		nil,
 		nil,
 		p,
+		nil,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds manual flushes at the end of the execution of a lambda runtime. By default this is disabled, in the gostatsd and a `flush.Coordinator` has to be explicitly injected for it to be enabled. This maintains backwards compatibility with the existing `main.go` for gostatsd.

### Changes
- Added and integrated `flush.Coordinator` which can be used to trigger flushes to the gostatsd server in forwarder mode, disabled by default.
- Add full end to end integration test
### Remaining tasks
- [x] update documentation