### PR TITLE
Remove outdated test case

### DIFF
--- a/tags_test.go
+++ b/tags_test.go
@@ -15,7 +15,6 @@ func TestTagsToMap(t *testing.T) {
 		expected map[string]string
 	}{
 		{"empty tags", "", nil, map[string]string{}},
-		{"host is added", "x", nil, map[string]string{"host": "x"}},
 		{"1 tag is added", "", []string{"a:b"}, map[string]string{"a": "b"}},
 		{"2 tags are added", "", []string{"a:b", "c:d"}, map[string]string{"a": "b", "c": "d"}},
 		{"missing keys are handled", "", []string{"b", "c:d"}, map[string]string{"unknown": "b", "c": "d"}},


### PR DESCRIPTION
We don't add host tag in gostatsd, this test case should've been failing. But as pointed out in [this issue](https://github.com/atlassian/gostatsd/issues/734#issuecomment-2728864825) go test suite is not running the case. 
Tested locally it seems it only run the last case in the tests slice.

The failure was detected in a [PR](https://github.com/atlassian/gostatsd/pull/736) to upgrade Go