### PR TITLE
Improving Lambda Extension API

### DIFF
--- a/cmd/lambda-extension/main.go
+++ b/cmd/lambda-extension/main.go
@@ -148,9 +148,11 @@ func main() {
 		os.Getenv(api.EnvLambdaAPIHostname),
 		conf.GetString(ParamLambdaFileName),
 		log,
-		opts...)
+		server,
+		opts...,
+	)
 
-	if err := manager.Run(ctx, server); err != nil {
+	if err := manager.Run(ctx); err != nil {
 		log.WithError(err).Error("Failed trying to run lambda extension")
 	}
 

--- a/internal/awslambda/extension/manager_integration_test.go
+++ b/internal/awslambda/extension/manager_integration_test.go
@@ -80,11 +80,11 @@ func TestManagerGostatsDIntegrationTest(t *testing.T) {
 	teleAddr := availableAddr()
 	u, err := url.Parse(lambdaServer.URL)
 	require.NoError(t, err)
-	m := NewManager(u.Host, "test", log, WithManualFlushEnabled(fc, teleAddr))
+	m := NewManager(u.Host, "test", log, statsDServer, WithManualFlushEnabled(fc, teleAddr))
 
 	wg := wait.Group{}
 	wg.StartWithContext(ctx, func(ctx context.Context) {
-		err := m.Run(ctx, statsDServer)
+		err := m.Run(ctx)
 		assert.ErrorIs(t, err, ctx.Err())
 	})
 


### PR DESCRIPTION
## Context

This removes inverse dep injection on start to make it more a concrete API that aligns with the existing server interface.

This will help when creating a "runtime" that can be included into a different project.

## Changes

- Simplified Lambda Extension API
- Updated tests with impacted changes.