### PR TITLE
Fix viper environment variable reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+39.0.0
+------
+- Fix breaking change from viper 1.15 -> 1.16
+
 38.1.0
 ------
 - Add support for LZ4 compression

--- a/internal/util/viper.go
+++ b/internal/util/viper.go
@@ -21,13 +21,8 @@ func GetSubViper(v *viper.Viper, key string) *viper.Viper {
 // InitViper sets up env var handling for a viper. This must be run on every created sub viper as these settings
 // are not persisted to nested viper instances.
 func InitViper(v *viper.Viper, subViperName string) {
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	if subViperName != "" {
-		// Sub viper environment variables are accessed via <EnvPrefix>_<subViperName>_<varName>
-		v.SetEnvPrefix(EnvPrefix + "_" + strings.ToUpper(subViperName))
-	} else {
-		v.SetEnvPrefix(EnvPrefix)
-	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	v.SetEnvPrefix(EnvPrefix)
 	v.SetTypeByDefaultValue(true)
 	v.AutomaticEnv()
 }


### PR DESCRIPTION
Some sort of breaking change from viper 1.15 to 1.16, because viper isn't semver or something I don't know.