### PR TITLE
Remove the replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
-
-// https://github.com/atlassian/gostatsd/pull/455
-replace github.com/denis-tingajkin/go-header => github.com/denis-tingaikin/go-header v0.4.2


### PR DESCRIPTION
This is to avoid code injection via a renamed repo introduced in https://github.com/atlassian/gostatsd/pull/455

Now golangci-lint had updated the dependency and we had updated golangci-lint, this is no longer an issue.