### PR TITLE
[bug] Specify CPU_ARCH in Dockerfile-multiarch-glibc

### DIFF
--- a/build/Dockerfile-multiarch-glibc
+++ b/build/Dockerfile-multiarch-glibc
@@ -16,7 +16,7 @@ ADD . /build
 
 # Race needs CGO
 # https://github.com/golang/go/issues/51235
-RUN make build CGO_ENABLED=1 PKG=${MAIN_PKG}
+RUN make build CPU_ARCH=${TARGETARCH} CGO_ENABLED=1 PKG=${MAIN_PKG}
 
 FROM ubuntu:22.04
 


### PR DESCRIPTION
The `make build` command depends on ARCH (OS) and CPU_ARCH (TARGETARCH) to construct the directory where the binary will be held. This is causing docker build  Dockerfile-multiarch-glibc for ARMs to fail because it is using the default value `amd64` instead of the TARGETARCH. 

This adds `CPU_ARCH` in the make build command inside `Dockerfile-multiarch-glibc`