### PR TITLE
Support batch sending metrics for OTLP backend

### DIFF
--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -119,7 +119,7 @@ func (b *Backend) SendEvent(ctx context.Context, event *gostatsd.Event) error {
 }
 
 func (bd *Backend) SendMetricsAsync(ctx context.Context, mm *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	group := NewGroup(bd.metricsPerBatch)
+	group := NewGroups(bd.metricsPerBatch)
 
 	mm.Counters.Each(func(name, _ string, cm gostatsd.Counter) {
 		resources, attributes := data.SplitMetricTagsByKeysAndConvert(cm.Tags, bd.resourceKeys)

--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -42,6 +42,9 @@ type Backend struct {
 	logger            logrus.FieldLogger
 	client            *http.Client
 	requestsBufferSem chan struct{}
+
+	// metricsPerBatch is the maximum number of metrics to send in a single batch.
+	metricsPerBatch uint
 }
 
 var _ gostatsd.Backend = (*Backend)(nil)
@@ -72,6 +75,7 @@ func NewClientFromViper(v *viper.Viper, logger logrus.FieldLogger, pool *transpo
 		client:                tc.Client,
 		logger:                logger,
 		requestsBufferSem:     make(chan struct{}, cfg.MaxRequests),
+		metricsPerBatch:       cfg.MetricsPerBatch,
 	}, nil
 }
 

--- a/pkg/backends/otlp/config.go
+++ b/pkg/backends/otlp/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	// MaxRequests (Optional, default: cpu.count * 2) is the upper limit on the number of inflight requests
 	MaxRequests int `mapstructure:"max_requests"`
 	// MetricsPerBatch (Optional, default: 1000) is the maximum number of metrics to send in a single batch.
-	MetricsPerBatch uint `mapstructure:"metrics_per_batch"`
+	MetricsPerBatch int `mapstructure:"metrics_per_batch"`
 	// ResourceKeys (Optional) is used to extract values from provided tags
 	// to apply to all values within a resource instead within each attribute.
 	// Strongly encouraged to allow down stream consumers to
@@ -71,7 +71,6 @@ func NewConfig(v *viper.Viper) (*Config, error) {
 		util.GetSubViper(v, BackendName).Unmarshal(cfg),
 		cfg.Validate(),
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backends/otlp/config_test.go
+++ b/pkg/backends/otlp/config_test.go
@@ -29,12 +29,14 @@ func TestNewConfig(t *testing.T) {
 				v.SetDefault("otlp.metrics_endpoint", "http://local/v1/metrics")
 				v.SetDefault("otlp.logs_endpoint", "http://local/v1/logs")
 				v.SetDefault("otlp.max_requests", 1)
+				v.SetDefault("otlp.metrics_per_batch", 999)
 				return v
 			}(),
 			expect: &Config{
 				MetricsEndpoint: "http://local/v1/metrics",
 				LogsEndpoint:    "http://local/v1/logs",
 				MaxRequests:     1,
+				MetricsPerBatch: 999,
 				Conversion:      "AsGauge",
 				Transport:       "default",
 				UserAgent:       "gostatsd",

--- a/pkg/backends/otlp/group.go
+++ b/pkg/backends/otlp/group.go
@@ -15,7 +15,7 @@ func (g *group) values() []data.ResourceMetrics {
 func (g *group) lenMetrics() int {
 	count := 0
 	for _, rm := range *g {
-		count += rm.CouneMetrics()
+		count += rm.CountMetrics()
 	}
 	return count
 }

--- a/pkg/backends/otlp/group.go
+++ b/pkg/backends/otlp/group.go
@@ -1,8 +1,9 @@
 package otlp
 
 import (
-	"github.com/atlassian/gostatsd/pkg/backends/otlp/internal/data"
 	"golang.org/x/exp/maps"
+
+	"github.com/atlassian/gostatsd/pkg/backends/otlp/internal/data"
 )
 
 type group map[uint64]data.ResourceMetrics

--- a/pkg/backends/otlp/group.go
+++ b/pkg/backends/otlp/group.go
@@ -6,31 +6,45 @@ import (
 	"github.com/atlassian/gostatsd/pkg/backends/otlp/internal/data"
 )
 
+type group map[uint64]data.ResourceMetrics
+
 // Group is used to ensure metrics that have the same resource attributes
 // are grouped together and it uses a fixed values to reduce potential memory
 // allocations compared to using a string value
-type Group map[uint64]data.ResourceMetrics
-
-func NewGroup() Group {
-	return make(Group)
+type Group struct {
+	batches         []group
+	metricsInserted int
+	batchSize       int
 }
 
-func (g *Group) Values() []data.ResourceMetrics {
+func NewGroup(batchSize int) Group {
+	return Group{
+		batches:   []group{make(group)},
+		batchSize: batchSize,
+	}
+}
+
+func (g *group) Values() []data.ResourceMetrics {
 	return maps.Values(*g)
 }
 
 func (g *Group) Insert(is data.InstrumentationScope, resources data.Map, m data.Metric) {
 	key := resources.Hash()
 
-	entry, exist := (*g)[key]
+	currentBatch := g.batches[len(g.batches)-1]
+	entry, exist := (currentBatch)[key]
 	if !exist {
 		entry = data.NewResourceMetrics(
 			data.NewResource(
 				data.WithResourceMap(resources),
 			),
 		)
-		(*g)[key] = entry
+		(currentBatch)[key] = entry
 	}
-
 	entry.AppendMetric(is, m)
+	currentBatch[key] = entry
+
+	if len(currentBatch) == g.batchSize {
+		g.batches = append(g.batches, make(group))
+	}
 }

--- a/pkg/backends/otlp/group.go
+++ b/pkg/backends/otlp/group.go
@@ -20,23 +20,23 @@ func (g *group) LenMetrics() int {
 	return count
 }
 
-// Group is used to ensure metrics that have the same resource attributes
+// Groups is used to ensure metrics that have the same resource attributes
 // are grouped together and it uses a fixed values to reduce potential memory
 // allocations compared to using a string value
-type Group struct {
+type Groups struct {
 	batches         []group
 	metricsInserted int
 	batchSize       int
 }
 
-func NewGroup(batchSize int) Group {
-	return Group{
+func NewGroups(batchSize int) Groups {
+	return Groups{
 		batches:   []group{make(group)},
 		batchSize: batchSize,
 	}
 }
 
-func (g *Group) Insert(is data.InstrumentationScope, resources data.Map, m data.Metric) {
+func (g *Groups) Insert(is data.InstrumentationScope, resources data.Map, m data.Metric) {
 	key := resources.Hash()
 
 	currentBatch := g.batches[len(g.batches)-1]
@@ -52,7 +52,8 @@ func (g *Group) Insert(is data.InstrumentationScope, resources data.Map, m data.
 	entry.AppendMetric(is, m)
 	currentBatch[key] = entry
 
-	if currentBatch.LenMetrics() == g.batchSize {
+	if currentBatch.LenMetrics() >= g.batchSize {
+		// next insertion "current batch" will be the a new batch
 		g.batches = append(g.batches, make(group))
 	}
 }

--- a/pkg/backends/otlp/group.go
+++ b/pkg/backends/otlp/group.go
@@ -8,11 +8,11 @@ import (
 
 type group map[uint64]data.ResourceMetrics
 
-func (g *group) Values() []data.ResourceMetrics {
+func (g *group) values() []data.ResourceMetrics {
 	return maps.Values(*g)
 }
 
-func (g *group) LenMetrics() int {
+func (g *group) lenMetrics() int {
 	count := 0
 	for _, rm := range *g {
 		count += rm.CouneMetrics()
@@ -20,23 +20,23 @@ func (g *group) LenMetrics() int {
 	return count
 }
 
-// Groups is used to ensure metrics that have the same resource attributes
+// groups is used to ensure metrics that have the same resource attributes
 // are grouped together and it uses a fixed values to reduce potential memory
 // allocations compared to using a string value
-type Groups struct {
+type groups struct {
 	batches         []group
 	metricsInserted int
 	batchSize       int
 }
 
-func NewGroups(batchSize int) Groups {
-	return Groups{
+func newGroups(batchSize int) groups {
+	return groups{
 		batches:   []group{make(group)},
 		batchSize: batchSize,
 	}
 }
 
-func (g *Groups) Insert(is data.InstrumentationScope, resources data.Map, m data.Metric) {
+func (g *groups) insert(is data.InstrumentationScope, resources data.Map, m data.Metric) {
 	key := resources.Hash()
 
 	currentBatch := g.batches[len(g.batches)-1]
@@ -52,8 +52,8 @@ func (g *Groups) Insert(is data.InstrumentationScope, resources data.Map, m data
 	entry.AppendMetric(is, m)
 	currentBatch[key] = entry
 
-	if currentBatch.LenMetrics() >= g.batchSize {
-		// next insertion "current batch" will be the a new batch
+	if currentBatch.lenMetrics() >= g.batchSize {
+
 		g.batches = append(g.batches, make(group))
 	}
 }

--- a/pkg/backends/otlp/group_test.go
+++ b/pkg/backends/otlp/group_test.go
@@ -58,47 +58,75 @@ func TestGroupInsert(t *testing.T) {
 func TestGroupBatch(t *testing.T) {
 	t.Parallel()
 
-	g := NewGroup(2)
+	for _, tc := range []struct {
+		name             string
+		batchSize        int
+		metricsAdded     map[string][]string // map[resourceMetrics][]metricNames
+		wantNumOfBatches int
+	}{
+		{
+			name:             "no metrics",
+			batchSize:        2,
+			metricsAdded:     map[string][]string{},
+			wantNumOfBatches: 1, // Must have at least one batch
+		},
+		{
+			name:      "metrics in one resource metrics exceeds batch limit should be split into two groups",
+			batchSize: 2,
+			metricsAdded: map[string][]string{
+				"r1": {"m1", "m2", "m3", "m4", "m5"},
+			},
+			wantNumOfBatches: 3,
+		},
+		{
+			name:      "metrics in multiple resource metrics doesn't exceeds batch limit stay in one group",
+			batchSize: 10,
+			metricsAdded: map[string][]string{
+				"r1": {"m1", "m2", "m3"},
+				"r2": {"m1", "m2", "m3"},
+				"r3": {"m1", "m2", "m3"},
+			},
+			wantNumOfBatches: 1,
+		},
+		{
+			name:      "should properly split metrics into groups according to batch size",
+			batchSize: 5,
+			metricsAdded: map[string][]string{
+				"r1": {"m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10"},
+				"r2": {"m1"},
+				"r3": {"m1", "m2", "m3", "m4", "m5"},
+				"r4": {"m1", "m2", "m3"},
+			},
+			wantNumOfBatches: 4,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGroup(tc.batchSize)
+			is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
+			for rm, metricNames := range tc.metricsAdded {
+				for _, metricName := range metricNames {
+					insertMetric(&g, is, rm, metricName)
+				}
+			}
 
-	is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
+			assert.Len(t, g.batches, tc.wantNumOfBatches, "Must have %d groups", tc.wantNumOfBatches)
+		})
+	}
+}
 
+func insertMetric(g *Group, is data.InstrumentationScope, serviceName string, metricName string) {
 	g.Insert(
 		is,
 		data.NewMap(
 			data.WithStatsdDelimitedTags(
 				[]string{
-					"service.name:my-awesome-service",
+					"service.name:" + serviceName,
 					"service.region:local",
 				},
 			),
 		),
-		data.NewMetric("my-metric"),
+		data.NewMetric(metricName),
 	)
-	g.Insert(
-		is,
-		data.NewMap(
-			data.WithStatsdDelimitedTags(
-				[]string{
-					"service.name:my-awesome-service",
-					"service.region:local",
-				},
-			),
-		),
-		data.NewMetric("my-metric"),
-	)
-	g.Insert(
-		is,
-		data.NewMap(
-			data.WithStatsdDelimitedTags(
-				[]string{
-					"service.name:my-other-service",
-					"service.region:local",
-				},
-			),
-		),
-		data.NewMetric("my-metric"),
-	)
-
-	batches := g.batches
-	assert.Equal(t, 2, len(batches))
 }

--- a/pkg/backends/otlp/group_test.go
+++ b/pkg/backends/otlp/group_test.go
@@ -11,7 +11,7 @@ import (
 func TestGroupInsert(t *testing.T) {
 	t.Parallel()
 
-	g := NewGroup(1000)
+	g := NewGroups(1000)
 
 	is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
 
@@ -103,7 +103,7 @@ func TestGroupBatch(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			g := NewGroup(tc.batchSize)
+			g := NewGroups(tc.batchSize)
 			is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
 			for rm, metricNames := range tc.metricsAdded {
 				for _, metricName := range metricNames {
@@ -116,7 +116,7 @@ func TestGroupBatch(t *testing.T) {
 	}
 }
 
-func insertMetric(g *Group, is data.InstrumentationScope, serviceName string, metricName string) {
+func insertMetric(g *Groups, is data.InstrumentationScope, serviceName string, metricName string) {
 	g.Insert(
 		is,
 		data.NewMap(

--- a/pkg/backends/otlp/group_test.go
+++ b/pkg/backends/otlp/group_test.go
@@ -11,7 +11,7 @@ import (
 func TestGroupInsert(t *testing.T) {
 	t.Parallel()
 
-	g := NewGroup()
+	g := NewGroup(1000)
 
 	is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
 
@@ -52,5 +52,53 @@ func TestGroupInsert(t *testing.T) {
 		data.NewMetric("my-metric"),
 	)
 
-	assert.Len(t, g.Values(), 2, "Must have two distinct value")
+	assert.Len(t, g.batches[0].Values(), 2, "Must have two distinct value")
+}
+
+func TestGroupBatch(t *testing.T) {
+	t.Parallel()
+
+	g := NewGroup(2)
+
+	is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
+
+	g.Insert(
+		is,
+		data.NewMap(
+			data.WithStatsdDelimitedTags(
+				[]string{
+					"service.name:my-awesome-service",
+					"service.region:local",
+				},
+			),
+		),
+		data.NewMetric("my-metric"),
+	)
+	g.Insert(
+		is,
+		data.NewMap(
+			data.WithStatsdDelimitedTags(
+				[]string{
+					"service.name:my-awesome-service",
+					"service.region:local",
+				},
+			),
+		),
+		data.NewMetric("my-metric"),
+	)
+	g.Insert(
+		is,
+		data.NewMap(
+			data.WithStatsdDelimitedTags(
+				[]string{
+					"service.name:my-other-service",
+					"service.region:local",
+				},
+			),
+		),
+		data.NewMetric("my-metric"),
+	)
+
+	batches := g.batches
+	assert.Equal(t, 2, len(batches))
 }

--- a/pkg/backends/otlp/group_test.go
+++ b/pkg/backends/otlp/group_test.go
@@ -11,11 +11,11 @@ import (
 func TestGroupInsert(t *testing.T) {
 	t.Parallel()
 
-	g := NewGroups(1000)
+	g := newGroups(1000)
 
 	is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
 
-	g.Insert(
+	g.insert(
 		is,
 		data.NewMap(
 			data.WithStatsdDelimitedTags(
@@ -27,7 +27,7 @@ func TestGroupInsert(t *testing.T) {
 		),
 		data.NewMetric("my-metric"),
 	)
-	g.Insert(
+	g.insert(
 		is,
 		data.NewMap(
 			data.WithStatsdDelimitedTags(
@@ -39,7 +39,7 @@ func TestGroupInsert(t *testing.T) {
 		),
 		data.NewMetric("my-metric"),
 	)
-	g.Insert(
+	g.insert(
 		is,
 		data.NewMap(
 			data.WithStatsdDelimitedTags(
@@ -52,7 +52,7 @@ func TestGroupInsert(t *testing.T) {
 		data.NewMetric("my-metric"),
 	)
 
-	assert.Len(t, g.batches[0].Values(), 2, "Must have two distinct value")
+	assert.Len(t, g.batches[0].values(), 2, "Must have two distinct value")
 }
 
 func TestGroupBatch(t *testing.T) {
@@ -103,7 +103,7 @@ func TestGroupBatch(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			g := NewGroups(tc.batchSize)
+			g := newGroups(tc.batchSize)
 			is := data.NewInstrumentationScope("gostatsd/aggregation", "v1.0.0")
 			for rm, metricNames := range tc.metricsAdded {
 				for _, metricName := range metricNames {
@@ -116,8 +116,8 @@ func TestGroupBatch(t *testing.T) {
 	}
 }
 
-func insertMetric(g *Groups, is data.InstrumentationScope, serviceName string, metricName string) {
-	g.Insert(
+func insertMetric(g *groups, is data.InstrumentationScope, serviceName string, metricName string) {
+	g.insert(
 		is,
 		data.NewMap(
 			data.WithStatsdDelimitedTags(

--- a/pkg/backends/otlp/internal/data/resource_metrics.go
+++ b/pkg/backends/otlp/internal/data/resource_metrics.go
@@ -29,3 +29,11 @@ func (rm ResourceMetrics) AppendMetric(is InstrumentationScope, m Metric) {
 	}
 	rm.raw.ScopeMetrics[0].Metrics = append(rm.raw.ScopeMetrics[0].Metrics, m.raw)
 }
+
+func (rm ResourceMetrics) CouneMetrics() int {
+	c := 0
+	for _, sm := range rm.raw.ScopeMetrics {
+		c += len(sm.Metrics)
+	}
+	return c
+}

--- a/pkg/backends/otlp/internal/data/resource_metrics.go
+++ b/pkg/backends/otlp/internal/data/resource_metrics.go
@@ -30,7 +30,7 @@ func (rm ResourceMetrics) AppendMetric(is InstrumentationScope, m Metric) {
 	rm.raw.ScopeMetrics[0].Metrics = append(rm.raw.ScopeMetrics[0].Metrics, m.raw)
 }
 
-func (rm ResourceMetrics) CouneMetrics() int {
+func (rm ResourceMetrics) CountMetrics() int {
 	c := 0
 	for _, sm := range rm.raw.ScopeMetrics {
 		c += len(sm.Metrics)

--- a/pkg/backends/otlp/internal/data/resource_metrics_test.go
+++ b/pkg/backends/otlp/internal/data/resource_metrics_test.go
@@ -31,5 +31,5 @@ func TestNewResourceMetrics(t *testing.T) {
 		),
 	)
 	assert.Len(t, rm.raw.ScopeMetrics, 2, "Must have two scope metrics defined")
-	assert.Equal(t, 3, rm.CouneMetrics())
+	assert.Equal(t, 3, rm.CountMetrics())
 }

--- a/pkg/backends/otlp/internal/data/resource_metrics_test.go
+++ b/pkg/backends/otlp/internal/data/resource_metrics_test.go
@@ -22,10 +22,14 @@ func TestNewResourceMetrics(t *testing.T) {
 		NewResource(),
 		NewScopeMetrics(
 			NewInstrumentationScope("gostatsd/aggregation", "test"),
+			NewMetric("a metric"),
+			NewMetric("another metric"),
 		),
 		NewScopeMetrics(
 			NewInstrumentationScope("gostatsd/aggregation", "test"),
+			NewMetric("some metric"),
 		),
 	)
 	assert.Len(t, rm.raw.ScopeMetrics, 2, "Must have two scope metrics defined")
+	assert.Equal(t, 3, rm.CouneMetrics())
 }

--- a/pkg/backends/otlp/testdata/all-options.toml
+++ b/pkg/backends/otlp/testdata/all-options.toml
@@ -1,27 +1,28 @@
-[ otlp ]
-metrics_endpoint      = 'an-example-of-an-awesome-hostname/with/path/to/otlp/metric/endpoint'
-logs_endpoint         = 'an-example-of-an-awesome-hostname/with/path/to/otlp/logs/endpoint'
-max_requests  = 7
-resource_keys = [ 'service.name', 'service.version', 'deployment.environment']
-conversion    = 'AsHistogram'
-transport     = 'otlp'
-user_agent    = 'gostatsd/otlp'
+[otlp]
+metrics_endpoint = 'an-example-of-an-awesome-hostname/with/path/to/otlp/metric/endpoint'
+logs_endpoint = 'an-example-of-an-awesome-hostname/with/path/to/otlp/logs/endpoint'
+max_requests = 7
+metrics_per_batch = 1000
+resource_keys = ['service.name', 'service.version', 'deployment.environment']
+conversion = 'AsHistogram'
+transport = 'otlp'
+user_agent = 'gostatsd/otlp'
 
 # While this these are valid to set, they are ignored here since conversion is
 # set to `AsHistogram` instead of `AsGauge`
-[ otlp.disabled_timer_aggregations ]
-lower           = false
-lowerpct        = false
-upper           = false
-upperpct        = false
-count           = false
-countpct        = false
-countpersecond  = false 
-mean            = false 
-meanpct         = false
-median          = false
-stddev          = false
-sum             = false 
-sumpct          = false
-sumsquares      = false
-sumsquarespct   = false
+[otlp.disabled_timer_aggregations]
+lower = false
+lowerpct = false
+upper = false
+upperpct = false
+count = false
+countpct = false
+countpersecond = false
+mean = false
+meanpct = false
+median = false
+stddev = false
+sum = false
+sumpct = false
+sumsquares = false
+sumsquarespct = false


### PR DESCRIPTION
This pull request introduces a batching mechanism for metrics in the OTLP backend's flushing process. Previously, metrics were not batched, causing the size of requests to grow unbounded with increasing flush intervals and the number of metrics handled. This change ensures that metrics are batched according to a configurable batch size, with a default of 1000 metrics per batch.