### PR TITLE
add tests and refactor retry sending

### DIFF
--- a/pkg/backends/otlp/config.go
+++ b/pkg/backends/otlp/config.go
@@ -91,7 +91,7 @@ func (c *Config) Validate() (errs error) {
 	if c.MaxRequests <= 0 {
 		errs = multierr.Append(errs, errors.New("max request must be a positive value"))
 	}
-	if c.MaxRetries <= 0 {
+	if c.MaxRetries < 0 {
 		errs = multierr.Append(errs, errors.New("max retries must be a positive value"))
 	}
 	if c.MetricsPerBatch <= 0 {

--- a/pkg/backends/otlp/internal/data/metric_response.go
+++ b/pkg/backends/otlp/internal/data/metric_response.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,10 @@ import (
 )
 
 func ProcessMetricResponse(resp *http.Response) (dropped int64, errs error) {
+	if resp == nil {
+		return 0, errors.New("empty response")
+	}
+
 	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
* Added tests for retry logic and rewrote the retry block to make it simpler
* Allow `maxRetries` to be set to 0 to indicate no retry (default value is still 3)