### PR TITLE
remove pb/gostatsd.pb.go from build, as go file is already commited

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ pb/gostatsd.pb.go: pb/gostatsd.proto .tools/bin/protoc
 	GOPATH="$(TOOLS_DIR):$(shell go env GOPATH)/bin" $(TOOLS_DIR)/protoc --go_out=.\
 		--go_opt=paths=source_relative $<
 
-build: pb/gostatsd.pb.go
+build:
 	CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=boringcrypto \
 		go build  \
 			-v \


### PR DESCRIPTION
should be able to run build commands without recompiling gostatsd.proto build-all can still be used for this purpose