### PR TITLE
Add backoff for retry in the OTLP backend

### DIFF
--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -89,7 +89,7 @@ func NewClientFromViper(v *viper.Viper, logger logrus.FieldLogger, pool *transpo
 		logger:                logger,
 		requestsBufferSem:     make(chan struct{}, cfg.MaxRequests),
 		maxRetries:            cfg.MaxRetries,
-		maxRequestElapsedTime: time.Duration(cfg.MaxRequestElapsedTime) * time.Second,
+		maxRequestElapsedTime: cfg.MaxRequestElapsedTime,
 		CompressPayload:       cfg.CompressPayload,
 		metricsPerBatch:       cfg.MetricsPerBatch,
 	}, nil

--- a/pkg/backends/otlp/backend.go
+++ b/pkg/backends/otlp/backend.go
@@ -9,16 +9,18 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync/atomic"
+	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/tilinna/clock"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/atlassian/gostatsd/pkg/stats"
-
 	"github.com/atlassian/gostatsd"
 	"github.com/atlassian/gostatsd/pkg/backends/otlp/internal/data"
+	"github.com/atlassian/gostatsd/pkg/stats"
 	"github.com/atlassian/gostatsd/pkg/transport"
 )
 
@@ -54,7 +56,8 @@ type Backend struct {
 	CompressPayload   bool
 
 	// metricsPerBatch is the maximum number of metrics to send in a single batch.
-	metricsPerBatch int
+	metricsPerBatch       int
+	maxRequestElapsedTime time.Duration
 }
 
 var _ gostatsd.Backend = (*Backend)(nil)
@@ -86,6 +89,7 @@ func NewClientFromViper(v *viper.Viper, logger logrus.FieldLogger, pool *transpo
 		logger:                logger,
 		requestsBufferSem:     make(chan struct{}, cfg.MaxRequests),
 		maxRetries:            cfg.MaxRetries,
+		maxRequestElapsedTime: time.Duration(cfg.MaxRequestElapsedTime) * time.Second,
 		CompressPayload:       cfg.CompressPayload,
 		metricsPerBatch:       cfg.MetricsPerBatch,
 	}, nil
@@ -337,6 +341,12 @@ func (c *Backend) postMetrics(ctx context.Context, batch group) error {
 		return err
 	}
 
+	b := backoff.NewExponentialBackOff()
+	clck := clock.FromContext(ctx)
+	b.Clock = clck
+	b.Reset()
+	b.MaxElapsedTime = c.maxRequestElapsedTime
+
 	for {
 		var dropped int64
 		c.requestsBufferSem <- struct{}{}
@@ -354,13 +364,27 @@ func (c *Backend) postMetrics(ctx context.Context, batch group) error {
 			}
 		}
 
-		if retries >= c.maxRetries {
-			break
+		next := b.NextBackOff()
+		if next == backoff.Stop || retries >= c.maxRetries {
+			atomic.AddUint64(&c.batchesDropped, 1)
+			return err
 		}
 
+		c.logger.WithFields(logrus.Fields{
+			"sleep": next,
+			"error": err,
+		}).Warn("failed to send metrics, will retry")
+
 		retries++
+
+		timer := clck.NewTimer(next)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
 		atomic.AddUint64(&c.batchesRetried.Cur, 1)
 	}
-
-	return err
 }

--- a/pkg/backends/otlp/backend_test.go
+++ b/pkg/backends/otlp/backend_test.go
@@ -472,7 +472,7 @@ func TestRetrySendMetrics(t *testing.T) {
 		name                 string
 		numUntilSuccess      int
 		maxRetries           int
-		maxRequestElapseTime int
+		maxRequestElapseTime string
 		wantAttempts         int
 		approxAttempts       bool // because of randomness of the retry interval
 		numErrs              int
@@ -509,7 +509,7 @@ func TestRetrySendMetrics(t *testing.T) {
 			name:                 "should not retry if maxRetries reached",
 			numUntilSuccess:      5,
 			maxRetries:           3,
-			maxRequestElapseTime: 100,
+			maxRequestElapseTime: "100s",
 			wantAttempts:         4,
 			numErrs:              1,
 		},
@@ -517,7 +517,7 @@ func TestRetrySendMetrics(t *testing.T) {
 			name:                 "should stop retry if maxRequestElapseTime reached",
 			numUntilSuccess:      5,
 			maxRetries:           100,
-			maxRequestElapseTime: 1,
+			maxRequestElapseTime: "1s",
 			wantAttempts:         3,
 			approxAttempts:       true,
 			numErrs:              1,
@@ -539,7 +539,9 @@ func TestRetrySendMetrics(t *testing.T) {
 			v.Set("otlp.metrics_endpoint", fmt.Sprintf("%s/%s", s.URL, "v1/metrics"))
 			v.Set("otlp.logs_endpoint", fmt.Sprintf("%s/%s", s.URL, "v1/logs"))
 			v.Set("otlp.max_retries", tc.maxRetries)
-			v.Set("otlp.max_request_elapsed_time", tc.maxRequestElapseTime)
+			if tc.maxRequestElapseTime != "" {
+				v.Set("otlp.max_request_elapsed_time", tc.maxRequestElapseTime)
+			}
 
 			logger := fixtures.NewTestLogger(t)
 

--- a/pkg/backends/otlp/config.go
+++ b/pkg/backends/otlp/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	MaxRequests int `mapstructure:"max_requests"`
 	// MaxRetries (Optional, default: 3) is the maximum number of retries to send a batch
 	MaxRetries int `mapstructure:"max_retries"`
+	// MaxRequestElapsedTime (Optional, default: 15) is the maximum time in seconds to wait for a request to complete
+	MaxRequestElapsedTime int `mapstructure:"max_request_elapsed_time"`
 	// CompressPayload (Optional, default: true) is used to enable payload compression
 	CompressPayload bool `mapstructure:"compress_payload"`
 	// MetricsPerBatch (Optional, default: 1000) is the maximum number of metrics to send in a single batch.
@@ -61,13 +63,14 @@ type Config struct {
 
 func newDefaultConfig() *Config {
 	return &Config{
-		Transport:       "default",
-		MaxRequests:     runtime.NumCPU() * 2,
-		MaxRetries:      3,
-		CompressPayload: true,
-		MetricsPerBatch: defaultMetricsPerBatch,
-		Conversion:      ConversionAsGauge,
-		UserAgent:       "gostatsd",
+		Transport:             "default",
+		MaxRequests:           runtime.NumCPU() * 2,
+		MaxRetries:            3,
+		MaxRequestElapsedTime: 15,
+		CompressPayload:       true,
+		MetricsPerBatch:       defaultMetricsPerBatch,
+		Conversion:            ConversionAsGauge,
+		UserAgent:             "gostatsd",
 	}
 }
 
@@ -96,6 +99,9 @@ func (c *Config) Validate() (errs error) {
 	}
 	if c.MaxRetries < 0 {
 		errs = multierr.Append(errs, errors.New("max retries must be a positive value"))
+	}
+	if c.MaxRequestElapsedTime <= 0 {
+		errs = multierr.Append(errs, errors.New("max request elapsed time must be a positive value"))
 	}
 	if c.MetricsPerBatch <= 0 {
 		errs = multierr.Append(errs, errors.New("metrics per batch must be a positive value"))

--- a/pkg/backends/otlp/config.go
+++ b/pkg/backends/otlp/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	// MaxRetries (Optional, default: 3) is the maximum number of retries to send a batch
 	MaxRetries int `mapstructure:"max_retries"`
 	// MaxRequestElapsedTime (Optional, default: 15) is the maximum time in seconds to wait for a request to complete
+	// 0 means it never stop until reaches MaxRetries
 	MaxRequestElapsedTime int `mapstructure:"max_request_elapsed_time"`
 	// CompressPayload (Optional, default: true) is used to enable payload compression
 	CompressPayload bool `mapstructure:"compress_payload"`
@@ -100,8 +101,8 @@ func (c *Config) Validate() (errs error) {
 	if c.MaxRetries < 0 {
 		errs = multierr.Append(errs, errors.New("max retries must be a positive value"))
 	}
-	if c.MaxRequestElapsedTime <= 0 {
-		errs = multierr.Append(errs, errors.New("max request elapsed time must be a positive value"))
+	if c.MaxRequestElapsedTime < 0 {
+		errs = multierr.Append(errs, errors.New("max request elapsed time must >= 0"))
 	}
 	if c.MetricsPerBatch <= 0 {
 		errs = multierr.Append(errs, errors.New("metrics per batch must be a positive value"))

--- a/pkg/backends/otlp/config.go
+++ b/pkg/backends/otlp/config.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"errors"
 	"runtime"
+	"time"
 
 	"github.com/spf13/viper"
 	"go.uber.org/multierr"
@@ -31,7 +32,7 @@ type Config struct {
 	MaxRetries int `mapstructure:"max_retries"`
 	// MaxRequestElapsedTime (Optional, default: 15) is the maximum time in seconds to wait for a request to complete
 	// 0 means it never stop until reaches MaxRetries
-	MaxRequestElapsedTime int `mapstructure:"max_request_elapsed_time"`
+	MaxRequestElapsedTime time.Duration `mapstructure:"max_request_elapsed_time"`
 	// CompressPayload (Optional, default: true) is used to enable payload compression
 	CompressPayload bool `mapstructure:"compress_payload"`
 	// MetricsPerBatch (Optional, default: 1000) is the maximum number of metrics to send in a single batch.
@@ -67,7 +68,7 @@ func newDefaultConfig() *Config {
 		Transport:             "default",
 		MaxRequests:           runtime.NumCPU() * 2,
 		MaxRetries:            3,
-		MaxRequestElapsedTime: 15,
+		MaxRequestElapsedTime: time.Second * 15,
 		CompressPayload:       true,
 		MetricsPerBatch:       defaultMetricsPerBatch,
 		Conversion:            ConversionAsGauge,

--- a/pkg/backends/otlp/config_test.go
+++ b/pkg/backends/otlp/config_test.go
@@ -2,6 +2,7 @@ package otlp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestNewConfig(t *testing.T) {
 				v.SetDefault("otlp.logs_endpoint", "http://local/v1/logs")
 				v.SetDefault("otlp.max_requests", 1)
 				v.SetDefault("otlp.max_retries", 3)
-				v.SetDefault("otlp.max_request_elapsed_time", 15)
+				v.SetDefault("otlp.max_request_elapsed_time", "15s")
 				v.SetDefault("otlp.compress_payload", true)
 				v.SetDefault("otlp.metrics_per_batch", 999)
 				return v
@@ -40,7 +41,7 @@ func TestNewConfig(t *testing.T) {
 				LogsEndpoint:          "http://local/v1/logs",
 				MaxRequests:           1,
 				MaxRetries:            3,
-				MaxRequestElapsedTime: 15,
+				MaxRequestElapsedTime: time.Second * 15,
 				CompressPayload:       true,
 				MetricsPerBatch:       999,
 				Conversion:            "AsGauge",

--- a/pkg/backends/otlp/config_test.go
+++ b/pkg/backends/otlp/config_test.go
@@ -30,20 +30,22 @@ func TestNewConfig(t *testing.T) {
 				v.SetDefault("otlp.logs_endpoint", "http://local/v1/logs")
 				v.SetDefault("otlp.max_requests", 1)
 				v.SetDefault("otlp.max_retries", 3)
+				v.SetDefault("otlp.max_request_elapsed_time", 15)
 				v.SetDefault("otlp.compress_payload", true)
 				v.SetDefault("otlp.metrics_per_batch", 999)
 				return v
 			}(),
 			expect: &Config{
-				MetricsEndpoint: "http://local/v1/metrics",
-				LogsEndpoint:    "http://local/v1/logs",
-				MaxRequests:     1,
-				MaxRetries:      3,
-				CompressPayload: true,
-				MetricsPerBatch: 999,
-				Conversion:      "AsGauge",
-				Transport:       "default",
-				UserAgent:       "gostatsd",
+				MetricsEndpoint:       "http://local/v1/metrics",
+				LogsEndpoint:          "http://local/v1/logs",
+				MaxRequests:           1,
+				MaxRetries:            3,
+				MaxRequestElapsedTime: 15,
+				CompressPayload:       true,
+				MetricsPerBatch:       999,
+				Conversion:            "AsGauge",
+				Transport:             "default",
+				UserAgent:             "gostatsd",
 			},
 			errVal: "",
 		},


### PR DESCRIPTION
Adding backoff for retry to avoid thundering herd if the upstream backend service is suffering