### PR TITLE
Update incorrect golang version in multiarch dockerfile

### DIFF
--- a/build/Dockerfile-multiarch
+++ b/build/Dockerfile-multiarch
@@ -1,5 +1,5 @@
 # Go version needs to be the same in: CI config, README, Dockerfiles, and Makefile
-FROM golang:1.21.3 AS build
+FROM golang:1.21.4 AS build
 WORKDIR /build
 
 # Install dependencies first to take advantage of the docker build cache.


### PR DESCRIPTION
Golang versions were inconsistent, and I previously tried to correct them, but missed this one.