### PR TITLE
pkg/cloudproviders/aws: fix dropped error

### DIFF
--- a/pkg/cloudproviders/aws/aws.go
+++ b/pkg/cloudproviders/aws/aws.go
@@ -240,6 +240,9 @@ func NewProviderFromViper(v *viper.Viper, logger logrus.FieldLogger, _ string) (
 		}),
 		config.WithRetryMaxAttempts(a.GetInt("max_retries")),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	metadataClient := imds.NewFromConfig(cfg)
 


### PR DESCRIPTION
This fixes a dropped `err` variable in `pkg/cloudproviders/aws`.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

