### PR TITLE
Fix race condition when we init lambda

### DIFF
--- a/pkg/statsd/handler_http_forwarder_v2.go
+++ b/pkg/statsd/handler_http_forwarder_v2.go
@@ -308,7 +308,7 @@ func (hfh *HttpForwarderHandlerV2) sendNop(ctx context.Context) {
 
 func (hfh *HttpForwarderHandlerV2) Run(ctx context.Context) {
 	var wg wait.Group
-	wg.StartWithContext(ctx, hfh.sendNop)
+	hfh.sendNop(ctx)
 	wg.Start(func() {
 		for metricMaps := range hfh.consolidatedMetrics {
 			hfh.acquireMergingSem()

--- a/pkg/statsd/handler_http_forwarder_v2_test.go
+++ b/pkg/statsd/handler_http_forwarder_v2_test.go
@@ -494,7 +494,9 @@ func TestManualFlush(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, uint64(2), atomic.LoadUint64(&ts.called), "Handler must have been called")
+	// First is for the "nop" (see HttpForwarderHandlerV2.Run + HttpForwarderHandlerV2.sendNop)
+	// Second is for the actual flush.
+	assert.Equal(t, uint64(1+1), atomic.LoadUint64(&ts.called), "Handler must have been called")
 	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.pineappleCount))
 	assert.EqualValues(t, 1, atomic.LoadUint64(&ts.derpCount))
 	assert.EqualValues(t, 10, atomic.LoadInt64(&ts.derpValue))


### PR DESCRIPTION
There's a couple of problems here:

1. We subscribe a telemetry endpoint before the service is ready.  If we receive a flush to that endpoint, then we try to perform a flush and get an NPE.

2. The access to the flusher is unprotected across multiple goroutines.  We just use an RWMutex for this, because it's rarely accessed and doesn't need anything fancy.

3. There's a race condition in the test because the nop write is (was) async.