### PR TITLE
Make sure to call the callback in the OTLP backends send metrics function

### DIFF
--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -216,12 +216,13 @@ func (bd *Backend) SendMetricsAsync(ctx context.Context, mm *gostatsd.MetricMap,
 
 	})
 
-	if err := bd.postMetrics(ctx, group.Values()); err != nil {
+	err := bd.postMetrics(ctx, group.Values())
+	if err != nil {
 		bd.logger.WithError(err).WithFields(logrus.Fields{
 			"endpoint": bd.endpoint,
 		}).Error("Issues trying to submit data")
-		cb(multierr.Errors(err))
 	}
+	cb(multierr.Errors(err))
 }
 
 func (c *Backend) postMetrics(ctx context.Context, resourceMetrics []data.ResourceMetrics) error {


### PR DESCRIPTION
Based on the [callback function](https://github.com/atlassian/gostatsd/blob/master/pkg/statsd/flusher.go#L108) passed in by the flusher, the callback should always be called to make sure the otlp backend job is marked done.