### PR TITLE
Optimize unique tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+40.1.1
+------
+- Optimize an internal code path, no user facing changes.
+
 40.1.0
 ------
 - Add support for configuration of receiver's buffer size - `receive-buffer-size`

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.187.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/json-iterator/go v1.1.12


### PR DESCRIPTION
We have two general code paths:

1. Merge two Tags in to one
2. Merge two Tags in to one, excluding certain tags

We used to handle number 1 by passing an empty map to number 2, however these can be seen as fast (add static tags) and slow (add static tags + perform filtering) code-paths.

The fast code path is now optimized by performing an array search instead of using a map to track things that have been seen.  This is more efficient for small values.  There is diminishing returns eventually, but that's with a high number of tags, which is an anti-pattern.

The primary benefit is in removing the map allocation.

The slow code path is unchanged, but could be improved by ensuring the map is sufficiently large, or using the same linear search method to check if a tag should be excluded.

Note: this benchmark isn't perfect because we clone the source arrays, but that can be identified in the profile.

```
BenchmarkUniqueTagsPractical/original-22                40025511               300.1 ns/op           304 B/op          3 allocs/op
BenchmarkUniqueTagsPractical/prealloc-22                38560572               308.3 ns/op           304 B/op          3 allocs/op
BenchmarkUniqueTagsPractical/array-search-22            56932317               210.9 ns/op           304 B/op          3 allocs/op
```