### PR TITLE
Avoid merging bucket tag into an array for histogram metrics

### DIFF
--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -170,9 +170,9 @@ func (bd *Backend) SendMetricsAsync(ctx context.Context, mm *gostatsd.MetricMap,
 		switch bd.convertTimersToGauges {
 		case true:
 			if len(t.Histogram) != 0 {
-				btags := data.NewMap()
-				btags.Merge(attributes)
 				for boundry, count := range t.Histogram {
+					btags := data.NewMap()
+					btags.Merge(attributes)
 					if math.IsInf(float64(boundry), 1) {
 						btags.Insert("le", "+Inf")
 					} else {
@@ -185,7 +185,7 @@ func (bd *Backend) SendMetricsAsync(ctx context.Context, mm *gostatsd.MetricMap,
 							data.NewGauge(data.NewNumberDataPoint(
 								uint64(t.Timestamp),
 								data.WithNumberDataPointMap(btags),
-								data.WithNumberDatapointIntValue(int64(count)),
+								data.WithNumberDataPointDoubleValue(float64(count)),
 							)),
 						),
 					)

--- a/pkg/backends/otlp/backend_test.go
+++ b/pkg/backends/otlp/backend_test.go
@@ -239,11 +239,17 @@ func TestBackendSendAsyncMetrics(t *testing.T) {
 				ms := req.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()
 				dp1 := ms[0].GetGauge().DataPoints[0]
 				dp2 := ms[1].GetGauge().DataPoints[0]
+
 				assert.Equal(t, 1.0, dp1.GetAsDouble())
 				assert.Equal(t, "le", dp1.GetAttributes()[0].Key)
-				assert.Equal(t, "500", dp1.GetAttributes()[0].GetValue().GetStringValue())
 				assert.Equal(t, "le", dp1.GetAttributes()[0].Key)
-				assert.Equal(t, "+Inf", dp2.GetAttributes()[0].Value.GetStringValue())
+				assert.True(t, func() bool {
+					dp1LeTagValue := dp1.GetAttributes()[0].GetValue().GetStringValue()
+					dp2LeTagValue := dp2.GetAttributes()[0].GetValue().GetStringValue()
+
+					// we're not sure in which order the bucket tag will be put into each metrics
+					return dp1LeTagValue == "500" && dp2LeTagValue == "+Inf" || dp1LeTagValue == "+Inf" && dp2LeTagValue == "500"
+				}())
 			},
 			validate: func(t *testing.T) func(errs []error) {
 				return func(errs []error) {

--- a/pkg/backends/otlp/backend_test.go
+++ b/pkg/backends/otlp/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -198,6 +199,51 @@ func TestBackendSendAsyncMetrics(t *testing.T) {
 			}(),
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				// Do nothing
+			},
+			validate: func(t *testing.T) func(errs []error) {
+				return func(errs []error) {
+					if !assert.Len(t, errs, 0, "Must not error") {
+						return
+					}
+				}
+			},
+		},
+		{
+			name: "validate metric data with gauge conversion",
+			mm: func() *gostatsd.MetricMap {
+				mm := gostatsd.NewMetricMap(false)
+				mm.Receive(&gostatsd.Metric{
+					Name:  "my-metric",
+					Value: 100.0,
+					Rate:  1,
+					Type:  gostatsd.TIMER,
+				})
+				mm.Timers.Each(func(name, tagsKey string, t gostatsd.Timer) {
+					t.Histogram = map[gostatsd.HistogramThreshold]int{
+						gostatsd.HistogramThreshold(math.Inf(1)): 1,
+						500:                                      1,
+					}
+					mm.Timers[name][tagsKey] = t
+				})
+				return mm
+			}(),
+			handler: func(_ http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err, "Must not error reading body")
+				assert.NotEmpty(t, body, "Must not have an empty body")
+
+				req := &v1export.ExportMetricsServiceRequest{}
+				err = proto.Unmarshal(body, req)
+				assert.NoError(t, err, "Must not error unmarshalling body")
+
+				ms := req.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()
+				dp1 := ms[0].GetGauge().DataPoints[0]
+				dp2 := ms[1].GetGauge().DataPoints[0]
+				assert.Equal(t, 1.0, dp1.GetAsDouble())
+				assert.Equal(t, "le", dp1.GetAttributes()[0].Key)
+				assert.Equal(t, "500", dp1.GetAttributes()[0].GetValue().GetStringValue())
+				assert.Equal(t, "le", dp1.GetAttributes()[0].Key)
+				assert.Equal(t, "+Inf", dp2.GetAttributes()[0].Value.GetStringValue())
 			},
 			validate: func(t *testing.T) func(errs []error) {
 				return func(errs []error) {


### PR DESCRIPTION
* Fix the issue that multiple histogram are sharing same tags - for historgrams even the resource attributes are the same the bucket tags are always different. For example, if a metric defines histogram buckets `["+Inf", "100"]`,  the expected `le` tag for these 2 metrics are `le:+Inf`, `le:100` respectively, not `le:["+Inf", "100"]`
* Change the data point value type to `float64` so it align with datadog backend data format 
