### PR TITLE
Fix release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: pb/gostatsd.pb.go
 			-v \
 			-ldflags "-X main.Version=$(REPO_VERSION) -X main.GitCommit=$(GIT_HASH) -X main.BuildDate=$(BUILD_DATE)" \
 			$(GOBUILD_OPTIONAL_FLAGS) \
-			-o build/bin/$(ARCH)/$(BINARY_NAME) \
+			-o build/bin/$(ARCH)/$(CPU_ARCH)/$(BINARY_NAME) \
 			$(PKG)
 
 build-gostatsd:

--- a/build/Dockerfile-multiarch-glibc
+++ b/build/Dockerfile-multiarch-glibc
@@ -26,6 +26,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-COPY --from=build /build/bin/linux/${TARGETARCH}/gostatsd /bin/gostatsd
+COPY --from=build /build/bin/${TARGETARCH}/gostatsd /bin/gostatsd
 
 ENTRYPOINT ["gostatsd"]

--- a/build/Dockerfile-multiarch-glibc
+++ b/build/Dockerfile-multiarch-glibc
@@ -26,6 +26,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-COPY --from=build /build/bin/${TARGETARCH}/gostatsd /bin/gostatsd
+COPY --from=build /build/bin/linux/${TARGETARCH}/gostatsd /bin/gostatsd
 
 ENTRYPOINT ["gostatsd"]


### PR DESCRIPTION
This [change](https://github.com/atlassian/gostatsd/pull/645/files#diff-335b7f0af38be3786aac89a9aeb95cd5cb56e836289ea3328a475e58b8b2cb3d) moved the go binary build in `Dockerfile-multiarch-glibc` to use the `make build` command which is writing the go binary to `build/bin/<cpu_arch>/<binary_name>` instead of `build/bin/<os>/<cpu_arch>/<binary_name`

This PR adjusts the build make command to be consistent and write binary output to `build/bin/<os>/<cpu_arch>/<binary_name`